### PR TITLE
[charts/csm-replication]: Updates for removing init container usage

### DIFF
--- a/charts/csm-replication/templates/controller.yaml
+++ b/charts/csm-replication/templates/controller.yaml
@@ -17,10 +17,8 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
-  - create
   - get
   - list
-  - update
   - watch
 - apiGroups:
   - apiextensions.k8s.io
@@ -29,7 +27,6 @@ rules:
   verbs:
   - get
   - list
-  - patch
   - watch
 - apiGroups:
   - coordination.k8s.io
@@ -267,12 +264,6 @@ spec:
       {{- toYaml .Values.hostAliases | nindent 6 }}
       {{- end }}
       serviceAccountName: dell-replication-controller-sa
-      initContainers:
-      - name: init-rg-migration
-        imagePullPolicy: Always
-        image: {{ .Values.initImage }}
-        command:
-        - /upgrade/migrate_rg.sh
       containers:
       - args:
         - prefix=replication.storage.dell.com

--- a/charts/csm-replication/values.yaml
+++ b/charts/csm-replication/values.yaml
@@ -7,10 +7,6 @@ replicas: 1
 # Allowed values: string
 image: dellemc/dell-replication-controller:v1.5.0
 
-# image: Defines controller's init container image. This shouldn't be changed
-# Allowed values: string
-initImage: dellemc/dell-replication-init:v1.0.1
-
 # logLevel: Defines initial log level for controller. This can be changed in runtime
 # Allowed values: "debug", "info", "warn", "error", "panic"
 # Default value: "info"


### PR DESCRIPTION
#### Is this a new chart?

No

#### What this PR does / why we need it:

Updating csm-replication charts for changes in PR https://github.com/dell/csm-replication/pull/104

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/885

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
