### PR TITLE
Use secret from the csi-vxflexos driver

### DIFF
--- a/charts/karavi-observability/templates/NOTES.txt
+++ b/charts/karavi-observability/templates/NOTES.txt
@@ -14,7 +14,6 @@ Karavi Metrics for PowerFlex
 
   The Karavi Metrics for PowerFlex deployment has been successfully installed.
 
-  PowerFlex Endpoint: {{ .Values.karaviMetricsPowerflex.powerflexEndpoint }}
   Provisioner Names: {{ .Values.karaviMetricsPowerflex.provisionerNames }}
   Prometheus Scrape Target: 
     From inside the Kubernetes cluster: otel-collector:8443

--- a/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
@@ -1,18 +1,3 @@
-{{- $powerflexUser := required "A valid PowerFlex user is required. Refer to the Helm Chart documentation." .Values.karaviMetricsPowerflex.powerflexUser }}
-{{- $powerflexPassword := required "A valid PowerFlex password is required. Refer to the Helm Chart documentation." .Values.karaviMetricsPowerflex.powerflexPassword }}
-{{- $powerflexEndpoint := required "A valid PowerFlex endpoint is required. Refer to the Helm Chart documentation." .Values.karaviMetricsPowerflex.powerflexEndpoint }}
-
-apiVersion: v1
-kind: Secret
-metadata:
-  name: powerflex-gateway-credentials
-type: Opaque
-data:
-  username: {{ $powerflexUser }}
-  password: {{ $powerflexPassword }}
-
----
-
 apiVersion: v1
 kind: Service
 metadata:
@@ -58,18 +43,6 @@ spec:
         image: {{ .Values.karaviMetricsPowerflex.image }}
         resources: {}
         env:
-        - name: POWERFLEX_ENDPOINT
-          value: {{ $powerflexEndpoint }}
-        - name: POWERFLEX_USER
-          valueFrom:
-            secretKeyRef:
-              name: powerflex-gateway-credentials
-              key: username
-        - name: POWERFLEX_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: powerflex-gateway-credentials
-              key: password
         - name: POWERFLEX_METRICS_ENDPOINT	
           value: "{{ .Values.karaviMetricsPowerflex.endpoint }}"
         - name: POWERFLEX_METRICS_NAMESPACE
@@ -79,12 +52,17 @@ spec:
         - name: TLS_ENABLED
           value: "true"
         volumeMounts:
+        - name: vxflexos-config
+          mountPath: /vxflexos-config
         - name: tls-secret
           mountPath: /etc/ssl/certs
           readOnly: true
         - name: karavi-metrics-powerflex-configmap
           mountPath: /etc/config
       volumes:
+      - name: vxflexos-config
+        secret:
+          secretName: vxflexos-config
       - name: tls-secret
         secret:
           secretName: otel-collector-tls

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -6,11 +6,6 @@ karaviTopology:
     type: ClusterIP
 
 karaviMetricsPowerflex:
-  powerflexEndpoint:
-  # base64 user and password
-  powerflexUser:
-  powerflexPassword:
-
   image: dellemc/karavi-metrics-powerflex:0.2.0-pre-release
   collectorAddr: otel-collector:55680
   # comma separated list of provisioner names (ex: csi-vxflexos.dellemc.com)


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?
No

#### What this PR does / why we need it:
Removes the Secret that contains the PowerFlex endpoint and credentials. Adds a new volume mount for the vxflexos-config Secret that will be copied from the PowerFlex CSI driver namespace to be used with Karavi Observability.

#### Which issue(s) is this PR associated with:

- https://github.com/dell/karavi-observability/issues/30

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
