### PR TITLE
Adding CSI Powerstore driver’s effective pod security profile for supporting ephemeral volumes as part of Openshift 4.13 support

### DIFF
--- a/charts/csi-powerstore/templates/csidriver.yaml
+++ b/charts/csi-powerstore/templates/csidriver.yaml
@@ -18,6 +18,8 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: {{ .Values.driverName }}
+  labels:
+    security.openshift.io/csi-ephemeral-volume-profile: restricted
 spec:
   storageCapacity: {{ (include "csi-powerstore.isStorageCapacitySupported" .) | default false }}
   podInfoOnMount: true


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
As part of Openshift 4.13 support in CSI Powerstore, an extra label "security.openshift.io/csi-ephemeral-volume-profile" needs to be added in CSIDriver;s yaml for supporting inline ephemeral volumes.
https://docs.openshift.com/container-platform/4.13/storage/container_storage_interface/ephemeral-storage-csi-inline.html

#### Which issue(s) is this PR associated with:
| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/724|


#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable

#### How Has This Been Tested?

Ran cert-csi for ephemeral volume suite:


![cert-csi-iscsi](https://github.com/dell/helm-charts/assets/125348121/e3a9b53e-1b79-41b4-8f62-d322860385ce)


