### PR TITLE
PowerScale k8s-1.28 support

### DIFF
--- a/charts/csi-isilon/Chart.yaml
+++ b/charts/csi-isilon/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: csi-isilon
 version: 2.8.0
 appVersion: "2.8.0"
-kubeVersion: ">= 1.21.0 < 1.28.0"
+kubeVersion: ">= 1.21.0 < 1.29.0"
 #If you are using a complex K8s version like "v1.22.3-mirantis-1", use this kubeVersion check instead
 #WARNING: this version of the check will allow the use of alpha and beta versions, which is NOT SUPPORTED
-#kubeVersion: ">= 1.21.0-0 < 1.28.0-0"
+#kubeVersion: ">= 1.21.0-0 < 1.29.0-0"
 description: |
   PowerScale CSI (Container Storage Interface) driver Kubernetes
   integration. This chart includes everything required to provision via CSI as

--- a/charts/csi-isilon/templates/_helpers.tpl
+++ b/charts/csi-isilon/templates/_helpers.tpl
@@ -3,7 +3,7 @@ Return the appropriate sidecar images based on k8s version
 */}}
 {{- define "csi-isilon.attacherImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "28") -}}
       {{- print "registry.k8s.io/sig-storage/csi-attacher:v4.3.0" -}}
     {{- end -}}
   {{- end -}}
@@ -11,7 +11,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-isilon.provisionerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "28") -}}
       {{- print "registry.k8s.io/sig-storage/csi-provisioner:v3.5.0" -}}
     {{- end -}}
   {{- end -}}
@@ -19,7 +19,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-isilon.snapshotterImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "28") -}}
       {{- print "registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2" -}}
     {{- end -}}
   {{- end -}}
@@ -27,7 +27,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-isilon.resizerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "28") -}}
       {{- print "registry.k8s.io/sig-storage/csi-resizer:v1.8.0" -}}
     {{- end -}}
   {{- end -}}
@@ -35,7 +35,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-isilon.registrarImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "28") -}}
       {{- print "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0" -}}
     {{- end -}}
   {{- end -}}
@@ -43,7 +43,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-isilon.healthmonitorImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "28") -}}
       {{- print "registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.9.0" -}}
     {{- end -}}
   {{- end -}}


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
It adds 1.28 k8s support in CSI PowerScale Driver

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/947

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
