### PR TITLE
karavi-observability: Update cert manager to 1.5.3

### DIFF
--- a/charts/karavi-observability/Chart.yaml
+++ b/charts/karavi-observability/Chart.yaml
@@ -6,5 +6,5 @@ type: application
 version: 1.0.0
 dependencies:
 - name: cert-manager
-  version: 1.1.0
+  version: 1.5.3
   repository: https://charts.jetstack.io

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -70,3 +70,9 @@ otelCollector:
     type: ClusterIP
   nginxProxy:
     image: nginxinc/nginx-unprivileged:1.18
+
+cert-manager:
+  startupapicheck:
+    enabled: false
+    serviceAccount:
+      create: false


### PR DESCRIPTION
#### Is this a new chart?

No

#### What this PR does / why we need it:
This PR upgrades cert-manager to the latest(1.5.3) version to support k8s 1.22. 

#### Which issue(s) is this PR associated with:

- 

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
