### PR TITLE
Rollback otel-collecter image version to 0.42.0

### DIFF
--- a/charts/karavi-observability/otel-collector-config.yaml
+++ b/charts/karavi-observability/otel-collector-config.yaml
@@ -2,7 +2,8 @@ receivers:
   otlp:
     protocols:
       grpc:
-        tls_settings:
+        endpoint: 0.0.0.0:55680
+        tls:
           cert_file: /etc/ssl/certs/tls.crt
           key_file: /etc/ssl/certs/tls.key
   

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -79,11 +79,11 @@ karaviMetricsPowerstore:
     probability: 0.0
 
 otelCollector:
-  image: otel/opentelemetry-collector:0.9.0
+  image: otel/opentelemetry-collector:0.42.0
   service:
     type: ClusterIP
   nginxProxy:
-    image: nginxinc/nginx-unprivileged:1.18
+    image: nginxinc/nginx-unprivileged:1.20
 
 cert-manager:
   startupapicheck:


### PR DESCRIPTION
#### Is this a new chart?

No

#### What this PR does / why we need it:

Rollback otel-collecter and nginxProxy image version to 0.42.0 and 1.20;
Rollback tls settings for otel in otel-collector-config.yaml.

#### Which issue(s) is this PR associated with:

- #356: https://github.com/dell/csm/issues/356

#### Special notes for your reviewer:
- This code change has been verified along with changes in karavi-metrics-powerflex [PR#130](https://github.com/dell/karavi-metrics-powerflex/pull/130)
- Rollback otel-collecter image version to 0.42.0, because we upgrade the OpenTelemetry to v1.7.0 in karavi-metrics-powerflex, and its async UpDownCounter is working well to fetch the “current value”.
#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
