### PR TITLE
[charts/container-storage-modules]: Uncomment Resiliency arguments

### DIFF
--- a/charts/container-storage-modules/values.yaml
+++ b/charts/container-storage-modules/values.yaml
@@ -210,28 +210,28 @@ csi-isilon:
     enabled: false
     image: dellemc/podmon:v1.7.0
     controller:
-     args:
-       - "--csisock=unix:/var/run/csi/csi.sock"
-       - "--labelvalue=csi-isilon"
-       - "--arrayConnectivityPollRate=60"
-       - "--driverPath=csi-isilon.dellemc.com"
-       - "--mode=controller"
-       - "--skipArrayConnectionValidation=false"
-       - "--driver-config-params=/csi-isilon-config-params/driver-config-params.yaml"
-       - "--driverPodLabelValue=dell-storage"
-       - "--ignoreVolumelessPods=false"
+      args:
+        - "--csisock=unix:/var/run/csi/csi.sock"
+        - "--labelvalue=csi-isilon"
+        - "--arrayConnectivityPollRate=60"
+        - "--driverPath=csi-isilon.dellemc.com"
+        - "--mode=controller"
+        - "--skipArrayConnectionValidation=false"
+        - "--driver-config-params=/csi-isilon-config-params/driver-config-params.yaml"
+        - "--driverPodLabelValue=dell-storage"
+        - "--ignoreVolumelessPods=false"
 
     node:
-     args:
-       - "--csisock=unix:/var/lib/kubelet/plugins/csi-isilon/csi_sock"
-       - "--labelvalue=csi-isilon"
-       - "--arrayConnectivityPollRate=60"
-       - "--driverPath=csi-isilon.dellemc.com"
-       - "--mode=node"
-       - "--leaderelection=false"
-       - "--driver-config-params=/csi-isilon-config-params/driver-config-params.yaml"
-       - "--driverPodLabelValue=dell-storage"
-       - "--ignoreVolumelessPods=false"
+      args:
+        - "--csisock=unix:/var/lib/kubelet/plugins/csi-isilon/csi_sock"
+        - "--labelvalue=csi-isilon"
+        - "--arrayConnectivityPollRate=60"
+        - "--driverPath=csi-isilon.dellemc.com"
+        - "--mode=node"
+        - "--leaderelection=false"
+        - "--driver-config-params=/csi-isilon-config-params/driver-config-params.yaml"
+        - "--driverPodLabelValue=dell-storage"
+        - "--ignoreVolumelessPods=false"
   authorization:
     enabled: false
     sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.8.0
@@ -298,14 +298,14 @@ csi-vxflexos:
     enabled: false
     image: dellemc/podmon:v1.7.0
     controller:
-     args:
-       - "--csisock=unix:/var/run/csi/csi.sock"
-       - "--labelvalue=csi-vxflexos"
-       - "--mode=controller"
-       - "--skipArrayConnectionValidation=false"
-       - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"
-       - "--driverPodLabelValue=dell-storage"
-       - "--ignoreVolumelessPods=false"
+      args:
+        - "--csisock=unix:/var/run/csi/csi.sock"
+        - "--labelvalue=csi-vxflexos"
+        - "--mode=controller"
+        - "--skipArrayConnectionValidation=false"
+        - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"
+        - "--driverPodLabelValue=dell-storage"
+        - "--ignoreVolumelessPods=false"
     node:
       args:
         - "--csisock=unix:/var/lib/kubelet/plugins/vxflexos.emc.dell.com/csi_sock"

--- a/charts/container-storage-modules/values.yaml
+++ b/charts/container-storage-modules/values.yaml
@@ -45,7 +45,7 @@ csi-powerstore:
     healthMonitor:
       enabled: false
     nodeSelector:
-      # Uncomment if CSM for Resiliency and CSI Driver pods monitor are enabled
+    # Uncomment if CSM for Resiliency and CSI Driver pods monitor are enabled
     # tolerations:
     # - key: "offline.vxflexos.storage.dell.com"
     #   operator: "Exists"
@@ -209,29 +209,29 @@ csi-isilon:
   podmon:
     enabled: false
     image: dellemc/podmon:v1.7.0
-    #controller:
-    #  args:
-    #    - "--csisock=unix:/var/run/csi/csi.sock"
-    #    - "--labelvalue=csi-isilon"
-    #    - "--arrayConnectivityPollRate=60"
-    #    - "--driverPath=csi-isilon.dellemc.com"
-    #    - "--mode=controller"
-    #    - "--skipArrayConnectionValidation=false"
-    #    - "--driver-config-params=/csi-isilon-config-params/driver-config-params.yaml"
-    #    - "--driverPodLabelValue=dell-storage"
-    #    - "--ignoreVolumelessPods=false"
+    controller:
+     args:
+       - "--csisock=unix:/var/run/csi/csi.sock"
+       - "--labelvalue=csi-isilon"
+       - "--arrayConnectivityPollRate=60"
+       - "--driverPath=csi-isilon.dellemc.com"
+       - "--mode=controller"
+       - "--skipArrayConnectionValidation=false"
+       - "--driver-config-params=/csi-isilon-config-params/driver-config-params.yaml"
+       - "--driverPodLabelValue=dell-storage"
+       - "--ignoreVolumelessPods=false"
 
-    #node:
-    #  args:
-    #    - "--csisock=unix:/var/lib/kubelet/plugins/csi-isilon/csi_sock"
-    #    - "--labelvalue=csi-isilon"
-    #    - "--arrayConnectivityPollRate=60"
-    #    - "--driverPath=csi-isilon.dellemc.com"
-    #    - "--mode=node"
-    #    - "--leaderelection=false"
-    #    - "--driver-config-params=/csi-isilon-config-params/driver-config-params.yaml"
-    #    - "--driverPodLabelValue=dell-storage"
-    #    - "--ignoreVolumelessPods=false"
+    node:
+     args:
+       - "--csisock=unix:/var/lib/kubelet/plugins/csi-isilon/csi_sock"
+       - "--labelvalue=csi-isilon"
+       - "--arrayConnectivityPollRate=60"
+       - "--driverPath=csi-isilon.dellemc.com"
+       - "--mode=node"
+       - "--leaderelection=false"
+       - "--driver-config-params=/csi-isilon-config-params/driver-config-params.yaml"
+       - "--driverPodLabelValue=dell-storage"
+       - "--ignoreVolumelessPods=false"
   authorization:
     enabled: false
     sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.8.0
@@ -297,24 +297,24 @@ csi-vxflexos:
   podmon:
     enabled: false
     image: dellemc/podmon:v1.7.0
-    # controller:
-    #  args:
-    #    - "--csisock=unix:/var/run/csi/csi.sock"
-    #    - "--labelvalue=csi-vxflexos"
-    #    - "--mode=controller"
-    #    - "--skipArrayConnectionValidation=false"
-    #    - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"
-    #    - "--driverPodLabelValue=dell-storage"
-    #    - "--ignoreVolumelessPods=false"
-    # node:
-    #   args:
-    #     - "--csisock=unix:/var/lib/kubelet/plugins/vxflexos.emc.dell.com/csi_sock"
-    #     - "--labelvalue=csi-vxflexos"
-    #     - "--mode=node"
-    #     - "--leaderelection=false"
-    #     - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"
-    #     - "--driverPodLabelValue=dell-storage"
-    #     - "--ignoreVolumelessPods=false"
+    controller:
+     args:
+       - "--csisock=unix:/var/run/csi/csi.sock"
+       - "--labelvalue=csi-vxflexos"
+       - "--mode=controller"
+       - "--skipArrayConnectionValidation=false"
+       - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"
+       - "--driverPodLabelValue=dell-storage"
+       - "--ignoreVolumelessPods=false"
+    node:
+      args:
+        - "--csisock=unix:/var/lib/kubelet/plugins/vxflexos.emc.dell.com/csi_sock"
+        - "--labelvalue=csi-vxflexos"
+        - "--mode=node"
+        - "--leaderelection=false"
+        - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"
+        - "--driverPodLabelValue=dell-storage"
+        - "--ignoreVolumelessPods=false"
   authorization:
     enabled: false
     sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.8.0


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
PR to uncomment resiliency controller and node arguments.

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/959

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
