### PR TITLE
Only use Issuer and Certificate if custom certificates are not provided

### DIFF
--- a/charts/karavi-observability/templates/cert-manager.yaml
+++ b/charts/karavi-observability/templates/cert-manager.yaml
@@ -13,17 +13,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
 
 ---
-
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: karavi-topology-issuer
-  namespace: {{ .Release.Namespace }}
-spec:
-  ca:
-    secretName: karavi-topology-secret
-
----
 {{- end }}
 
 # If the otelCollector cert and key are provided, deploy a CA Issuer using the cert and key
@@ -41,17 +30,6 @@ data:
   tls.key: {{ $privateKeyFileContents | b64enc }}
 
 ---
-
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: otel-collector-issuer
-  namespace: {{ .Release.Namespace }}
-spec:
-  ca:
-    secretName: otel-collector-secret
-
----
 {{- end }}
 
 # If any set of cert+key combos are not provided, deploy a selfsigned-issuer
@@ -65,7 +43,6 @@ spec:
   selfSigned: {}
 
 ---
-{{- end }}
 
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -73,7 +50,7 @@ metadata:
   name: otel-collector
   namespace: {{ .Release.Namespace }}
 spec:
-  secretName: otel-collector-tls
+  secretName: otel-collector-secret
   duration: 2160h # 90d
   renewBefore: 360h # 15d
   subject:
@@ -91,11 +68,7 @@ spec:
   - otel-collector
   - otel-collector.karavi.svc.kubernetes.local
   issuerRef:
-  {{- if and (.Values.otelCollector.certificateFile) (.Values.otelCollector.privateKeyFile) }}
-    name: otel-collector-issuer
-  {{- else }}
     name: selfsigned-issuer
-  {{- end }}
     kind: Issuer
     group: cert-manager.io
 
@@ -107,7 +80,7 @@ metadata:
   name: karavi-topology
   namespace: {{ .Release.Namespace }}
 spec:
-  secretName: karavi-topology-tls
+  secretName: karavi-topology-secret
   duration: 2160h # 90d
   renewBefore: 360h # 15d
   subject:
@@ -125,11 +98,8 @@ spec:
   - karavi-topology
   - karavi-topology.karavi.svc.kubernetes.local
   issuerRef:
-  {{- if and (.Values.karaviTopology.certificateFile) (.Values.karaviTopology.privateKeyFile) }}
-    name: karavi-topology-issuer
-  {{- else }}
     name: selfsigned-issuer
-  {{- end }}
     kind: Issuer
     group: cert-manager.io
 
+{{- end }}

--- a/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
@@ -103,7 +103,7 @@ spec:
       volumes:
       - name: tls-secret
         secret:
-          secretName: otel-collector-tls
+          secretName: otel-collector-secret
           items:
             - key: tls.crt
               path: cert.crt

--- a/charts/karavi-observability/templates/karavi-topology.yaml
+++ b/charts/karavi-observability/templates/karavi-topology.yaml
@@ -40,7 +40,7 @@ spec:
       volumes:
         - name: karavi-topology-secret-volume
           secret:
-            secretName: karavi-topology-tls
+            secretName: karavi-topology-secret
             items:
             - key: tls.crt
               path: localhost.crt

--- a/charts/karavi-observability/templates/otel-collector.yaml
+++ b/charts/karavi-observability/templates/otel-collector.yaml
@@ -63,7 +63,7 @@ spec:
       volumes:
       - name: tls-secret
         secret:
-          secretName: otel-collector-tls
+          secretName: otel-collector-secret
           items:
             - key: tls.crt
               path: tls.crt


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
The issue:
When providing custom certificates, the Secrets that contain the certificates were not being created by cert-manager. This prevented the Karavi pods from being available.

The fix:
If certificates are provided, we will not create the Certificate and Issuer CRD resources that are used by cert-manager. We will create the Secrets with those certificates and they will be mounted inside of the Karavi pods. If certificates are not provided, cert-manager will generate them and mount them.

#### Which issue(s) is this PR associated with:

- N/A