### PR TITLE
Add support for zipkin and golang profile in topology service

### DIFF
--- a/charts/karavi-observability/templates/karavi-observability-configmap.yaml
+++ b/charts/karavi-observability/templates/karavi-observability-configmap.yaml
@@ -33,6 +33,9 @@ data:
     PROVISIONER_NAMES: {{ .Values.karaviTopology.provisionerNames }}
     LOG_LEVEL: "{{ .Values.karaviTopology.logLevel }}"
     LOG_FORMAT: "{{ .Values.karaviTopology.logFormat }}"
+    ZIPKIN_URI: "{{ .Values.karaviTopology.zipkin.uri }}"
+    ZIPKIN_SERVICE_NAME: "{{ .Values.karaviTopology.zipkin.serviceName }}"
+    ZIPKIN_PROBABILITY: "{{ .Values.karaviTopology.zipkin.probability }}"
 
 {{ end }}
 

--- a/charts/karavi-observability/templates/karavi-topology.yaml
+++ b/charts/karavi-observability/templates/karavi-topology.yaml
@@ -59,6 +59,8 @@ spec:
         env:
         - name: PORT
           value: "8443"
+        - name: DEBUG
+          value: "false"
         volumeMounts:
         - name: karavi-topology-secret-volume
           mountPath: "/certs"

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -7,6 +7,10 @@ karaviTopology:
     type: ClusterIP
   logLevel: INFO
   logFormat: text
+  zipkin:
+    uri: ""
+    serviceName: karavi-topology
+    probability: 0.0
 
 karaviMetricsPowerflex:
   image: dellemc/csm-metrics-powerflex:v0.3.0


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

This PR will add support for golang profiling and zipkin support for topology service.

#### Which issue(s) is this PR associated with:

- #https://github.com/dell/karavi-observability/issues/58

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
- [x] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
