### PR TITLE
[charts/karavi-observability] BugFix: Removed otel-collector nodeport and revved chart version

### DIFF
--- a/charts/karavi-observability/Chart.yaml
+++ b/charts/karavi-observability/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: "0.2.0"
+appVersion: "0.2.1"
 name: karavi-observability
 description: Karavi Observability is part of the [Karavi](https://github.com/dell/karavi) open source suite of Kubernetes storage enablers for Dell EMC storage products. Karavi Observability provides Kubernetes administrators with visibility into metrics and topology data related to containerized storage.
 type: application
-version: 0.2.0
+version: 0.2.1
 dependencies:
 - name: cert-manager
   version: 1.1.0

--- a/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: karavi-metrics-powerflex
 spec:
-  type: NodePort
+  type: {{ .Values.karaviMetricsPowerflex.service.type }}
   ports:
   - name: karavi-metrics-powerflex
     port: 2222

--- a/charts/karavi-observability/templates/otel-collector.yaml
+++ b/charts/karavi-observability/templates/otel-collector.yaml
@@ -26,7 +26,6 @@ metadata:
     app.kubernetes.io/name: otel-collector
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  type: NodePort
   ports:
     - port: 55680
       targetPort: 55680

--- a/charts/karavi-observability/templates/otel-collector.yaml
+++ b/charts/karavi-observability/templates/otel-collector.yaml
@@ -26,6 +26,7 @@ metadata:
     app.kubernetes.io/name: otel-collector
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
+  type: {{ .Values.otelCollector.service.type }}
   ports:
     - port: 55680
       targetPort: 55680

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -33,5 +33,7 @@ karaviMetricsPowerflex:
 
 otelCollector:
   image: otel/opentelemetry-collector:0.9.0
+  service:
+    type: ClusterIP
   nginxProxy:
     image: nginx:1

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -30,6 +30,8 @@ karaviMetricsPowerflex:
   concurrentPowerflexQueries: 10
   # set the default endpoint for powerflex service
   endpoint: karavi-metrics-powerflex
+  service:
+    type: ClusterIP
 
 otelCollector:
   image: otel/opentelemetry-collector:0.9.0


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Makes the otel-collector pod deployed as ClusterIP instead of NodePort

#### Which issue(s) is this PR associated with:

https://github.com/dell/karavi-observability/issues/23

#### Special notes for your reviewer:
None

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
- [x] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
