### PR TITLE
[charts/karavi-observability] Updated otel-collector and cert manager for observability helm chart

### DIFF
--- a/charts/karavi-observability/Chart.yaml
+++ b/charts/karavi-observability/Chart.yaml
@@ -6,5 +6,5 @@ type: application
 version: 1.0.1
 dependencies:
 - name: cert-manager
-  version: 1.5.3
+  version: 1.6.1
   repository: https://charts.jetstack.io

--- a/charts/karavi-observability/otel-collector-config.yaml
+++ b/charts/karavi-observability/otel-collector-config.yaml
@@ -2,7 +2,7 @@ receivers:
   otlp:
     protocols:
       grpc:
-        tls_settings:
+        tls:
           cert_file: /etc/ssl/certs/tls.crt
           key_file: /etc/ssl/certs/tls.key
       http:

--- a/charts/karavi-observability/otel-collector-config.yaml
+++ b/charts/karavi-observability/otel-collector-config.yaml
@@ -2,10 +2,10 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:55680
         tls:
           cert_file: /etc/ssl/certs/tls.crt
           key_file: /etc/ssl/certs/tls.key
-      http:
   
 exporters:
   prometheus:

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -65,11 +65,11 @@ karaviMetricsPowerstore:
     probability: 0.0
 
 otelCollector:
-  image: otel/opentelemetry-collector:0.9.0
+  image: otel/opentelemetry-collector:0.42.0
   service:
     type: ClusterIP
   nginxProxy:
-    image: nginxinc/nginx-unprivileged:1.18
+    image: nginxinc/nginx-unprivileged:1.20
 
 cert-manager:
   startupapicheck:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
With upcoming updates to the otel-collector and all of the otel packages in the various observability repos the otel-collector config needed to be updated according to upstream changes to the collector.

#### Which issue(s) is this PR associated with:

None

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
- [x] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable

I have run e2e tests with this config change successfully:
```
--- PASS: Test_Metrics (58.55s)
    --- PASS: Test_Metrics/Powerflex_Volume_Metrics (14.19s)
    --- PASS: Test_Metrics/Powerflex_Storage_Pool (14.17s)
    --- PASS: Test_Metrics/Powerflex_ExportNode_Metrics (30.18s)
PASS
ok      karavi-testing/karavi-metrics/metrics-test      58.584s
--- PASS: Test_Query_Topology (14.17s)
PASS
ok      karavi-testing/karavi-topology/topology-test    14.197s

--- PASS: Test_Metrics (246.54s)
    --- PASS: Test_Metrics/PowerStore_Space_Metrics (192.17s)
    --- PASS: Test_Metrics/PowerStore_FileSystem_Metrics (40.19s)
    --- PASS: Test_Metrics/PowerStore_Volume_Metrics (14.17s)
PASS
ok      karavi-testing/karavi-metrics/metrics-test      246.577s
```