### PR TITLE
Revert "Adding CSI Powerstore driver’s effective pod security profile for supporting ephemeral volumes as part of Openshift 4.13 support"

### DIFF
--- a/charts/csi-powerstore/templates/csidriver.yaml
+++ b/charts/csi-powerstore/templates/csidriver.yaml
@@ -18,8 +18,6 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: {{ .Values.driverName }}
-  labels:
-    security.openshift.io/csi-ephemeral-volume-profile: restricted
 spec:
   storageCapacity: {{ (include "csi-powerstore.isStorageCapacitySupported" .) | default false }}
   podInfoOnMount: true


### PR DESCRIPTION
Reverts dell/helm-charts#261 as we have already taken this issue in "Known Issues"