### PR TITLE
Karavi topology cert prom

### DIFF
--- a/charts/karavi-observability/Chart.yaml
+++ b/charts/karavi-observability/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: "0.3.0"
+appVersion: "0.3.1"
 name: karavi-observability
 description: Karavi Observability is part of the [Karavi](https://github.com/dell/karavi) open source suite of Kubernetes storage enablers for Dell EMC storage products. Karavi Observability provides Kubernetes administrators with visibility into metrics and topology data related to containerized storage.
 type: application
-version: 0.3.0
+version: 0.3.1
 dependencies:
 - name: cert-manager
   version: 1.1.0

--- a/charts/karavi-observability/templates/cert-manager.yaml
+++ b/charts/karavi-observability/templates/cert-manager.yaml
@@ -121,6 +121,7 @@ spec:
   usages:
     - server auth
     - client auth
+    - signing
   dnsNames:
   - karavi-topology
   - karavi-topology.karavi.svc.kubernetes.local

--- a/charts/karavi-observability/templates/cert-manager.yaml
+++ b/charts/karavi-observability/templates/cert-manager.yaml
@@ -9,7 +9,7 @@ data:
 kind: Secret
 type: kubernetes.io/tls
 metadata:
-  name: karavi-topology-secret
+  name: karavi-topology-tls
   namespace: {{ .Release.Namespace }}
 
 ---
@@ -21,7 +21,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ca:
-    secretName: karavi-topology-secret
+    secretName: karavi-topology-tls
 
 ---
 {{- end }}
@@ -34,7 +34,7 @@ apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls
 metadata:
-  name: otel-collector-secret
+  name: otel-collector-tls
   namespace: {{ .Release.Namespace }}
 data:
   tls.crt: {{ $certificateFileContents  | b64enc }}
@@ -49,7 +49,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ca:
-    secretName: otel-collector-secret
+    secretName: otel-collector-tls
 
 ---
 {{- end }}
@@ -67,6 +67,8 @@ spec:
 ---
 {{- end }}
 
+# only create Certificate for self-signed
+{{- if and (not .Values.otelCollector.certificateFile) (not .Values.otelCollector.privateKeyFile) }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -91,29 +93,27 @@ spec:
   - otel-collector
   - otel-collector.karavi.svc.kubernetes.local
   issuerRef:
-  {{- if and (.Values.otelCollector.certificateFile) (.Values.otelCollector.privateKeyFile) }}
-    name: otel-collector-issuer
-  {{- else }}
     name: selfsigned-issuer
-  {{- end }}
     kind: Issuer
     group: cert-manager.io
 
 ---
+{{- end }}
 
+# only create Certificate for self-signed
+{{- if and (not .Values.karaviTopology.certificateFile) (not .Values.karaviTopology.privateKeyFile) }} 
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: karavi-topology
   namespace: {{ .Release.Namespace }}
 spec:
-  secretName: karavi-topology-tls
   duration: 2160h # 90d
   renewBefore: 360h # 15d
   subject:
     organizations:
     - dellemc
-  isCA: false
+  isCA: true
   privateKey:
     algorithm: RSA
     encoding: PKCS1
@@ -124,12 +124,9 @@ spec:
   dnsNames:
   - karavi-topology
   - karavi-topology.karavi.svc.kubernetes.local
+  secretName: karavi-topology-tls
   issuerRef:
-  {{- if and (.Values.karaviTopology.certificateFile) (.Values.karaviTopology.privateKeyFile) }}
-    name: karavi-topology-issuer
-  {{- else }}
     name: selfsigned-issuer
-  {{- end }}
     kind: Issuer
     group: cert-manager.io
-
+{{- end }}

--- a/charts/karavi-observability/templates/cert-manager.yaml
+++ b/charts/karavi-observability/templates/cert-manager.yaml
@@ -91,7 +91,7 @@ spec:
     - client auth
   dnsNames:
   - otel-collector
-  - otel-collector.karavi.svc.kubernetes.local
+  - otel-collector.{{ .Release.Namespace }}.svc.kubernetes.local
   issuerRef:
     name: selfsigned-issuer
     kind: Issuer
@@ -124,7 +124,7 @@ spec:
     - signing
   dnsNames:
   - karavi-topology
-  - karavi-topology.karavi.svc.kubernetes.local
+  - karavi-topology.{{ .Release.Namespace }}.svc.kubernetes.local
   secretName: karavi-topology-tls
   issuerRef:
     name: selfsigned-issuer

--- a/charts/karavi-observability/templates/cert-manager.yaml
+++ b/charts/karavi-observability/templates/cert-manager.yaml
@@ -164,7 +164,7 @@ spec:
 
 
 # only create Certificate for self-signed
-{{- if and (.Values.karaviMetricsPowerstore.certificateFile) (.Values.karaviMetricsPowerstore.privateKeyFile) }}
+{{- if and (not .Values.karaviMetricsPowerstore.certificateFile) (not .Values.karaviMetricsPowerstore.privateKeyFile) }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Prevents cert-manager from modifying passed certificates and ensures that self-singed certificates can be used for CA verification

#### Which issue(s) is this PR associated with:

- https://github.com/dell/karavi-observability/issues/52

#### Special notes for your reviewer:
The topology self-signed certificate is missing Key Usage and will get illegal characters if used for CA verification. Now the certificated looks:
```
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            2a:f9:d2:63:30:b9:17:4d:38:9e:21:e3:0e:fd:89:b4
    Signature Algorithm: sha256WithRSAEncryption
        Issuer: O=dellemc
        Validity
            Not Before: May 25 20:26:43 2021 GMT
            Not After : Aug 23 20:26:43 2021 GMT
        Subject: O=dellemc
        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption
                Public-Key: (2048 bit)
                Modulus:
                    00:d9:b8:06:7d:a5:a2:a7:f9:d7:66:02:05:13:34:
                    be:ac:b6:65:35:9a:57:09:bd:86:89:34:c2:5a:b7:
                    63:04:de:63:2d:0a:f6:1e:32:af:1e:e0:45:ab:b0:
                    dd:e2:d1:e5:dc:5e:ca:13:3d:39:43:a6:e0:b4:64:
                    62:d5:6b:63:07:60:3d:19:4e:aa:5d:5c:23:7c:2e:
                    47:e9:d5:76:52:da:25:14:e6:91:4b:54:77:8a:a4:
                    7e:10:83:cd:25:7f:64:a4:45:d2:cc:3d:34:c0:cb:
                    af:0f:b2:a3:97:d8:d0:35:64:f4:66:93:c2:67:89:
                    27:eb:3f:00:fa:3c:a6:50:15:56:31:e1:ff:33:c4:
                    ef:9a:dc:64:45:1e:8a:6b:3b:a0:54:93:47:4e:03:
                    af:a4:8c:e4:38:80:8b:b6:0b:00:f9:a5:8e:19:9e:
                    b2:9c:c6:39:44:f4:30:cf:26:21:46:9b:ea:d6:fa:
                    d2:73:83:44:0f:c8:68:0f:ac:d0:b1:25:ea:b7:53:
                    18:f8:31:31:ac:9b:d4:83:02:d0:f7:c6:60:af:c3:
                    77:4c:19:c3:d4:0b:ff:d9:0a:8e:cf:07:7b:a2:58:
                    9b:15:f9:4f:55:ce:c1:77:47:2b:a1:c7:4c:29:02:
                    38:54:50:da:13:5f:a5:71:05:c6:92:43:26:f4:66:
                    1b:45
                Exponent: 65537 (0x10001)
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Certificate Sign
            X509v3 Extended Key Usage:
                TLS Web Server Authentication, TLS Web Client Authentication
            X509v3 Basic Constraints: critical
                CA:TRUE
            X509v3 Subject Key Identifier:
                62:C6:48:B7:D7:F7:B3:E4:C1:79:4C:EC:AD:87:F0:09:16:C9:DF:6D
            X509v3 Subject Alternative Name:
                DNS:karavi-topology, DNS:karavi-topology.karavi.svc.kubernetes.local
    Signature Algorithm: sha256WithRSAEncryption
         05:8f:2f:6c:35:e5:47:30:90:c0:28:aa:fd:52:5c:5f:02:4c:
         59:98:02:b6:71:94:60:ef:31:09:02:5c:5f:de:2d:d0:3a:c8:
         1b:2c:d8:3e:94:c9:ef:98:a5:f3:de:df:6a:4a:65:9d:f6:42:
         d5:0c:51:a2:63:71:1e:34:bb:bd:46:26:ab:5e:b8:92:62:ce:
         de:78:68:ca:5a:9a:6f:52:18:70:6b:52:3f:49:88:a6:1d:5a:
         19:57:6a:9a:14:d8:5a:b3:30:e3:1b:e6:93:03:df:b9:10:e4:
         48:43:d3:e3:5c:6c:a7:ac:01:fd:37:4e:05:f5:9b:16:c3:ce:
         85:3f:12:46:6d:75:a1:3a:bf:27:6e:ce:04:fe:03:70:c2:75:
         ca:78:da:53:12:e6:21:96:25:5d:12:30:63:62:05:5c:1c:1c:
         60:11:71:dc:1a:30:1c:06:d3:9c:6c:5a:a4:cd:c5:33:5d:e1:
         91:ce:79:75:ba:7a:4a:05:b0:21:2f:ef:16:9b:78:77:7c:13:
         46:cb:b0:c9:22:40:e8:64:47:b6:3c:38:0a:dc:c1:19:73:de:
         b0:45:8e:e3:de:fe:e6:fd:65:85:98:ab:45:7f:a5:f7:e8:e4:
         6c:b0:16:57:33:9b:f3:c0:03:96:ef:bc:df:69:ff:0e:00:f3:
         4a:12:75:42
```

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
