### PR TITLE
Added Zipkin and debug metrics support for metrics-powerstore

### DIFF
--- a/charts/karavi-observability/templates/cert-manager.yaml
+++ b/charts/karavi-observability/templates/cert-manager.yaml
@@ -26,6 +26,34 @@ spec:
 ---
 {{- end }}
 
+# If the karavi-metrics-powerstore cert and key are provided, deploy a CA Issuer using the cert and key
+{{- if and (.Values.karaviMetricsPowerstore.certificateFile) (.Values.karaviMetricsPowerstore.privateKeyFile) }}
+{{- $certificateFileContents := .Values.karaviMetricsPowerstore.certificateFile }}
+{{- $privateKeyFileContents := .Values.karaviMetricsPowerstore.privateKeyFile }}
+apiVersion: v1
+data:
+  tls.crt: {{ $certificateFileContents | b64enc }}
+  tls.key: {{ $privateKeyFileContents | b64enc }}
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: karavi-metrics-powerstore-secret
+  namespace: {{ .Release.Namespace }}
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: karavi-metrics-powerstore-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: karavi-metrics-powerstore-secret
+
+---
+{{- end }}
+
 # If the otelCollector cert and key are provided, deploy a CA Issuer using the cert and key
 {{- if and (.Values.otelCollector.certificateFile) (.Values.otelCollector.privateKeyFile) }}
 {{- $certificateFileContents := .Values.otelCollector.certificateFile }}
@@ -55,7 +83,7 @@ spec:
 {{- end }}
 
 # If any set of cert+key combos are not provided, deploy a selfsigned-issuer
-{{- if or (and (not .Values.karaviTopology.certificateFile) (not .Values.karaviTopology.privateKeyFile)) (and (not .Values.otelCollector.certificateFile) (not .Values.otelCollector.privateKeyFile)) }}
+{{- if or (and (not .Values.karaviTopology.certificateFile) (not .Values.karaviTopology.privateKeyFile)) (and (not .Values.otelCollector.certificateFile) (not .Values.otelCollector.privateKeyFile)) (and (not .Values.karaviMetricsPowerstore.certificateFile) (not .Values.karaviMetricsPowerstore.privateKeyFile)) }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -133,3 +161,36 @@ spec:
     kind: Issuer
     group: cert-manager.io
 
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: karavi-metrics-powerstore
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: karavi-metrics-powerstore-tls
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  subject:
+    organizations:
+    - dellemc
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+  - karavi-metrics-powerstore
+  - karavi-metrics-powerstore.karavi.svc.kubernetes.local
+  issuerRef:
+  {{- if and (.Values.karaviMetricsPowerstore.certificateFile) (.Values.karaviMetricsPowerstore.privateKeyFile) }}
+    name: karavi-metrics-powerstore-issuer
+  {{- else }}
+    name: selfsigned-issuer
+  {{- end }}
+    kind: Issuer
+    group: cert-manager.io

--- a/charts/karavi-observability/templates/karavi-metrics-powerstore.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerstore.yaml
@@ -11,8 +11,8 @@ spec:
   type: {{ .Values.karaviMetricsPowerstore.service.type }}
   ports:
   - name: karavi-metrics-powerstore
-    port: 2222
-    targetPort: 2222
+    port: 9090
+    targetPort: 9090
   selector:
     app.kubernetes.io/name: karavi_metrics_powerstore
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -54,6 +54,8 @@ spec:
         - name: TLS_ENABLED
           value: "true"
         volumeMounts:
+        - name: karavi-metrics-powerstore-secret-volume
+          mountPath: "/certs"
         - name: powerstore-config
           mountPath: /powerstore-config
         - name: tls-secret
@@ -62,6 +64,14 @@ spec:
         - name: karavi-metrics-powerstore-configmap
           mountPath: /etc/config
       volumes:
+      - name: karavi-metrics-powerstore-secret-volume
+        secret:
+          secretName: karavi-metrics-powerstore-tls
+          items:
+            - key: tls.crt
+              path: localhost.crt
+            - key: tls.key
+              path: localhost.key
       - name: powerstore-config
         secret:
           secretName: powerstore-config

--- a/charts/karavi-observability/templates/karavi-observability-configmap.yaml
+++ b/charts/karavi-observability/templates/karavi-observability-configmap.yaml
@@ -53,6 +53,9 @@ data:
     POWERSTORE_MAX_CONCURRENT_QUERIES: "{{ .Values.karaviMetricsPowerstore.concurrentPowerstoreQueries }}"
     LOG_LEVEL: "{{ .Values.karaviMetricsPowerstore.logLevel }}"
     LOG_FORMAT: "{{ .Values.karaviMetricsPowerstore.logFormat }}"
+    ZIPKIN_URI: "{{ .Values.karaviMetricsPowerstore.zipkin.uri }}"
+    ZIPKIN_SERVICE_NAME: "{{ .Values.karaviMetricsPowerstore.zipkin.serviceName }}"
+    ZIPKIN_PROBABILITY: "{{ .Values.karaviMetricsPowerstore.zipkin.probability }}"
 
 {{ end }}
 

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -52,6 +52,10 @@ karaviMetricsPowerstore:
     type: ClusterIP
   logLevel: INFO
   logFormat: text
+  zipkin:
+    uri: ""
+    serviceName: metrics-powerstore
+    probability: 0.0
 
 otelCollector:
   image: otel/opentelemetry-collector:0.9.0


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
This PR updates metrics-powerstore with following functionality:
- Add support for passing Zipkin configuration (URI, Service Name, and Probability) to the metrics-powerstore service. By default, Zipkin is disabled (Probability=0).
- Provide certificate/key files used to support TLS support for the new debug endpoint in metrics-powerstore. If files are not provided, cert-manager will generate certificates automatically.

#### Testing:
Installed the helm-chart and verified metrics-powerstore was successfully configured.

#### Which issue(s) is this PR associated with:

- https://github.com/dell/karavi-observability/issues/48

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
