### PR TITLE
[charts/csi-vxflexos]:2.8.0 removed externalAccess from csi-vxflexos manifests.

### DIFF
--- a/charts/csi-vxflexos/templates/controller.yaml
+++ b/charts/csi-vxflexos/templates/controller.yaml
@@ -424,10 +424,6 @@ spec:
             - name: X_CSI_NFS_ACLS
               value: "{{ .Values.nfsAcls }}"
             {{- end }}
-            {{- if hasKey .Values "externalAccess" }}
-            - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
-              value: "{{ .Values.externalAccess }}"
-            {{- end }}
             {{- if hasKey .Values "enableQuota" }}
             {{- if eq .Values.enableQuota true}}
             - name: X_CSI_QUOTA_ENABLED

--- a/charts/csi-vxflexos/values.yaml
+++ b/charts/csi-vxflexos/values.yaml
@@ -38,11 +38,6 @@ kubeletConfigDir: /var/lib/kubelet
 # Default value: none
 defaultFsType: ext4
 
-# externalAccess: allows to specify additional entries for host to access NFS volumes. Both single IP address and subnet are valid entries.
-# Allowed Values: x.x.x.x/xx or x.x.x.x
-# Default Value: None
-externalAccess:
-
 # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
 # Allowed values:
 #  Always: Always pull the image.


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
this pr addresses the removal of redundant parameter i.e external Access.

#### Which issue(s) is this PR associated with:

- #Issue_Number

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
