### PR TITLE
Added log level and format to configmaps for topology and metrics-powerflex

### DIFF
--- a/charts/karavi-observability/Chart.yaml
+++ b/charts/karavi-observability/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: "0.3.0"
+appVersion: "0.4.0"
 name: karavi-observability
 description: Karavi Observability is part of the [Karavi](https://github.com/dell/karavi) open source suite of Kubernetes storage enablers for Dell EMC storage products. Karavi Observability provides Kubernetes administrators with visibility into metrics and topology data related to containerized storage.
 type: application
-version: 0.3.0
+version: 0.4.0
 dependencies:
 - name: cert-manager
   version: 1.1.0

--- a/charts/karavi-observability/templates/karavi-observability-configmap.yaml
+++ b/charts/karavi-observability/templates/karavi-observability-configmap.yaml
@@ -13,6 +13,9 @@ data:
     POWERFLEX_STORAGE_POOL_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerflex.storageClassPoolMetricsEnabled }}"
     POWERFLEX_STORAGE_POOL_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerflex.storageClassPoolPollFrequencySeconds }}"
     POWERFLEX_MAX_CONCURRENT_QUERIES: "{{ .Values.karaviMetricsPowerflex.concurrentPowerflexQueries }}"
+    LOG_LEVEL: "{{ .Values.karaviMetricsPowerflex.logLevel }}"
+    LOG_FORMAT: "{{ .Values.karaviMetricsPowerflex.logFormat }}"
+
   
 ---
 
@@ -23,3 +26,5 @@ metadata:
 data:
   karavi-topology.yaml: |
     PROVISIONER_NAMES: {{ .Values.karaviTopology.provisionerNames }}
+    LOG_LEVEL: "{{ .Values.karaviTopology.logLevel }}"
+    LOG_FORMAT: "{{ .Values.karaviTopology.logFormat }}"

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -4,6 +4,8 @@ karaviTopology:
   provisionerNames: csi-vxflexos.dellemc.com
   service:
     type: ClusterIP
+  logLevel: INFO
+  logFormat: text
 
 karaviMetricsPowerflex:
   image: dellemc/csm-metrics-powerflex:v0.3.0
@@ -27,6 +29,9 @@ karaviMetricsPowerflex:
   endpoint: karavi-metrics-powerflex
   service:
     type: ClusterIP
+  logLevel: INFO
+  logFormat: text
+
 
 otelCollector:
   image: otel/opentelemetry-collector:0.9.0


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

This adds 2 new properties to the topology and metrics-powerflex services to support setting the log level (e.g. debug, info, warn, error, etc) and log format (e.g. text, json).

#### Which issue(s) is this PR associated with:

- https://github.com/dell/karavi-observability/issues/43

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
