### PR TITLE
Update nginx image to be compatible with OpenShift

### DIFF
--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -33,4 +33,4 @@ otelCollector:
   service:
     type: ClusterIP
   nginxProxy:
-    image: nginx:1
+    image: nginxinc/nginx-unprivileged:1.18


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

On OpenShift, the nginx:1 image fails with an error `nginx: [emerg] mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)`. The fix is to use the unprivileged version of the image.

#### Testing:
- Sucessfully ran e2e against k8s 1.20
- Successfully ran e2e against Openshift 4.6

#### Which issue(s) is this PR associated with:

- https://github.com/dell/helm-charts/issues/54

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
