### PR TITLE
[charts/csm-authorization]: feature-725: Remove tenant service ingress

### DIFF
--- a/charts/csm-authorization/Chart.yaml
+++ b/charts/csm-authorization/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: csm-authorization
-version: 1.6.0
-appVersion: 1.6.0
+version: 1.7.0
+appVersion: 1.7.0
 type: application
 description: CSM for Authorization is part of the [Container Storage Modules](https://github.com/dell/csm) open source suite of Kubernetes storage enablers for Dell EMC storage products. CSM for Authorization provides storage and Kubernetes administrators the ability to apply RBAC for Dell CSI Drivers.
 dependencies:

--- a/charts/csm-authorization/templates/NOTES.txt
+++ b/charts/csm-authorization/templates/NOTES.txt
@@ -10,9 +10,6 @@ LoadBalancer host rules for proxy-server:
 - {{ .Values.authorization.hostname }}
 - {{ .Release.Name }}-ingress-nginx-controller.{{ include "custom.namespace" . }}.svc.cluster.local
 
-LoadBalancer host rules for tenant-service:
-- tenant.{{ .Values.authorization.hostname }}
-
 LoadBalancer host rules for role-service:
 - role.{{ .Values.authorization.hostname }}
 

--- a/charts/csm-authorization/templates/certificate.yaml
+++ b/charts/csm-authorization/templates/certificate.yaml
@@ -52,16 +52,10 @@ spec:
   - karavi-auth
   - karavi-auth.{{ include "custom.namespace" . }}.svc.kubernetes.local
   - {{ .Values.authorization.hostname }}
-  - tenant.{{ .Values.authorization.hostname }}
   - role.{{ .Values.authorization.hostname }}
   - storage.{{ .Values.authorization.hostname }}
   {{- if .Values.authorization.proxyServerIngress.hosts  }}
   {{- range .Values.authorization.proxyServerIngress.hosts }}
-  - {{ tpl . $}}
-  {{- end }}
-  {{- end}}
-  {{- if .Values.authorization.tenantServiceIngress.hosts  }}
-  {{- range .Values.authorization.tenantServiceIngress.hosts }}
   - {{ tpl . $}}
   {{- end }}
   {{- end}}

--- a/charts/csm-authorization/templates/ingress.yaml
+++ b/charts/csm-authorization/templates/ingress.yaml
@@ -53,58 +53,6 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: tenant-service
-  namespace: {{ include "custom.namespace" . }}
-  annotations:
-  {{- if .Values.authorization.tenantServiceIngress.annotations }}
-    {{- range $key, $value := .Values.authorization.tenantServiceIngress.annotations }}
-    {{ $key }}: {{ tpl $value $ | quote }}
-    {{- end }}
-  {{- end }}
-spec:
-  ingressClassName: {{ .Values.authorization.tenantServiceIngress.ingressClassName }}
-  tls:
-  - hosts:
-      - tenant.{{ .Values.authorization.hostname }}
-      {{- if .Values.authorization.tenantServiceIngress.hosts  }}
-      {{- range .Values.authorization.tenantServiceIngress.hosts }}
-      - {{ tpl . $}}
-      {{- end }}
-      {{- end}}
-    {{- if and (.Values.authorization.certificate) (.Values.authorization.privateKey) }}
-    secretName: user-provided-tls
-    {{- else }}
-    secretName: karavi-selfsigned-tls
-    {{- end}}
-  rules:
-  - host: tenant.{{ .Values.authorization.hostname }}
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: tenant-service
-            port:
-              number: 50051
-  {{- if .Values.authorization.tenantServiceIngress.hosts  }}
-  {{- range .Values.authorization.tenantServiceIngress.hosts }}
-  - host: {{ tpl . $}}
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: tenant-service
-            port:
-              number: 50051
-  {{- end }}
-  {{- end}}
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
   name: role-service
   namespace: {{ include "custom.namespace" . }}
   annotations:

--- a/charts/csm-authorization/values.yaml
+++ b/charts/csm-authorization/values.yaml
@@ -20,7 +20,6 @@ authorization:
 
   # base hostname for the ingress rules that expose the services
   # the proxy-server ingress will use this hostname
-  # the tenant-service ingress will use tenant.hostname
   # the role-service ingress will use role.hostname
   hostname: csm-authorization.com
 
@@ -47,18 +46,6 @@ authorization:
 
     # additional annotations for the proxy-server ingress
     annotations: {}
-
-  # tenant-service ingress configuration
-  tenantServiceIngress:
-    ingressClassName: nginx
-
-    # additional host rules for the tenant-service ingress
-    hosts: []
-
-    # additional annotations for the tenant-service ingress
-    # if applicable, an annotation supporting grpc for your ingress controller must be supplied
-    annotations:
-      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
 
   # role-service ingress configuration
   roleServiceIngress:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

This PR removes the tenant-service ingress because `karavictl` will now be sending requests to the proxy-server.

#### Which issue(s) is this PR associated with:

https://github.com/dell/csm/issues/725

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
- [x] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
