### PR TITLE
charts karavi repositories use main as the primary repository branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,7 +31,7 @@ even continue reviewing your changes.
 
 #### Checklist
 [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
-- [ ] [DCO](https://github.com/helm-charts/blob/master/CONTRIBUTING.md) signed
+- [ ] [DCO](https://github.com/helm-charts/blob/main/CONTRIBUTING.md) signed
 - [ ] Chart Version bumped
 - [ ] Variables are documented in the README.md
 - [ ] Title of the PR starts with chart name (e.g. `[charts/charts_dir/mychartname]`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,17 +36,17 @@ When opening a Bug please include the following information to help with debuggi
 An Issue __must__ be created before submitting any pull request. Any pull request that is created should be linked to an Issue.
 
 ## Branching Strategy
-We are following a scaled trunk branching strategy where short-lived branches are created off of the master branch. When coding is complete, the branch is merged back into master after being approved in a pull request code review.
+We are following a scaled trunk branching strategy where short-lived branches are created off of the main branch. When coding is complete, the branch is merged back into main after being approved in a pull request code review.
 
 Steps to create a branch for a bug fix or feature:
 1. Fork the repository.
-2. Create a branch off of the master branch. The branch name should be descriptive and include the chart name, the bug fix it contains or the release # associated with the version update being made to the chart.
+2. Create a branch off of the main branch. The branch name should be descriptive and include the chart name, the bug fix it contains or the release # associated with the version update being made to the chart.
 3. Update the chart and commit to your branch.  Note: The chart version must be updated if any change is made to the chart.  See [Versioning](./charts/VERSIONING.md) 
-4. If other code changes have merged into the upstream master branch, perform a rebase of those changes into your branch.
-5. Open a pull request between your branch and the upstream master branch.  This will trigger a GitHub action to lint the chart in question.
+4. If other code changes have merged into the upstream main branch, perform a rebase of those changes into your branch.
+5. Open a pull request between your branch and the upstream main branch.  This will trigger a GitHub action to lint the chart in question.
 6. Once your pull request has merged, GitHub actions will take care of creating a chart release, packaging the chart, and making the new version available in the Helm repo.
 
-Release branches will be created from the master branch near the time of a planned release when all features are completed. Only critical bug fixes will be merged into the feature branch at this time. All other bug fixes and features can continue to be merged into the master branch. When a feature branch is stable, the branch will be tagged for release and the release branch will be deleted.
+Release branches will be created from the main branch near the time of a planned release when all features are completed. Only critical bug fixes will be merged into the feature branch at this time. All other bug fixes and features can continue to be merged into the main branch. When a feature branch is stable, the branch will be tagged for release and the release branch will be deleted.
 
 ## Code Reviews
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart: No

#### What this PR does / why we need it: This PR change the our repo default branch to 'main' from 'master'

#### Which issue this PR fixes
  - fixes # IOAD-1241: Karavi repositories use "main" as the primary repository branch

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm-charts/blob/master/CONTRIBUTING.md) signed
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/charts_dir/mychartname]`)