### PR TITLE
[charts/karavi-observability] Make `app.kubernetes.io/name` and `name` consistent

### DIFF
--- a/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/name: karavi_metrics_powerflex
+    app.kubernetes.io/name: karavi-metrics-powerflex
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: karavi-metrics-powerflex
 spec:
@@ -14,7 +14,7 @@ spec:
     port: 2222
     targetPort: 2222
   selector:
-    app.kubernetes.io/name: karavi_metrics_powerflex
+    app.kubernetes.io/name: karavi-metrics-powerflex
     app.kubernetes.io/instance: {{ .Release.Name }}
 
 ---
@@ -24,19 +24,19 @@ kind: Deployment
 metadata:
   name: karavi-metrics-powerflex
   labels:
-    app.kubernetes.io/name: karavi_metrics_powerflex
+    app.kubernetes.io/name: karavi-metrics-powerflex
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: karavi_metrics_powerflex
+      app.kubernetes.io/name: karavi-metrics-powerflex
       app.kubernetes.io/instance: {{ .Release.Name }}
   replicas: 1
   strategy: {}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: karavi_metrics_powerflex
+        app.kubernetes.io/name: karavi-metrics-powerflex
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccount: {{ .Release.Name }}-metrics-powerflex-controller

--- a/charts/karavi-observability/templates/karavi-metrics-powerstore.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerstore.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/name: karavi_metrics_powerstore
+    app.kubernetes.io/name: karavi-metrics-powerstore
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: karavi-metrics-powerstore
 spec:
@@ -14,7 +14,7 @@ spec:
     port: 9090
     targetPort: 9090
   selector:
-    app.kubernetes.io/name: karavi_metrics_powerstore
+    app.kubernetes.io/name: karavi-metrics-powerstore
     app.kubernetes.io/instance: {{ .Release.Name }}
 
 ---
@@ -24,19 +24,19 @@ kind: Deployment
 metadata:
   name: karavi-metrics-powerstore
   labels:
-    app.kubernetes.io/name: karavi_metrics_powerstore
+    app.kubernetes.io/name: karavi-metrics-powerstore
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: karavi_metrics_powerstore
+      app.kubernetes.io/name: karavi-metrics-powerstore
       app.kubernetes.io/instance: {{ .Release.Name }}
   replicas: 1
   strategy: {}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: karavi_metrics_powerstore
+        app.kubernetes.io/name: karavi-metrics-powerstore
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccount: {{ .Release.Name }}-metrics-powerstore-controller

--- a/charts/karavi-observability/templates/karavi-topology.yaml
+++ b/charts/karavi-observability/templates/karavi-topology.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/name: karavi_topology
+    app.kubernetes.io/name: karavi-topology
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: karavi-topology
 spec:
@@ -14,7 +14,7 @@ spec:
     port: 8443
     targetPort: 8443
   selector:
-    app.kubernetes.io/name: karavi_topology
+    app.kubernetes.io/name: karavi-topology
     app.kubernetes.io/instance: {{ .Release.Name }}
 
 ---
@@ -24,19 +24,19 @@ kind: Deployment
 metadata:
   name: karavi-topology
   labels:
-    app.kubernetes.io/name: karavi_topology
+    app.kubernetes.io/name: karavi-topology
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: karavi_topology
+      app.kubernetes.io/name: karavi-topology
       app.kubernetes.io/instance: {{ .Release.Name }}
   replicas: 1
   strategy: {}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: karavi_topology
+        app.kubernetes.io/name: karavi-topology
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       volumes:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
It replaces the  `app.kubernetes.io/name`  with `name` of the application.

It is better to be consistent between these and generally speaking the [names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) should be compatible with DNS names (i.e. no `_` accepted).
#### Which issue(s) is this PR associated with:

[dell/csm/#186](https://github.com/dell/csm/issues/186)

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [X] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
