### PR TITLE
Create configmaps to replace environment variables

### DIFF
--- a/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
@@ -57,9 +57,10 @@ spec:
       - name: karavi-metrics-powerflex
         image: {{ .Values.karaviMetricsPowerflex.image }}
         resources: {}
+        envFrom:
+        - configMapRef:
+            name: karavi-metrics-powerflex-configmap
         env:
-        - name: COLLECTOR_ADDR
-          value: {{ .Values.karaviMetricsPowerflex.collectorAddr }}
         - name: POWERFLEX_ENDPOINT
           value: {{ $powerflexEndpoint }}
         - name: POWERFLEX_USER
@@ -72,24 +73,6 @@ spec:
             secretKeyRef:
               name: powerflex-gateway-credentials
               key: password
-        - name: PROVISIONER_NAMES
-          value: {{ .Values.karaviMetricsPowerflex.provisionerNames }}
-        - name: POWERFLEX_SDC_METRICS_ENABLED
-          value: "{{ .Values.karaviMetricsPowerflex.sdcMetricsEnabled }}"
-        - name: POWERFLEX_SDC_IO_POLL_FREQUENCY
-          value: "{{ .Values.karaviMetricsPowerflex.sdcPollFrequencySeconds }}"
-        - name: POWERFLEX_VOLUME_IO_POLL_FREQUENCY
-          value: "{{ .Values.karaviMetricsPowerflex.volumePollFrequencySeconds }}"
-        - name: POWERFLEX_VOLUME_METRICS_ENABLED
-          value: "{{ .Values.karaviMetricsPowerflex.volumeMetricsEnabled }}"
-        - name: POWERFLEX_STORAGE_POOL_METRICS_ENABLED
-          value: "{{ .Values.karaviMetricsPowerflex.storageClassPoolMetricsEnabled }}"
-        - name: POWERFLEX_STORAGE_POOL_POLL_FREQUENCY
-          value: "{{ .Values.karaviMetricsPowerflex.storageClassPoolPollFrequencySeconds }}"
-        - name: POWERFLEX_MAX_CONCURRENT_QUERIES
-          value: "{{ .Values.karaviMetricsPowerflex.concurrentPowerflexQueries }}"
-        - name: POWERFLEX_METRICS_ENDPOINT
-          value: "{{ .Values.karaviMetricsPowerflex.endpoint }}"
         - name: POWERFLEX_METRICS_NAMESPACE
           valueFrom:
             fieldRef:
@@ -100,6 +83,9 @@ spec:
         - name: tls-secret
           mountPath: /etc/ssl/certs
           readOnly: true
+        - name: karavi-metrics-powerflex-configmap
+          mountPath: /etc/config/karavi-metrics-powerflex-config.yaml
+          subPath: karavi-metrics-powerflex-config.yaml
       volumes:
       - name: tls-secret
         secret:
@@ -107,5 +93,8 @@ spec:
           items:
             - key: tls.crt
               path: cert.crt
+      - name: karavi-metrics-powerflex-configmap
+        configMap:
+          name: karavi-metrics-powerflex-configmap
       restartPolicy: Always
 status: {}

--- a/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
@@ -57,9 +57,6 @@ spec:
       - name: karavi-metrics-powerflex
         image: {{ .Values.karaviMetricsPowerflex.image }}
         resources: {}
-        envFrom:
-        - configMapRef:
-            name: karavi-metrics-powerflex-configmap
         env:
         - name: POWERFLEX_ENDPOINT
           value: {{ $powerflexEndpoint }}
@@ -73,6 +70,8 @@ spec:
             secretKeyRef:
               name: powerflex-gateway-credentials
               key: password
+        - name: POWERFLEX_METRICS_ENDPOINT	
+          value: "{{ .Values.karaviMetricsPowerflex.endpoint }}"
         - name: POWERFLEX_METRICS_NAMESPACE
           valueFrom:
             fieldRef:
@@ -84,8 +83,7 @@ spec:
           mountPath: /etc/ssl/certs
           readOnly: true
         - name: karavi-metrics-powerflex-configmap
-          mountPath: /etc/config/karavi-metrics-powerflex-config.yaml
-          subPath: karavi-metrics-powerflex-config.yaml
+          mountPath: /config-maps
       volumes:
       - name: tls-secret
         secret:

--- a/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
@@ -83,7 +83,7 @@ spec:
           mountPath: /etc/ssl/certs
           readOnly: true
         - name: karavi-metrics-powerflex-configmap
-          mountPath: /config-maps
+          mountPath: /etc/config
       volumes:
       - name: tls-secret
         secret:

--- a/charts/karavi-observability/templates/karavi-observability-configmap.yaml
+++ b/charts/karavi-observability/templates/karavi-observability-configmap.yaml
@@ -21,4 +21,5 @@ kind: ConfigMap
 metadata:
   name: karavi-topology-configmap
 data:
-  PROVISIONER_NAMES: {{ .Values.karaviTopology.provisionerNames }}
+  karavi-topology.yaml: |
+    PROVISIONER_NAMES: {{ .Values.karaviTopology.provisionerNames }}

--- a/charts/karavi-observability/templates/karavi-observability-configmap.yaml
+++ b/charts/karavi-observability/templates/karavi-observability-configmap.yaml
@@ -3,16 +3,16 @@ kind: ConfigMap
 metadata:
   name: karavi-metrics-powerflex-configmap
 data:
-  COLLECTOR_ADDR: {{ .Values.karaviMetricsPowerflex.collectorAddr }}
-  PROVISIONER_NAMES: {{ .Values.karaviMetricsPowerflex.provisionerNames }}
-  POWERFLEX_SDC_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerflex.sdcMetricsEnabled }}"
-  POWERFLEX_SDC_IO_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerflex.sdcPollFrequencySeconds }}"
-  POWERFLEX_VOLUME_IO_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerflex.volumePollFrequencySeconds }}"
-  POWERFLEX_VOLUME_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerflex.volumeMetricsEnabled }}"
-  POWERFLEX_STORAGE_POOL_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerflex.storageClassPoolMetricsEnabled }}"
-  POWERFLEX_STORAGE_POOL_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerflex.storageClassPoolPollFrequencySeconds }}"
-  POWERFLEX_MAX_CONCURRENT_QUERIES: "{{ .Values.karaviMetricsPowerflex.concurrentPowerflexQueries }}"
-  POWERFLEX_METRICS_ENDPOINT: "{{ .Values.karaviMetricsPowerflex.endpoint }}"
+  karavi-metrics-powerflex.yaml : |
+    COLLECTOR_ADDR: {{ .Values.karaviMetricsPowerflex.collectorAddr }}
+    PROVISIONER_NAMES: {{ .Values.karaviMetricsPowerflex.provisionerNames }}
+    POWERFLEX_SDC_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerflex.sdcMetricsEnabled }}"
+    POWERFLEX_SDC_IO_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerflex.sdcPollFrequencySeconds }}"
+    POWERFLEX_VOLUME_IO_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerflex.volumePollFrequencySeconds }}"
+    POWERFLEX_VOLUME_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerflex.volumeMetricsEnabled }}"
+    POWERFLEX_STORAGE_POOL_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerflex.storageClassPoolMetricsEnabled }}"
+    POWERFLEX_STORAGE_POOL_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerflex.storageClassPoolPollFrequencySeconds }}"
+    POWERFLEX_MAX_CONCURRENT_QUERIES: "{{ .Values.karaviMetricsPowerflex.concurrentPowerflexQueries }}"
   
 ---
 

--- a/charts/karavi-observability/templates/karavi-observability-configmap.yaml
+++ b/charts/karavi-observability/templates/karavi-observability-configmap.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1 
+kind: ConfigMap 
+metadata:
+  name: karavi-metrics-powerflex-configmap
+data:
+  COLLECTOR_ADDR: {{ .Values.karaviMetricsPowerflex.collectorAddr }}
+  PROVISIONER_NAMES: {{ .Values.karaviMetricsPowerflex.provisionerNames }}
+  POWERFLEX_SDC_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerflex.sdcMetricsEnabled }}"
+  POWERFLEX_SDC_IO_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerflex.sdcPollFrequencySeconds }}"
+  POWERFLEX_VOLUME_IO_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerflex.volumePollFrequencySeconds }}"
+  POWERFLEX_VOLUME_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerflex.volumeMetricsEnabled }}"
+  POWERFLEX_STORAGE_POOL_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerflex.storageClassPoolMetricsEnabled }}"
+  POWERFLEX_STORAGE_POOL_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerflex.storageClassPoolPollFrequencySeconds }}"
+  POWERFLEX_MAX_CONCURRENT_QUERIES: "{{ .Values.karaviMetricsPowerflex.concurrentPowerflexQueries }}"
+  POWERFLEX_METRICS_ENDPOINT: "{{ .Values.karaviMetricsPowerflex.endpoint }}"
+  
+---
+
+apiVersion: v1 
+kind: ConfigMap 
+metadata:
+  name: karavi-topology-configmap
+data:
+  PROVISIONER_NAMES: {{ .Values.karaviTopology.provisionerNames }}

--- a/charts/karavi-observability/templates/karavi-topology.yaml
+++ b/charts/karavi-observability/templates/karavi-topology.yaml
@@ -46,18 +46,25 @@ spec:
               path: localhost.crt
             - key: tls.key
               path: localhost.key
+        - name: karavi-topology-configmap
+          configMap:
+            name: karavi-topology-configmap
       serviceAccount: {{ .Release.Name }}-topology-controller
       containers:
       - name: karavi-topology
         image: {{ .Values.karaviTopology.image }}
         resources: {}
+        envFrom:
+        - configMapRef:
+            name: karavi-topology-configmap
         env:
-        - name: PROVISIONER_NAMES
-          value: {{ .Values.karaviTopology.provisionerNames }}
         - name: PORT
           value: "8443"
         volumeMounts:
         - name: karavi-topology-secret-volume
           mountPath: "/certs"
+        - name: karavi-topology-configmap
+          mountPath: /etc/config/karavi-topology-config.yaml
+          subPath: karavi-topology-config.yaml
       restartPolicy: Always
 status: {}

--- a/charts/karavi-observability/templates/karavi-topology.yaml
+++ b/charts/karavi-observability/templates/karavi-topology.yaml
@@ -54,9 +54,6 @@ spec:
       - name: karavi-topology
         image: {{ .Values.karaviTopology.image }}
         resources: {}
-        envFrom:
-        - configMapRef:
-            name: karavi-topology-configmap
         env:
         - name: PORT
           value: "8443"

--- a/charts/karavi-observability/templates/karavi-topology.yaml
+++ b/charts/karavi-observability/templates/karavi-topology.yaml
@@ -64,7 +64,6 @@ spec:
         - name: karavi-topology-secret-volume
           mountPath: "/certs"
         - name: karavi-topology-configmap
-          mountPath: /etc/config/karavi-topology-config.yaml
-          subPath: karavi-topology-config.yaml
+          mountPath: "/etc/config"
       restartPolicy: Always
 status: {}

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -16,7 +16,7 @@ karaviMetricsPowerflex:
   # comma separated list of provisioner names (ex: csi-vxflexos.dellemc.com)
   provisionerNames: csi-vxflexos.dellemc.com
   # set sdcMetricsEnabled to "false" to disable collection of SDC metrics
-  sdc_metricsEnabled: "true"
+  sdcmetricsEnabled: "true"
   # set polling frequency to the PowerFlex array to get metrics data
   sdcPollFrequencySeconds: 10
   volumePollFrequencySeconds: 10

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -16,7 +16,7 @@ karaviMetricsPowerflex:
   # comma separated list of provisioner names (ex: csi-vxflexos.dellemc.com)
   provisionerNames: csi-vxflexos.dellemc.com
   # set sdcMetricsEnabled to "false" to disable collection of SDC metrics
-  sdcmetricsEnabled: "true"
+  sdcMetricsEnabled: "true"
   # set polling frequency to the PowerFlex array to get metrics data
   sdcPollFrequencySeconds: 10
   volumePollFrequencySeconds: 10


### PR DESCRIPTION
#### Is this a new chart?

No

#### What this PR does / why we need it:
This PR is to create config files in /etc/config named karavi-metrics-powerflex.yaml and karavi-topology.yaml , which contains parameters that can be modified while running the karavi-observability services. The config files will be created during the helm install. 

#### Which issue(s) is this PR associated with:

- [dell/karavy-observability#25](https://github.com/dell/karavi-observability/issues/25)

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
