### PR TITLE
[charts/cosi] correct cosi log level setting

### DIFF
--- a/charts/cosi/templates/_helpers.tpl
+++ b/charts/cosi/templates/_helpers.tpl
@@ -32,13 +32,17 @@ Create chart name and version as used by the chart label.
 
 {{/*
 # COSI driver log level
+# Values are set to the integer value, higher value means more verbose logging
 # Possible values: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
 # Default value: 4
 */}}
 {{- define "cosi.logLevel" }}
-  {{- $logLevelValues := list 0 1 2 3 4 5 6 7 8 9 10 }}
-  {{- if (has .Values.provisioner.logLevel $logLevelValues) }}
-    {{- .Values.provisioner.logLevel }}
+  {{- if (kindIs "int64" .Values.provisioner.logLevel) }}
+    {{- if (or (ge .Values.provisioner.logLevel 0) (le .Values.provisioner.logLevel 10)) }}
+      {{- .Values.provisioner.logLevel }}
+    {{- else }}
+      {{- 4 }}
+    {{- end }}
   {{- else }}
     {{- 4 }}
   {{- end }}
@@ -47,12 +51,18 @@ Create chart name and version as used by the chart label.
 {{/*
 # COSI driver sidecar log level
 # Values are set to the integer value, higher value means more verbose logging
+# Possible values: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+# Default value: 4
 */}}
 {{- define "cosi.provisionerSidecarVerbosity" }}
-  {{- if (kindIs "int" .Values.sidecar.verbosity) }}
-    {{- .Values.sidecar.verbosity }}
+  {{- if (kindIs "int64" .Values.sidecar.verbosity) }}
+    {{- if (or (ge .Values.sidecar.verbosity 0) (le .Values.sidecar.verbosity 10)) }}
+      {{- .Values.sidecar.verbosity }}
+    {{- else }}
+      {{- 4 }}
+    {{- end }}
   {{- else }}
-    {{- 5 }}
+    {{- 4 }}
   {{- end }}
 {{- end }}
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

Correct validating the `.Values.provisioner.logLevel`

#### Which issue(s) is this PR associated with:

N/A

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
