### PR TITLE
Change Powerstore metrics timeticker to PowerStore APIs default values

### DIFF
--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -45,10 +45,10 @@ karaviMetricsPowerstore:
   # comma separated list of provisioner names (ex: csi-powerstore.dellemc.com)
   provisionerNames: csi-powerstore.dellemc.com
   # set polling frequency to the PowerStore array to get metrics data
-  volumePollFrequencySeconds: 10
-  spacePollFrequencySeconds: 10
-  arrayPollFrequencySeconds: 10
-  filesystemPollFrequencySeconds: 10
+  volumePollFrequencySeconds: 20
+  spacePollFrequencySeconds: 300
+  arrayPollFrequencySeconds: 300
+  filesystemPollFrequencySeconds: 20
   # set volumeMetricsEnabled to "false" to disable collection of Volume metrics
   volumeMetricsEnabled: "true"
   # set the the default max concurrent queries to powerstore


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

Yes/No

#### What this PR does / why we need it: 
Change Powerstore metrics timeticker to PowerStore APIs default values

#### Which issue(s) is this PR associated with:

- #https://github.com/dell/karavi-observability/issues/61

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
