### PR TITLE
Remove GITHUB_BASE_REF dependency

### DIFF
--- a/.github/workflows/helm-validations.yml
+++ b/.github/workflows/helm-validations.yml
@@ -17,8 +17,9 @@ jobs:
      - name: Check for files changed
        id: diff
        run: |
-            git fetch origin $GITHUB_BASE_REF --depth=1
-            git diff --name-only origin/$GITHUB_BASE_REF.. | grep \.yaml$ && echo '::set-output name=run_tests::true' || true
+            URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
+            FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename')
+            echo $FILES | grep \.yaml$ && echo '::set-output name=run_tests::true' || true
  
   # This job will run helm lint and version increment check on updated charts
   lint:


### PR DESCRIPTION
 Remove GITHUB_BASE_REF dependency

<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
This PR  removes the GITHUB_BASE_REF dependency for skipping helm lint tests. Without this change, PR whose base ref isn't master will 'randomly' fail or act abnormally. 

#### Which issue(s) is this PR associated with:

- [#27](https://github.com/dell/karavi-observability/issues/27)

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
