### PR TITLE
Adding k8 28 support for powermax

### DIFF
--- a/charts/container-storage-modules/Chart.yaml
+++ b/charts/container-storage-modules/Chart.yaml
@@ -45,7 +45,7 @@ dependencies:
   condition: csi-powerstore.enabled
 
 - name: csi-powermax
-  version: 2.7.0
+  version: 2.8.0
   repository: https://dell.github.io/helm-charts
   condition: csi-powermax.enabled
 

--- a/charts/container-storage-modules/values.yaml
+++ b/charts/container-storage-modules/values.yaml
@@ -136,7 +136,7 @@ csi-powermax:
       enabled: false
     nodeSelector:
   csireverseproxy:
-    image: dellemc/csipowermax-reverseproxy:v2.6.0
+    image: dellemc/csipowermax-reverseproxy:v2.7.0
     deployAsSidecar: true
   replication:
     enabled: false

--- a/charts/csi-powermax/Chart.yaml
+++ b/charts/csi-powermax/Chart.yaml
@@ -1,22 +1,22 @@
 apiVersion: v2
-appVersion: "2.7.0"
+appVersion: "2.8.0"
 name: csi-powermax
-version: 2.7.0
+version: 2.8.0
 description: |
   PowerMax CSI (Container Storage Interface) driver Kubernetes
   integration. This chart includes everything required to provision via CSI as
   well as a PowerMax StorageClass.
 type: application
-kubeVersion: ">= 1.23.0 < 1.28.0"
+kubeVersion: ">= 1.23.0 < 1.29.0"
 # If you are using a complex K8s version like "v1.23.3-mirantis-1", use this kubeVersion check instead
 # WARNING: this version of the check will allow the use of alpha and beta versions, which is NOT SUPPORTED
-# kubeVersion: ">= 1.23.0-0 < 1.28.0-0"
+# kubeVersion: ">= 1.23.0-0 < 1.29.0-0"
 keywords:
 - csi
 - storage
 dependencies:
   - name: csireverseproxy
-    version: 2.6.0
+    version: 2.7.0
     condition: required
 home: https://github.com/dell/csi-powermax
 icon: https://avatars1.githubusercontent.com/u/20958494?s=200&v=4

--- a/charts/csi-powermax/charts/csireverseproxy/Chart.yaml
+++ b/charts/csi-powermax/charts/csireverseproxy/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for CSI PowerMax ReverseProxy
 
 type: application
 
-version: 2.6.0
+version: 2.7.0
 
-appVersion: 2.6.0
+appVersion: 2.7.0

--- a/charts/csi-powermax/charts/csireverseproxy/values.yaml
+++ b/charts/csi-powermax/charts/csireverseproxy/values.yaml
@@ -1,4 +1,4 @@
-image: dellemc/csipowermax-reverseproxy:v2.6.0
+image: dellemc/csipowermax-reverseproxy:v2.7.0
 port: 2222
 
 # TLS secret which is used for setting up the proxy HTTPS server

--- a/charts/csi-powermax/templates/_helpers.tpl
+++ b/charts/csi-powermax/templates/_helpers.tpl
@@ -3,7 +3,7 @@ Return the appropriate sidecar images based on k8s version
 */}}
 {{- define "csi-powermax.attacherImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "23") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "23") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "28") -}}
       {{- print "registry.k8s.io/sig-storage/csi-attacher:v4.3.0" -}}
     {{- end -}}
   {{- end -}}
@@ -11,7 +11,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-powermax.provisionerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "23") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "23") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "28") -}}
       {{- print "registry.k8s.io/sig-storage/csi-provisioner:v3.5.0" -}}
     {{- end -}}
   {{- end -}}
@@ -19,7 +19,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-powermax.snapshotterImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "23") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "23") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "28") -}}
       {{- print "registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2" -}}
     {{- end -}}
   {{- end -}}
@@ -27,7 +27,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-powermax.resizerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "23") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "23") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "28") -}}
       {{- print "registry.k8s.io/sig-storage/csi-resizer:v1.8.0" -}}
     {{- end -}}
   {{- end -}}
@@ -35,7 +35,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-powermax.registrarImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "23") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "23") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "28") -}}
       {{- print "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0" -}}
     {{- end -}}
   {{- end -}}
@@ -43,7 +43,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-powermax.healthmonitorImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "23") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "23") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "28") -}}
       {{- print "registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.9.0" -}}
     {{- end -}}
   {{- end -}}

--- a/charts/csi-powermax/values.yaml
+++ b/charts/csi-powermax/values.yaml
@@ -262,8 +262,8 @@ enableCHAP: false
 csireverseproxy:
   # image: Define the container images used for the reverse proxy
   # Default value: None
-  # Example: "csipowermax-reverseproxy:v2.6.0"
-  image: dellemc/csipowermax-reverseproxy:v2.6.0
+  # Example: "csipowermax-reverseproxy:v2.7.0"
+  image: dellemc/csipowermax-reverseproxy:v2.7.0
   # "tlsSecret" defines the TLS secret that is created with certificate
   # and its associated key
   # Default value: None


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Adding k8 28 support for powermax
Updating helm/driver version 

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/947

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
