### PR TITLE
enable authorization for csm observability powerscale

### DIFF
--- a/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
@@ -75,7 +75,7 @@ spec:
         env:
           - name: PROXY_HOST
             value: "{{ .Values.karaviMetricsPowerflex.authorization.proxyHost }}"
-          - name: INSECURE
+          - name: SKIP_CERTIFICATE_VALIDATION
             value: "{{ .Values.karaviMetricsPowerflex.authorization.skipCertificateValidation }}"
           - name: PLUGIN_IDENTIFIER
             value: powerflex

--- a/charts/karavi-observability/templates/karavi-metrics-powerscale.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerscale.yaml
@@ -26,6 +26,12 @@ metadata:
   labels:
     app.kubernetes.io/name: karavi-metrics-powerscale
     app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if hasKey .Values "karaviMetricsPowerscale.authorization" }}
+  {{- if eq .Values.karaviMetricsPowerscale.authorization.enabled true }}
+  annotations:
+    com.dell.karavi-authorization-proxy: "true"
+  {{ end }}
+  {{ end }}
 spec:
   selector:
     matchLabels:
@@ -61,6 +67,37 @@ spec:
           readOnly: true
         - name: karavi-metrics-powerscale-configmap
           mountPath: /etc/config
+      {{- if hasKey .Values.karaviMetricsPowerscale "authorization" }}
+      {{- if eq .Values.karaviMetricsPowerscale.authorization.enabled true }}
+      - name: karavi-authorization-proxy
+        imagePullPolicy: IfNotPresent
+        image: {{ required "Must provide the authorization sidecar container image." .Values.karaviMetricsPowerscale.authorization.sidecarProxyImage }}
+        env:
+          - name: PROXY_HOST
+            value: "{{ .Values.karaviMetricsPowerscale.authorization.proxyHost }}"
+          - name: SKIP_CERTIFICATE_VALIDATION
+            value: "{{ .Values.karaviMetricsPowerscale.authorization.skipCertificateValidation }}"
+          - name: PLUGIN_IDENTIFIER
+            value: powerscale
+          - name: ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: isilon-proxy-authz-tokens
+                key: access
+          - name: REFRESH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: isilon-proxy-authz-tokens
+                key: refresh
+        volumeMounts:
+          - name: karavi-authorization-config
+            mountPath: /etc/karavi-authorization/config
+          - name: proxy-server-root-certificate
+            mountPath: /etc/karavi-authorization/root-certificates
+          - name: isilon-config-params
+            mountPath: /etc/karavi-authorization
+      {{ end }}
+      {{ end }}
       volumes:
       - name: isilon-creds
         secret:
@@ -74,6 +111,19 @@ spec:
       - name: karavi-metrics-powerscale-configmap
         configMap:
           name: karavi-metrics-powerscale-configmap
+     {{- if hasKey .Values.karaviMetricsPowerscale "authorization" }}
+     {{- if eq .Values.karaviMetricsPowerscale.authorization.enabled true }}
+      - name: karavi-authorization-config
+        secret:
+          secretName: isilon-karavi-authorization-config
+      - name: proxy-server-root-certificate
+        secret:
+          secretName: isilon-proxy-server-root-certificate
+      - name: isilon-config-params
+        configMap:
+          name: isilon-config-params
+      {{ end }}
+      {{ end }}
       restartPolicy: Always
 status: {}
 

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -113,6 +113,20 @@ karaviMetricsPowerscale:
     # set isiLogVerbose to 0/1/2 decide High/Medium/Low content of the OneFS REST API message should be logged in debug level logs
     # default isiLogVerbose: 0 to log full content of the HTTP request and response
     isiLogVerbose: 0
+  authorization:
+    enabled: false
+    # sidecarProxyImage: the container image used for the csm-authorization-sidecar.
+    # Default value: dellemc/csm-authorization-sidecar:v1.3.0
+    sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.3.0
+    # proxyHost: hostname of the csm-authorization server
+    # Default value: None
+    proxyHost:
+    # skipCertificateValidation: certificate validation of the csm-authorization server
+    # Allowed Values:
+    #   "true" - TLS certificate verification will be skipped
+    #   "false" - TLS certificate will be verified
+    # Default value: "true"
+    skipCertificateValidation: true
 
 otelCollector:
   image: otel/opentelemetry-collector:0.42.0


### PR DESCRIPTION
#### Is this a new chart?

No

#### What this PR does / why we need it:
enable authorization for csm observability powerscale

#### Which issue(s) is this PR associated with:

- #413: https://github.com/dell/csm/issues/413

#### Special notes for your reviewer:
To enable authorization for csm observability powerscale, and To **keep compatibility** with authorization of csm observability powerflex, please run below commands to copy/rename configmap and secrets from isilon namespace to karavi namespace:
 1. `kubectl get configmap isilon-config-params -n isilon -o yaml | sed 's/namespace: isilon/namespace: karavi/' | kubectl create -f -`
 2. `kubectl get secret karavi-authorization-config proxy-server-root-certificate proxy-authz-tokens -n isilon -o yaml | sed 's/namespace: isilon/namespace: karavi/' | sed 's/name: karavi-authorization-config/name: isilon-karavi-authorization-config/' | sed 's/name: proxy-server-root-certificate/name: isilon-proxy-server-root-certificate/' | sed 's/name: proxy-authz-tokens/name: isilon-proxy-authz-tokens/' | kubectl create -f -`

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
