### PR TITLE
Added script and documentation for installing Helm charts in an offline environment

### DIFF
--- a/charts/karavi-powerflex-metrics/README.md
+++ b/charts/karavi-powerflex-metrics/README.md
@@ -18,10 +18,13 @@ Karavi Powerflex Metrics can be deployed using Helm.  The chart must be configur
 To install the helm chart:
 ```console
 $ helm repo add dell github.com/dell/helm-charts
-$ helm install karavi-powerflex-metrics --namespace karavi --create-namespace
+$ helm install dell/karavi-powerflex-metrics --namespace karavi --create-namespace
 ```
 After installation, there will be a Deployment of a PowerFlex Metrics service in Kubernetes.
 The PowerFlex Metrics service will automatically start to gather PowerFlex metrics and push them to the OpenTelemetry collector.
+
+#### Offline Chart Installation
+To install the helm chart in an environment that does not have an internet connection, follow the instructions for the [Offline Karavi Helm Chart Installer](../karavi/installer/README.md). When creating the offline bundle, use `dell/karavi-powerflex-metrics` as the chart name.
 
 #### Uninstalling the Chart
 To uninstall/delete the deployment:

--- a/charts/karavi-topology/README.md
+++ b/charts/karavi-topology/README.md
@@ -17,9 +17,12 @@ Karavi Topology can be deployed using Helm.
 To install the helm chart:
 ```console
 $ helm repo add dell github.com/dell/helm-charts
-$ helm install karavi-topology -n karavi --create-namespace
+$ helm install dell/karavi-topology -n karavi --create-namespace
 ```
 After installation, there will be a deployment of the karavi-topology service in Kubernetes.
+
+#### Offline Chart Installation
+To install the helm chart in an environment that does not have an internet connection, follow the instructions for the [Offline Karavi Helm Chart Installer](../karavi/installer/README.md).  When creating the offline bundle, use `dell/karavi-topology` as the chart name.
 
 #### Uninstalling the Chart
 To uninstall/delete the deployment:

--- a/charts/karavi/.helmignore
+++ b/charts/karavi/.helmignore
@@ -21,3 +21,4 @@
 .idea/
 *.tmproj
 .vscode/
+installer/

--- a/charts/karavi/README.md
+++ b/charts/karavi/README.md
@@ -17,11 +17,14 @@ Karavi can be deployed using Helm.
 To install the helm chart:
 ```console
 $ helm repo add dell github.com/dell/helm-charts
-$ helm install karavi -n karavi --create-namespace --render-subchart-notes
+$ helm install dell/karavi -n karavi --create-namespace --render-subchart-notes
 ```
 After installation, the following deployments will be in Kubernetes:
 - [karavi-topology](../karavi-topology/README.md)
 - [karavi-powerflex-metrics](../karavi-powerflex-metrics/README.md)
+
+#### Offline Chart Installation
+To install the helm chart in an environment that does not have an internet connection, follow the instructions for the [Offline Karavi Helm Chart Installer](./installer/README.md). When creating the offline bundle, use `dell/karavi` as the chart name.
 
 #### Uninstalling the Chart
 To uninstall/delete the deployment:

--- a/charts/karavi/installer/.gitignore
+++ b/charts/karavi/installer/.gitignore
@@ -1,0 +1,5 @@
+*
+!.gitignore
+!offline-installer.sh
+!README.md
+

--- a/charts/karavi/installer/README.md
+++ b/charts/karavi/installer/README.md
@@ -1,0 +1,118 @@
+<!--
+Copyright (c) 2020 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+-->
+
+# Offline Karavi Helm Chart Installer
+
+The following instructions can be followed when a Helm chart will be installed in an environment that does not have an internet connection and will be unable to download the Helm chart and related Docker images.
+
+## Dependencies
+
+Multiple Linux based systems may be required to create and process an offline bundle for use.
+* One Linux based system, with internet access, will be used to create the bundle. This involves the user invoking a script that utilizes `docker` to pull and save container images to file.
+* One Linux based system, with access to an image registry, to invoke a script that uses `docker` to restore container images from file and push them to a registry
+
+If one Linux system has both internet access and access to an internal registry, that system can be used for both steps.
+
+Preparing an offline bundle requires the following utilities:
+
+| Dependency            | Usage |
+| --------------------- | ----- |
+| `docker`   | `docker` will be used to pull images from public image registries, tag them, and push them to a private registry.<br>Required on both the system building the offline bundle as well as the system preparing for installation. <br>Tested version is `docker` 18.09+
+
+## Workflow
+
+To perform an offline installation of a helm chart, the following steps should be performed:
+1. Build an offline bundle
+2. Unpack the offline bundle and prepare for installation
+3. Perform a Helm installation
+
+### Build the Offline Bundle
+1. Copy the `offline-installer.sh` script to a local Linux system using `curl` or `wget`:
+```
+[user@anothersystem /home/user]# curl https://raw.githubusercontent.com/dell/helm-charts/main/charts/karavi/installer/offline-installer.sh --output offline-installer.sh
+```
+or
+```
+[user@anothersystem /home/user]# wget -O offline-installer.sh https://raw.githubusercontent.com/dell/helm-charts/main/charts/karavi/installer/offline-installer.sh
+```
+
+2. Set the file as executable.
+```
+[user@anothersystem /home/user]# chmod +x offline-installer.sh
+```
+
+3. Build the bundle by providing the Helm chart name as the argument:
+```
+[user@anothersystem /home/user]# ./offline-installer.sh -c dell/karavi
+
+*
+* Adding Helm repository https://github.com/dell/helm-charts
+
+
+*
+* Downloading Helm chart dell/karavi to directory /home/user/offline-karavi-bundle/helm-original
+
+
+*
+* Downloading and saving Docker images
+
+   dellemc/karavi-powerflex-metrics:0.1.0
+   dellemc/karavi-topology:0.1.0
+
+*
+* Compressing offline-karavi-bundle.tar.gz
+```
+
+### Unpack the Offline Bundle
+
+1. Copy the bundle file to another Linux system that has access to the internal Docker registry and that can install the Helm chart. From that Linux system, unpack the bundle.
+
+```
+[user@anothersystem /home/user]# tar -xzf offline-karavi-bundle.tar.gz
+```
+
+2. Change directory into the new directory created from unpacking the bundle:
+
+```
+[user@anothersystem /home/user]# cd offline-karavi-bundle
+```
+
+3. Prepare the bundle by providing the internal Docker registry URL.
+
+```
+[user@anothersystem /home/user/offline-karavi-bundle]# ./offline-installer.sh -p my-registry:5000
+
+*
+* Loading, tagging, and pushing Docker images to registry my-registry:5000/
+
+   dellemc/karavi-powerflex-metrics:0.1.0 -> my-registry:5000/karavi-powerflex-metrics:0.1.0
+   dellemc/karavi-topology:0.1.0 -> my-registry:5000/karavi-topology:0.1.0
+```
+
+### Perform Helm installation
+
+1. Change directory to `helm` which contains the updated Helm chart directory:
+```
+[user@anothersystem /home/user/offline-karavi-bundle]# cd helm
+```
+
+2. Now that the required images have been made available and the Helm Charts configuration updated with references to the internal registry location, installation can proceed by following the instructions that are documented within the Helm charts repository.
+
+```
+[user@anothersystem /home/user/offline-karavi-bundle/helm]# helm install -n install-namespace app-name karavi
+
+NAME: app-name
+LAST DEPLOYED: Fri Nov  6 08:48:13 2020
+NAMESPACE: install-namespace
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+
+```

--- a/charts/karavi/installer/offline-installer.sh
+++ b/charts/karavi/installer/offline-installer.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+
+# Copyright (c) 2020 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+
+usage() {
+   echo
+   echo "$0"
+   echo "Make a package for offline installation of a Helm chart"
+   echo
+   echo "Arguments:"
+   echo "-c             Create an offline bundle with chart argument"
+   echo "-p             Prepare this bundle for installation with registry argument"
+   echo "               Supply the registry name/path which will hold the images"
+   echo "               For example: my.registry.com:5000/dell/karavi"
+   echo "-h             Displays this information"
+   echo
+   echo "Exactly one of '-c' or '-p' needs to be specified"
+   echo
+}
+
+status() {
+  echo
+  echo "*"
+  echo "* $@"
+  echo
+}
+
+REGISTRY=""
+CHARTNAME=""
+HELMBACKUPDIR="helm-original"
+HELMDIR="helm"
+IMAGEDIR="images"
+HELMREPO="https://github.com/dell/helm-charts"
+CHARTPREFIX="dell/"
+
+create_bundle() {
+
+    # set the distribution directory and file based on the name of the chart
+    DISTDIR="offline-${CHARTNAME#$CHARTPREFIX}-bundle"
+    DISTFILE="${DISTDIR}.tar.gz"
+
+    # remove the distribution directory in case it already exists and create all required sub-directories
+    rm -rf ${DISTDIR}
+    mkdir -p ${DISTDIR} ${DISTDIR}/${HELMBACKUPDIR} ${DISTDIR}/${IMAGEDIR}
+
+    status "Adding Helm repository ${HELMREPO}"
+    run_command "helm repo add dell ${HELMREPO}"
+
+    status "Downloading Helm chart ${CHARTNAME} to directory $(pwd)/${DISTDIR}/${HELMBACKUPDIR}"
+    run_command "helm pull ${CHARTNAME} --untar --untardir ${DISTDIR}/${HELMBACKUPDIR}"
+
+    # search for all images from the values.yaml files that were contained in the Helm chart
+    find ${DISTDIR}/${HELMBACKUPDIR} -name "values.yaml" -type f -exec egrep -oh "image: (.+)" {} \; | awk '{print $2}' > ${DISTDIR}/images.txt
+
+    status "Downloading and saving Docker images"
+    while read line; do
+        echo "   $line"
+        run_command "${DOCKER} pull ${line}"
+        IMAGEFILE=$(echo "${line}" | sed 's|[/:]|-|g')
+        run_command "${DOCKER} save -o ${DISTDIR}/${IMAGEDIR}/${IMAGEFILE}.tar ${line}"
+    done < ${DISTDIR}/images.txt
+
+    # copy this script into the distribution directory
+    cp $0 ${DISTDIR}
+
+    status "Compressing ${DISTFILE}"
+    tar -czf ${DISTFILE} ${DISTDIR}
+}
+
+install_bundle() {
+    # make a helm directory that will store the modified helm chart with updated image names
+    rm -rf ${HELMDIR}
+    cp -r ${HELMBACKUPDIR} ${HELMDIR}
+    status "Loading, tagging, and pushing Docker images to registry ${REGISTRY}"
+    while read line; do
+        local IMAGEFILE=$(echo "${line}" | sed 's|[/:]|-|g')
+        local NEWIMAGENAME="${REGISTRY}${line##*/}"
+        echo "   $line -> ${NEWIMAGENAME}"
+
+        # replace the image names in the helm directory with the new names based on the provided registry URL
+        find ${HELMDIR} -type f -exec sed -i "s|$line|$NEWIMAGENAME|g" {} \;
+
+        run_command "${DOCKER} load --input ${IMAGEDIR}/${IMAGEFILE}.tar"
+        run_command "${DOCKER} tag ${line} ${NEWIMAGENAME}"
+        run_command "${DOCKER} push ${NEWIMAGENAME}"
+    done < images.txt
+}
+
+run_command() {
+  CMDOUT=$(eval "${@}" 2>&1)
+  local rc=$?
+
+  if [ $rc -ne 0 ]; then
+    echo
+    echo "ERROR"
+    echo "Received a non-zero return code ($rc) from the following comand:"
+    echo "  ${@}"
+    echo
+    echo "Output was:"
+    echo "${CMDOUT}"
+    echo
+    echo "Exiting"
+    exit 1
+  fi
+}
+
+
+while getopts "c:p:h" opt; do
+  case $opt in
+    c)
+      CREATE="true"
+      CHARTNAME="${OPTARG}"
+      ;;
+    p)
+      PREPARE="true"
+      REGISTRY="${OPTARG}"
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ "${CREATE}" == "${PREPARE}" ]; then
+  usage
+  exit 1
+fi
+
+if [ "${CREATE}" == "true" ]; then
+  if [ "${CHARTNAME}" == "" ]; then
+    usage
+    exit 1
+  fi
+  if [[ $CHARTNAME != $CHARTPREFIX* ]]; then
+    echo "Chart name must begin with '${CHARTPREFIX}' (ex: dell/karavi)"
+    exit 1
+  fi
+fi
+
+if [ "${PREPARE}" == "true" ]; then
+  if [ "${REGISTRY}" == "" ]; then
+    usage
+    exit 1
+  fi
+  if [ "${REGISTRY: -1}" != "/" ]; then
+    REGISTRY="${REGISTRY}/"
+  fi
+fi
+
+DOCKER=$(which docker 2>/dev/null)
+if [ "${DOCKER}" == "" ]; then
+  echo "Unable to find docker in $PATH"
+  exit 1
+fi
+
+# create a bundle
+if [ "${CREATE}" == "true" ]; then
+  create_bundle
+fi
+
+# prepare a bundle for installation
+if [ "${PREPARE}" == "true" ]; then
+  install_bundle
+fi
+
+echo
+
+exit 0


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart?
No

#### What this PR does / why we need it:
Added script and documentation for installing Helm charts in an offline environment.

Since the helm repository is still private, this was tested by:
- Creating a local package of each helm chart (karavi, karavi-topology, and karavi-powerflex-metrics)
- Running the install script against each chart and verified that the appropriate images were downloaded, saved, and packaged in the offline bundle.
- Prepared the installation by using the script to push images to a local Docker registry.
- Successfully performed Helm installation using the updated helm chart and images from the local Docker registry.

#### Which issue(s) is this PR associated with:
  - #3 

#### Special notes for your reviewer:

#### Checklist:
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]