### PR TITLE
[karavi/karavi-powerflex-metrics] Remove duplicate certificate data in Config Maps in favor of Secret

### DIFF
--- a/charts/karavi-powerflex-metrics/otel-collector-config.yaml
+++ b/charts/karavi-powerflex-metrics/otel-collector-config.yaml
@@ -3,8 +3,8 @@ receivers:
     protocols:
       grpc:
         tls_settings:
-          cert_file: /etc/ssl/certs/cert.crt
-          key_file: /etc/ssl/certs/cert.key
+          cert_file: /etc/ssl/certs/tls.crt
+          key_file: /etc/ssl/certs/tls.key
       http:
   
 exporters:

--- a/charts/karavi-powerflex-metrics/templates/karavi-powerflex-metrics.yaml
+++ b/charts/karavi-powerflex-metrics/templates/karavi-powerflex-metrics.yaml
@@ -93,14 +93,15 @@ spec:
         - name: TLS_ENABLED
           value: "true"
         volumeMounts:
-        - name: cert-file-config
-          mountPath: /etc/ssl/certs/cert.crt
-          subPath: cert.crt
-          readOnly: false
+        - name: tls-secret
+          mountPath: /etc/ssl/certs
+          readOnly: true
       volumes:
-      - name: cert-file-config
-        configMap:
-           name: cert-file-config
-
+      - name: tls-secret
+        secret:
+          secretName: tls-secret
+          items:
+            - key: tls.crt
+              path: cert.crt
       restartPolicy: Always
 status: {}

--- a/charts/karavi-powerflex-metrics/templates/otel-collector.yaml
+++ b/charts/karavi-powerflex-metrics/templates/otel-collector.yaml
@@ -1,41 +1,5 @@
-apiVersion: v1
-data:
-  otel-collector-config.yaml: {{ (.Files.Get "otel-collector-config.yaml") | quote }}
-kind: ConfigMap
-metadata:
-  name: otel-collector-config
-
----
-
 {{- $certificateFileContents := required "A valid certificate file is required. Refer to the Helm Chart documentation." (.Values.otelCollector.certificateFile) }}
-apiVersion: v1
-data:
-  cert.crt: {{ $certificateFileContents | quote }}
-kind: ConfigMap
-metadata:
-  name: cert-file-config
-
----
-
 {{- $privateKeyFileContents := required "A valid private key file is required. Refer to the Helm Chart documentation." (.Values.otelCollector.privateKeyFile) }}
-apiVersion: v1
-apiVersion: v1
-data:
-  cert.key: {{ $privateKeyFileContents | quote }}
-kind: ConfigMap
-metadata:
-  name: key-file-config
-
----
-
-apiVersion: v1
-data:
-  nginx.conf: {{ (.Files.Get "nginx.conf") | quote }}
-kind: ConfigMap
-metadata:
-  name: nginx-config
-
----
 
 apiVersion: v1
 kind: Secret
@@ -45,6 +9,24 @@ data:
   tls.crt: {{ $certificateFileContents  | b64enc }}
   tls.key: {{ $privateKeyFileContents | b64enc }}
 type: kubernetes.io/tls
+
+---
+
+apiVersion: v1
+data:
+  otel-collector-config.yaml: {{ (.Files.Get "otel-collector-config.yaml") | quote }}
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+
+---
+
+apiVersion: v1
+data:
+  nginx.conf: {{ (.Files.Get "nginx.conf") | quote }}
+kind: ConfigMap
+metadata:
+  name: nginx-config
 
 ---
 
@@ -105,12 +87,6 @@ spec:
       - name: otel-collector-config
         configMap:
           name: otel-collector-config
-      - name: cert-file-config
-        configMap:
-          name: cert-file-config
-      - name: key-file-config
-        configMap:
-          name: key-file-config
       containers:
       - name: nginx-proxy
         image: {{ .Values.nginxProxy.image }}
@@ -129,11 +105,7 @@ spec:
         - name: otel-collector-config
           mountPath: /etc/otel-collector-config.yaml
           subPath: otel-collector-config.yaml
-        - name: cert-file-config
-          mountPath: /etc/ssl/certs/cert.crt
-          subPath: cert.crt
-        - name: key-file-config
-          mountPath: /etc/ssl/certs/cert.key
-          subPath: cert.key
+        - name: tls-secret
+          mountPath: /etc/ssl/certs
       restartPolicy: Always
 status: {}


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart?
No

#### What this PR does / why we need it:

This PR removes the duplicate effort of storing the public certificate and private key in Config Maps when that data is already in a Secret, which is more secure anyway. Volume mounts related to certificates now only use the Secret.

This was tested manually by deploying karavi-powerflex-metrics chart by itself and with the main karavi chart. Both are successful.

#### Which issue(s) is this PR associated with:
  - #43 

#### Special notes for your reviewer:

#### Checklist:
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [x] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable