### PR TITLE
[charts/karavi-observability] Adjust PowerScale polling enable and frequency

### DIFF
--- a/charts/karavi-observability/templates/karavi-observability-configmap.yaml
+++ b/charts/karavi-observability/templates/karavi-observability-configmap.yaml
@@ -77,11 +77,12 @@ data:
   karavi-metrics-powerscale.yaml : |
     COLLECTOR_ADDR: {{ .Values.karaviMetricsPowerscale.collectorAddr }}
     PROVISIONER_NAMES: {{ .Values.karaviMetricsPowerscale.provisionerNames }}
-    POWERSCALE_VOLUME_IO_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerscale.volumePollFrequencySeconds }}"
-    POWERSCALE_VOLUME_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerscale.volumeMetricsEnabled }}"
     POWERSCALE_MAX_CONCURRENT_QUERIES: "{{ .Values.karaviMetricsPowerscale.concurrentPowerscaleQueries }}"
-    POWERSCALE_CLUSTER_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerscale.clusterPollFrequencySeconds }}"
-    POWERSCALE_CLUSTER_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerscale.clusterMetricsEnabled }}"
+    POWERSCALE_CAPACITY_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerscale.capacityMetricsEnabled }}"
+    POWERSCALE_PERFORMANCE_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerscale.performanceMetricsEnabled }}"
+    POWERSCALE_CLUSTER_CAPACITY_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerscale.clusterCapacityPollFrequencySeconds }}"
+    POWERSCALE_CLUSTER_PERFORMANCE_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerscale.clusterPerformancePollFrequencySeconds }}"
+    POWERSCALE_QUOTA_CAPACITY_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerscale.quotaCapacityPollFrequencySeconds }}"
     POWERSCALE_ISICLIENT_INSECURE: "{{ .Values.karaviMetricsPowerscale.isiClientOptions.isiSkipCertificateValidation }}"
     POWERSCALE_ISICLIENT_AUTH_TYPE: "{{ .Values.karaviMetricsPowerscale.isiClientOptions.isiAuthType }}"
     POWERSCALE_ISICLIENT_VERBOSE: "{{ .Values.karaviMetricsPowerscale.isiClientOptions.isiLogVerbose }}"

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -84,13 +84,16 @@ karaviMetricsPowerscale:
   collectorAddr: otel-collector:55680
   # comma separated list of provisioner names (ex: csi-isilon.dellemc.com)
   provisionerNames: csi-isilon.dellemc.com
-  # set polling frequency to the PowerScale cluster to get metrics data
-  volumePollFrequencySeconds: 20
-  clusterPollFrequencySeconds: 30
-  # set volumeMetricsEnabled to "false" to disable collection of Volume metrics
-  volumeMetricsEnabled: "true"
-  # set clusterMetricsEnabled to "false" to disable collection of Cluster metrics
-  clusterMetricsEnabled: "true"
+  # set capacityMetricsEnabled to "false" to disable collection of capacity metrics
+  capacityMetricsEnabled: "true"
+  # set performanceMetricsEnabled to "false" to disable collection of performance metrics
+  performanceMetricsEnabled: "true"
+  # set polling frequency to get cluster capacity metrics data
+  clusterCapacityPollFrequencySeconds: 30
+  # set polling frequency to get cluster performance data
+  clusterPerformancePollFrequencySeconds: 20
+  # set polling frequency to get quota capacity metrics data
+  quotaCapacityPollFrequencySeconds: 30
   # set the the default max concurrent queries to PowerScale
   concurrentPowerscaleQueries: 10
   # set the default endpoint for PowerScale service


### PR DESCRIPTION
#### Is this a new chart?
No

#### What this PR does / why we need it:
Adjust new enable and frequency for PowerScale as below:
capacityMetricsEnabled: "true"
performanceMetricsEnabled: "true"
clusterCapacityPollFrequencySeconds: 30
clusterPerformancePollFrequencySeconds: 20
quotaCapacityPollFrequencySeconds: 30

#### Which issue(s) is this PR associated with:
- #377: https://github.com/dell/csm/issues/377

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
