### PR TITLE
[charts/karavi-observability] Feature cert gen init

### DIFF
--- a/charts/karavi-observability/.gitignore
+++ b/charts/karavi-observability/.gitignore
@@ -1,1 +1,2 @@
 Chart.lock
+charts/

--- a/charts/karavi-observability/Chart.yaml
+++ b/charts/karavi-observability/Chart.yaml
@@ -4,3 +4,8 @@ name: karavi-observability
 description: Karavi Observability is part of the [Karavi](https://github.com/dell/karavi) open source suite of Kubernetes storage enablers for Dell EMC storage products. Karavi Observability provides Kubernetes administrators with visibility into metrics and topology data related to containerized storage.
 type: application
 version: 0.2.0
+
+dependencies:
+    - name: cert-manager
+      version: 1.1.0
+      repository: https://charts.jetstack.io

--- a/charts/karavi-observability/Chart.yaml
+++ b/charts/karavi-observability/Chart.yaml
@@ -4,8 +4,3 @@ name: karavi-observability
 description: Karavi Observability is part of the [Karavi](https://github.com/dell/karavi) open source suite of Kubernetes storage enablers for Dell EMC storage products. Karavi Observability provides Kubernetes administrators with visibility into metrics and topology data related to containerized storage.
 type: application
 version: 0.2.0
-
-dependencies:
-    - name: cert-manager
-      version: 1.1.0
-      repository: https://charts.jetstack.io

--- a/charts/karavi-observability/Chart.yaml
+++ b/charts/karavi-observability/Chart.yaml
@@ -4,3 +4,8 @@ name: karavi-observability
 description: Karavi Observability is part of the [Karavi](https://github.com/dell/karavi) open source suite of Kubernetes storage enablers for Dell EMC storage products. Karavi Observability provides Kubernetes administrators with visibility into metrics and topology data related to containerized storage.
 type: application
 version: 0.2.0
+dependencies:
+- name: cert-manager
+  version: 1.1.0
+  repository: https://charts.jetstack.io
+  condition: certManager.enabled

--- a/charts/karavi-observability/Chart.yaml
+++ b/charts/karavi-observability/Chart.yaml
@@ -8,4 +8,3 @@ dependencies:
 - name: cert-manager
   version: 1.1.0
   repository: https://charts.jetstack.io
-  condition: certManager.enabled

--- a/charts/karavi-observability/templates/cert-manager.yaml
+++ b/charts/karavi-observability/templates/cert-manager.yaml
@@ -1,0 +1,128 @@
+{{- if and (.Values.karaviTopology.certificateFile) (.Values.karaviTopology.privateKeyFile) }}
+{{- $certificateFileContents := .Values.karaviTopology.certificateFile }}
+{{- $privateKeyFileContents := .Values.karaviTopology.privateKeyFile }}
+apiVersion: v1
+data:
+  tls.crt: {{ $certificateFileContents | b64enc }}
+  tls.key: {{ $privateKeyFileContents | b64enc }}
+kind: Secret
+metadata:
+  name: karavi-topology-secret
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: karavi-topology-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: karavi-topology-secret
+
+---
+{{- end }}
+
+{{- if and (.Values.otelCollector.certificateFile) (.Values.otelCollector.privateKeyFile) }}
+{{- $certificateFileContents := .Values.otelCollector.certificateFile }}
+{{- $privateKeyFileContents := .Values.otelCollector.privateKeyFile }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: otel-collector-secret
+data:
+  tls.crt: {{ $certificateFileContents  | b64enc }}
+  tls.key: {{ $privateKeyFileContents | b64enc }}
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: otel-collector-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: otel-collector-secret
+
+---
+{{- end }}
+
+{{- if or (and (not .Values.karaviTopology.certificateFile) (not .Values.karaviTopology.privateKeyFile)) (and (not .Values.otelCollector.certificateFile) (not .Values.otelCollector.privateKeyFile)) }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+
+---
+{{- end }}
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: otel-collector
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: otel-collector-tls
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  subject:
+    organizations:
+    - dellemc
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+  - otel-collector
+  - otel-collector.karavi.svc.kubernetes.local
+  issuerRef:
+  {{- if and (.Values.otelCollector.certificateFile) (.Values.otelCollector.privateKeyFile) }}
+    name: otel-collector-issuer
+  {{- else }}
+    name: selfsigned-issuer
+  {{- end }}
+    kind: Issuer
+    group: cert-manager.io
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: karavi-topology
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: karavi-topology-tls
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  subject:
+    organizations:
+    - dellemc
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+  - karavi-topology
+  - karavi-topology.karavi.svc.kubernetes.local
+  issuerRef:
+  {{- if and (.Values.karaviTopology.certificateFile) (.Values.karaviTopology.privateKeyFile) }}
+    name: karavi-topology-issuer
+  {{- else }}
+    name: selfsigned-issuer
+  {{- end }}
+    kind: Issuer
+    group: cert-manager.io
+

--- a/charts/karavi-observability/templates/cert-manager.yaml
+++ b/charts/karavi-observability/templates/cert-manager.yaml
@@ -1,3 +1,4 @@
+# If the karavi-topology cert and key are provided, deploy a CA Issuer using the cert and key
 {{- if and (.Values.karaviTopology.certificateFile) (.Values.karaviTopology.privateKeyFile) }}
 {{- $certificateFileContents := .Files.Get .Values.karaviTopology.certificateFile }}
 {{- $privateKeyFileContents := .Files.Get .Values.karaviTopology.privateKeyFile }}
@@ -25,6 +26,7 @@ spec:
 ---
 {{- end }}
 
+# If the otelCollector cert and key are provided, deploy a CA Issuer using the cert and key
 {{- if and (.Values.otelCollector.certificateFile) (.Values.otelCollector.privateKeyFile) }}
 {{- $certificateFileContents := .Files.Get .Values.otelCollector.certificateFile }}
 {{- $privateKeyFileContents := .Files.Get .Values.otelCollector.privateKeyFile }}
@@ -52,6 +54,7 @@ spec:
 ---
 {{- end }}
 
+# If any set of cert+key combos are not provided, deploy a selfsigned-issuer
 {{- if or (and (not .Values.karaviTopology.certificateFile) (not .Values.karaviTopology.privateKeyFile)) (and (not .Values.otelCollector.certificateFile) (not .Values.otelCollector.privateKeyFile)) }}
 apiVersion: cert-manager.io/v1
 kind: Issuer

--- a/charts/karavi-observability/templates/cert-manager.yaml
+++ b/charts/karavi-observability/templates/cert-manager.yaml
@@ -1,13 +1,15 @@
 {{- if and (.Values.karaviTopology.certificateFile) (.Values.karaviTopology.privateKeyFile) }}
-{{- $certificateFileContents := .Values.karaviTopology.certificateFile }}
-{{- $privateKeyFileContents := .Values.karaviTopology.privateKeyFile }}
+{{- $certificateFileContents := .Files.Get .Values.karaviTopology.certificateFile }}
+{{- $privateKeyFileContents := .Files.Get .Values.karaviTopology.privateKeyFile }}
 apiVersion: v1
 data:
   tls.crt: {{ $certificateFileContents | b64enc }}
   tls.key: {{ $privateKeyFileContents | b64enc }}
 kind: Secret
+type: kubernetes.io/tls
 metadata:
   name: karavi-topology-secret
+  namespace: {{ .Release.Namespace }}
 
 ---
 
@@ -24,12 +26,14 @@ spec:
 {{- end }}
 
 {{- if and (.Values.otelCollector.certificateFile) (.Values.otelCollector.privateKeyFile) }}
-{{- $certificateFileContents := .Values.otelCollector.certificateFile }}
-{{- $privateKeyFileContents := .Values.otelCollector.privateKeyFile }}
+{{- $certificateFileContents := .Files.Get .Values.otelCollector.certificateFile }}
+{{- $privateKeyFileContents := .Files.Get .Values.otelCollector.privateKeyFile }}
 apiVersion: v1
 kind: Secret
+type: kubernetes.io/tls
 metadata:
   name: otel-collector-secret
+  namespace: {{ .Release.Namespace }}
 data:
   tls.crt: {{ $certificateFileContents  | b64enc }}
   tls.key: {{ $privateKeyFileContents | b64enc }}

--- a/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
@@ -103,7 +103,7 @@ spec:
       volumes:
       - name: tls-secret
         secret:
-          secretName: tls-secret
+          secretName: otel-collector-tls
           items:
             - key: tls.crt
               path: cert.crt

--- a/charts/karavi-observability/templates/karavi-topology.yaml
+++ b/charts/karavi-observability/templates/karavi-topology.yaml
@@ -41,6 +41,11 @@ spec:
         - name: karavi-topology-secret-volume
           secret:
             secretName: karavi-topology-tls
+            items:
+            - key: tls.crt
+              path: localhost.crt
+            - key: tls.key
+              path: localhost.key
       serviceAccount: {{ .Release.Name }}-topology-controller
       containers:
       - name: karavi-topology

--- a/charts/karavi-observability/templates/karavi-topology.yaml
+++ b/charts/karavi-observability/templates/karavi-topology.yaml
@@ -17,18 +17,6 @@ spec:
 
 ---
 
-{{- $certificateFileContents := required "A valid certificate file is required. Refer to the Helm Chart documentation." .Values.karaviTopology.certificateFile }}
-{{- $privateKeyFileContents := required "A valid private key file is required. Refer to the Helm Chart documentation." .Values.karaviTopology.privateKeyFile }}
-apiVersion: v1
-data:
-  localhost.crt: {{ $certificateFileContents | b64enc }}
-  localhost.key: {{ $privateKeyFileContents | b64enc }}
-kind: Secret
-metadata:
-  name: karavi-topology-secret
-
----
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -52,7 +40,7 @@ spec:
       volumes:
         - name: karavi-topology-secret-volume
           secret:
-            secretName: karavi-topology-secret
+            secretName: karavi-topology-tls
       serviceAccount: {{ .Release.Name }}-topology-controller
       containers:
       - name: karavi-topology

--- a/charts/karavi-observability/templates/otel-collector.yaml
+++ b/charts/karavi-observability/templates/otel-collector.yaml
@@ -1,17 +1,3 @@
-{{- $certificateFileContents := required "A valid certificate file is required. Refer to the Helm Chart documentation." .Values.otelCollector.certificateFile }}
-{{- $privateKeyFileContents := required "A valid private key file is required. Refer to the Helm Chart documentation." .Values.otelCollector.privateKeyFile }}
-
-apiVersion: v1
-kind: Secret
-metadata:
-  name: tls-secret
-data:
-  tls.crt: {{ $certificateFileContents  | b64enc }}
-  tls.key: {{ $privateKeyFileContents | b64enc }}
-type: kubernetes.io/tls
-
----
-
 apiVersion: v1
 data:
   otel-collector-config.yaml: {{ (.Files.Get "otel-collector-config.yaml") | quote }}
@@ -75,7 +61,7 @@ spec:
       volumes:
       - name: tls-secret
         secret:
-          secretName: tls-secret
+          secretName: otel-collector-tls
           items:
             - key: tls.crt
               path: tls.crt


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Adds cert-manager as a dependency on the karavi-observability chart and creates cert-manager resources to enable ssl cert management for the karavi-observability services.

If no certificates/keys are provided in the values.yaml, cert-manager will automatically use self-signed certs.

#### Which issue(s) is this PR associated with:

- https://github.com/dell/karavi-observability/issues/1

#### Special notes for your reviewer:

Documentation related to this PR will be added to the dell/karavi-observability repo

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
- [x] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
