### PR TITLE
karavi-observability: Reverting OTEL version for patch 1.1.1

### DIFF
--- a/charts/karavi-observability/otel-collector-config.yaml
+++ b/charts/karavi-observability/otel-collector-config.yaml
@@ -2,8 +2,7 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: 0.0.0.0:55680
-        tls:
+        tls_settings:
           cert_file: /etc/ssl/certs/tls.crt
           key_file: /etc/ssl/certs/tls.key
   

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -79,11 +79,11 @@ karaviMetricsPowerstore:
     probability: 0.0
 
 otelCollector:
-  image: otel/opentelemetry-collector:0.42.0
+  image: otel/opentelemetry-collector:0.9.0
   service:
     type: ClusterIP
   nginxProxy:
-    image: nginxinc/nginx-unprivileged:1.20
+    image: nginxinc/nginx-unprivileged:1.18
 
 cert-manager:
   startupapicheck:


### PR DESCRIPTION
#### Is this a new chart?
No

#### What this PR does / why we need it:
Reverts the OTEl version to fix the issue with displaying metrics in Grafana

#### Which issue(s) is this PR associated with:

- [#288](https://github.com/dell/csm/issues/288)

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
