### PR TITLE
Rename arrayCapacityPollFrequencySeconds to capacityPollFrequencySeconds

### DIFF
--- a/charts/karavi-observability/templates/karavi-observability-configmap.yaml
+++ b/charts/karavi-observability/templates/karavi-observability-configmap.yaml
@@ -106,7 +106,7 @@ data:
     POWERMAX_MAX_CONCURRENT_QUERIES: "{{ .Values.karaviMetricsPowermax.concurrentPowermaxQueries }}"
     POWERMAX_CAPACITY_METRICS_ENABLED: "{{ .Values.karaviMetricsPowermax.capacityMetricsEnabled }}"
     POWERMAX_PERFORMANCE_METRICS_ENABLED: "{{ .Values.karaviMetricsPowermax.performanceMetricsEnabled }}"
-    POWERMAX_ARRAY_CAPACITY_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowermax.arrayCapacityPollFrequencySeconds }}"
+    POWERMAX_CAPACITY_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowermax.capacityPollFrequencySeconds }}"
     POWERMAX_ARRAY_PERFORMANCE_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowermax.arrayPerformancePollFrequencySeconds }}"
     LOG_LEVEL: "{{ .Values.karaviMetricsPowermax.logLevel }}"
     LOG_FORMAT: "{{ .Values.karaviMetricsPowermax.logFormat }}"

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -138,8 +138,8 @@ karaviMetricsPowermax:
   capacityMetricsEnabled: "true"
   # set performanceMetricsEnabled to "false" to disable collection of performance metrics
   performanceMetricsEnabled: "true"
-  # set polling frequency to get array capacity metrics data
-  arrayCapacityPollFrequencySeconds: 20
+  # set polling frequency to get capacity metrics data for volume, storagegroup, srp and array
+  capacityPollFrequencySeconds: 20
   # set polling frequency to get cluster performance data
   arrayPerformancePollFrequencySeconds: 20
   # set the default max concurrent queries to PowerMax


### PR DESCRIPTION
#### Is this a new chart?

No

#### What this PR does / why we need it:
Rename arrayCapacityPollFrequencySeconds to capacityPollFrequencySeconds to support capacity metrics for Observability PowerMax

#### Which issue(s) is this PR associated with:

- #https://github.com/dell/csm/issues/586

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
