### PR TITLE
[charts/csi-unity] : 2.7.0 csi-unity support for helm in csm-installation-wizard

### DIFF
--- a/charts/container-storage-modules/Chart.yaml
+++ b/charts/container-storage-modules/Chart.yaml
@@ -60,7 +60,7 @@ dependencies:
   condition: csi-vxflexos.enabled
 
 - name: csi-unity
-  version: 2.6.0
+  version: 2.7.0
   repository: file://../csi-unity
   condition: csi-unity.enabled
 

--- a/charts/csi-unity/Chart.yaml
+++ b/charts/csi-unity/Chart.yaml
@@ -1,16 +1,16 @@
 apiVersion: v2
-appVersion: 2.6.0
+appVersion: 2.7.0
 name: csi-unity
-version: 2.6.0
+version: 2.7.0
 description: |
   Unity XT CSI (Container Storage Interface) driver Kubernetes
   integration. This chart includes everything required to provision via CSI as
   well as a Unity XT StorageClass.
 type: application
-kubeVersion: ">= 1.24.0 < 1.27.0"
+kubeVersion: ">= 1.25.0 < 1.28.0"
 # If you are using a complex K8s version like "v1.24.3-mirantis-1", use this kubeVersion check instead
 # WARNING: this version of the check will allow the use of alpha and beta versions, which is NOT SUPPORTED
-# kubeVersion: ">= 1.22.0-0 < 1.27.0-0"
+# kubeVersion: ">= 1.22.0-0 < 1.28.0-0"
 keywords:
 - csi
 - storage

--- a/charts/csi-unity/templates/_helpers.tpl
+++ b/charts/csi-unity/templates/_helpers.tpl
@@ -3,7 +3,7 @@ Return the appropriate sidecar images based on k8s version
 */}}
 {{- define "csi-unity.attacherImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "26") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
       {{- print "k8s.gcr.io/sig-storage/csi-attacher:v4.2.0" -}}
     {{- end -}}
   {{- end -}}
@@ -11,7 +11,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-unity.provisionerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "26") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
       {{- print "k8s.gcr.io/sig-storage/csi-provisioner:v3.4.0" -}}
     {{- end -}}
   {{- end -}}
@@ -19,7 +19,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-unity.snapshotterImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "26") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
       {{- print "k8s.gcr.io/sig-storage/csi-snapshotter:v6.2.1" -}}
     {{- end -}}
   {{- end -}}
@@ -27,7 +27,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-unity.resizerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "26") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
       {{- print "k8s.gcr.io/sig-storage/csi-resizer:v1.7.0" -}}
     {{- end -}}
   {{- end -}}
@@ -35,7 +35,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-unity.registrarImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "26") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
       {{- print "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.3" -}}
     {{- end -}}
   {{- end -}}
@@ -43,7 +43,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-unity.healthmonitorImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "26") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
       {{- print "gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.8.0" -}}
     {{- end -}}
   {{- end -}}

--- a/charts/csi-unity/values.yaml
+++ b/charts/csi-unity/values.yaml
@@ -3,8 +3,8 @@
 
 # version: version of this values file
 # Note: Do not change this value
-# Examples : "v2.6.0" , "nightly"
-version: "v2.6.0"
+# Examples : "v2.7.0" , "nightly"
+version: "v2.7.0"
 
 # LogLevel is used to set the logging level of the driver.
 # Allowed values: "error", "warn"/"warning", "info", "debug"


### PR DESCRIPTION
[charts/csi-unity] : 2.7.0 csi-unity support for helm in csm-installation-wizard

#### Is this a new chart?

No

#### What this PR does / why we need it:
To support csi-unity-driver 2.7.0

#### Which issue(s) is this PR associated with:

- #Issue_Number

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable

Tested using both csm-installation-wizard ui and the helm way of installation.