### PR TITLE
StorageCapacityTracking feature changes

### DIFF
--- a/charts/csi-powermax/templates/_helpers.tpl
+++ b/charts/csi-powermax/templates/_helpers.tpl
@@ -48,3 +48,11 @@ Return the appropriate sidecar images based on k8s version
     {{- end -}}
   {{- end -}}
 {{- end -}}
+
+{{- define "csi-powermax.isStorageCapacitySupported" -}}
+{{- if eq .Values.storageCapacity.enabled true -}}
+  {{- if and (eq .Capabilities.KubeVersion.Major "1") (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "25") -}}
+      {{- true -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/csi-powermax/templates/_helpers.tpl
+++ b/charts/csi-powermax/templates/_helpers.tpl
@@ -51,7 +51,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-powermax.isStorageCapacitySupported" -}}
 {{- if eq .Values.storageCapacity.enabled true -}}
-  {{- if and (eq .Capabilities.KubeVersion.Major "1") (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "25") -}}
+  {{- if and (eq .Capabilities.KubeVersion.Major "1") (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") -}}
       {{- true -}}
   {{- end -}}
 {{- end -}}

--- a/charts/csi-powermax/templates/controller.yaml
+++ b/charts/csi-powermax/templates/controller.yaml
@@ -93,7 +93,7 @@ rules:
     verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]  
   {{- end}} 
   # Permissions for Storage Capacity
-  {{- if eq (include "csi-powermax.isStorageCapacitySupported" .) "false" }}
+  {{- if eq (include "csi-powermax.isStorageCapacitySupported" .) "true" }}
   - apiGroups: ["storage.k8s.io"]
     resources: ["csistoragecapacities"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
@@ -196,7 +196,7 @@ spec:
             - "--leader-election"
             - "--extra-create-metadata"
             - "--feature-gates=Topology=true"
-            - "--enable-capacity={{ (include "csi-powermax.isStorageCapacitySupported" .) | default true }}"
+            - "--enable-capacity={{ (include "csi-powermax.isStorageCapacitySupported" .) | default false }}"
             - "--capacity-ownerref-level=2"
             - "--capacity-poll-interval={{ .Values.storageCapacity.pollInterval | default "5m" }}"
           env:

--- a/charts/csi-powermax/templates/controller.yaml
+++ b/charts/csi-powermax/templates/controller.yaml
@@ -196,7 +196,7 @@ spec:
             - "--leader-election"
             - "--extra-create-metadata"
             - "--feature-gates=Topology=true"
-            - "--enable-capacity={{ (include "csi-powermax.isStorageCapacitySupported" .) | default false }}"
+            - "--enable-capacity={{ (include "csi-powermax.isStorageCapacitySupported" .) | default true }}"
             - "--capacity-ownerref-level=2"
             - "--capacity-poll-interval={{ .Values.storageCapacity.pollInterval | default "5m" }}"
           env:

--- a/charts/csi-powermax/templates/controller.yaml
+++ b/charts/csi-powermax/templates/controller.yaml
@@ -93,7 +93,7 @@ rules:
     verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]  
   {{- end}} 
   # Permissions for Storage Capacity
-  {{- if eq (include "csi-powermax.isStorageCapacitySupported" .) "true" }}
+  {{- if eq (include "csi-powermax.isStorageCapacitySupported" .) "false" }}
   - apiGroups: ["storage.k8s.io"]
     resources: ["csistoragecapacities"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/charts/csi-powermax/templates/controller.yaml
+++ b/charts/csi-powermax/templates/controller.yaml
@@ -91,7 +91,19 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]  
-  {{- end}}  
+  {{- end}} 
+  # Permissions for Storage Capacity
+  {{- if eq (include "csi-powermax.isStorageCapacitySupported" .) "true" }}
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csistoragecapacities"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
+  {{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -184,9 +196,20 @@ spec:
             - "--leader-election"
             - "--extra-create-metadata"
             - "--feature-gates=Topology=true"
+            - "--enable-capacity={{ (include "csi-powermax.isStorageCapacitySupported" .) | default false }}"
+            - "--capacity-ownerref-level=2"
+            - "--capacity-poll-interval={{ .Values.storageCapacity.pollInterval | default "5m" }}"
           env:
             - name: ADDRESS
               value: /var/run/csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/charts/csi-powermax/templates/csidriver.yaml
+++ b/charts/csi-powermax/templates/csidriver.yaml
@@ -7,5 +7,7 @@ metadata:
     name: csi-powermax
   {{- end }}
 spec:
+    podInfoOnMount: true
     attachRequired: true
+    storageCapacity: {{ (include "csi-powermax.isStorageCapacitySupported" .) | default true }}
     fsGroupPolicy: {{ .Values.fsGroupPolicy }}

--- a/charts/csi-powermax/templates/csidriver.yaml
+++ b/charts/csi-powermax/templates/csidriver.yaml
@@ -9,5 +9,5 @@ metadata:
 spec:
     podInfoOnMount: true
     attachRequired: true
-    storageCapacity: {{ (include "csi-powermax.isStorageCapacitySupported" .) | default true }}
+    storageCapacity: {{ (include "csi-powermax.isStorageCapacitySupported" .) | default false }}
     fsGroupPolicy: {{ .Values.fsGroupPolicy }}

--- a/charts/csi-powermax/templates/csidriver.yaml
+++ b/charts/csi-powermax/templates/csidriver.yaml
@@ -9,5 +9,5 @@ metadata:
 spec:
     podInfoOnMount: true
     attachRequired: true
-    storageCapacity: {{ (include "csi-powermax.isStorageCapacitySupported" .) | default false }}
+    storageCapacity: {{ (include "csi-powermax.isStorageCapacitySupported" .) | default true }}
     fsGroupPolicy: {{ .Values.fsGroupPolicy }}

--- a/charts/csi-powermax/values.yaml
+++ b/charts/csi-powermax/values.yaml
@@ -428,7 +428,7 @@ authorization:
   skipCertificateValidation: true
 
 # Storage Capacity Tracking
-# Note: Capacity tracking is supported in kubernetes v1.25 and above, this feature will be automatically disabled in older versions.
+# Note: Capacity tracking is supported in kubernetes v1.24 and above, this feature will be automatically disabled in older versions.
 storageCapacity:
   # enabled : Enable/Disable storage capacity tracking
   # Allowed values:

--- a/charts/csi-powermax/values.yaml
+++ b/charts/csi-powermax/values.yaml
@@ -427,6 +427,20 @@ authorization:
   # Default value: "true"
   skipCertificateValidation: true
 
+# Storage Capacity Tracking
+# Note: Capacity tracking is supported in kubernetes v1.25 and above, this feature will be automatically disabled in older versions.
+storageCapacity:
+  # enabled : Enable/Disable storage capacity tracking
+  # Allowed values:
+  #   true: enable storage capacity tracking
+  #   false: disable storage capacity tracking
+  # Default value: true
+  enabled: true
+  # pollInterval : Configure how often external-provisioner polls the driver to detect changed capacity
+  # Allowed values: 1m,2m,3m,...,10m,...,60m etc
+  # Default value: 5m
+  pollInterval: 5m
+
 # VMware/vSphere virtualization support
 # set enable to true, if you to enable VMware virtualized environment support via RDM
 # Allowed Values:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

Yes/No

#### What this PR does / why we need it:

Support StorageCapacityTracking feature for PowerMax.

Additional context
This feature helps the scheduler to schedule the pod on a node (satisfying the topology constraints) only if the requested capacity is available on the storage array.

#### Which issue(s) is this PR associated with:
https://github.com/dell/csm/issues/876

- #Issue_Number
https://github.com/dell/csm/issues/876

#### Special notes for your reviewer:


#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
