### PR TITLE
Changed helm repo url in offline install script

### DIFF
--- a/charts/karavi-observability/installer/offline-installer.sh
+++ b/charts/karavi-observability/installer/offline-installer.sh
@@ -37,7 +37,7 @@ CHARTNAME=""
 HELMBACKUPDIR="helm-original"
 HELMDIR="helm"
 IMAGEDIR="images"
-HELMREPO="https://github.com/dell/helm-charts"
+HELMREPO="https://dell.github.io/helm-charts"
 CHARTPREFIX="dell/"
 
 create_bundle() {


### PR DESCRIPTION
#### Is this a new chart?
No

#### What this PR does / why we need it:
Fixes the URL for the helm repo location in the offline installer script for Karavi-Observability

#### Which issue(s) is this PR associated with:
  - #52 

#### Special notes for your reviewer:
N/A