### PR TITLE
[csm-authorization]: allow all powerflex paths and change default values

### DIFF
--- a/charts/csm-authorization/Chart.yaml
+++ b/charts/csm-authorization/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: csm-authorization
-version: 1.3.0
-appVersion: 1.3.0
+version: 1.3.1
+appVersion: 1.3.1
 type: application
 description: CSM for Authorization is part of the [Container Storage Modules](https://github.com/dell/csm) open source suite of Kubernetes storage enablers for Dell EMC storage products. CSM for Authorization provides storage and Kubernetes administrators the ability to apply RBAC for Dell CSI Drivers.
 dependencies:

--- a/charts/csm-authorization/policies/url.rego
+++ b/charts/csm-authorization/policies/url.rego
@@ -33,7 +33,7 @@ allowlist = [
 		"POST /api/instances/Volume::[a-f0-9]+/action/removeVolume/"
 ]
 
-default allow = false
+default allow = true
 allow {
 	regex.match(allowlist[_], sprintf("%s %s", [input.method, input.url]))
 }

--- a/charts/csm-authorization/values.yaml
+++ b/charts/csm-authorization/values.yaml
@@ -35,7 +35,7 @@ authorization:
 
   # proxy-server ingress configuration
   proxyServerIngress:
-    ingressClassName:  # nginx
+    ingressClassName: nginx
 
     # additional host rules for the proxy-server ingress
     hosts: []
@@ -46,15 +46,15 @@ authorization:
 
   # tenant-service ingress configuration
   tenantServiceIngress:
-    ingressClassName:  # nginx
+    ingressClassName: nginx
 
     # additional host rules for the tenant-service ingress
     hosts: []
 
     # additional annotations for the tenant-service ingress
     # if applicable, an annotation supporting grpc for your ingress controller must be supplied
-    annotations: {}
-      # nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    annotations:
+      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
 
   # role-service ingress configuration
   roleServiceIngress:
@@ -65,8 +65,8 @@ authorization:
 
     # additional annotations for the role-service ingress
     # an annotation supporting grpc for your ingress controller must be supplied, if applicable
-    annotations: {}
-      # nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    annotations:
+      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
 
   # storage-service ingress configuration
   storageServiceIngress:
@@ -77,8 +77,8 @@ authorization:
 
     # additional annotations for the storage-service ingress
     # an annotation supporting grpc for your ingress controller must be supplied, if applicable
-    annotations: {}
-      # nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    annotations:
+      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
 
 redis:
   images:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

- Changes the default behavior of the csi-powerflex url paths policy to allow all paths by default. 
- Since the nginx-controller is enabled by default, we should enable the relevant ingressClassName and annotations by default.

#### Which issue(s) is this PR associated with:

https://github.com/dell/csm/issues/353

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
