### PR TITLE
[charts/karavi-observability]Add port definitions to otel-collector deployment

### DIFF
--- a/charts/karavi-observability/Chart.yaml
+++ b/charts/karavi-observability/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.3.1"
 name: karavi-observability
 description: CSM for Observability is part of the [Container Storage Modules](https://github.com/dell/csm) open source suite of Kubernetes storage enablers for Dell EMC storage products. CSM for Observability provides Kubernetes administrators with visibility into metrics and topology data related to containerized storage.
 type: application
-version: 1.3.1
+version: 1.3.2
 dependencies:
 - name: cert-manager
   version: 1.6.1

--- a/charts/karavi-observability/templates/otel-collector.yaml
+++ b/charts/karavi-observability/templates/otel-collector.yaml
@@ -78,6 +78,11 @@ spec:
       containers:
       - name: nginx-proxy
         image: {{ .Values.otelCollector.nginxProxy.image }}
+        ports:
+        - containerPort: 8443
+          name: exporter-https
+        - containerPort: 55680
+          name: receiver
         volumeMounts:
           - name: tls-secret
             mountPath: /etc/ssl/certs


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

This PR adds a container ports definitions to `otel-collector` Deployment. The reason for this is that without these ports prometheus-operator simply ignores any `ServiceMonitor` or `PodMonitor` we create for fetching metrics from Otel. Simply speaking there's no way how we can add Otel into Prometheus using prometheus-operator.

And overall it looks cleaner to have those ports in Deployment spec.

See this for reasoning https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint
> Name or number of the target port of the Pod behind the Service, the port must be specified with container port property.

#### Which issue(s) is this PR associated with:

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
