### PR TITLE
[charts/csi-powerflex] Added external access

### DIFF
--- a/charts/container-storage-modules/values.yaml
+++ b/charts/container-storage-modules/values.yaml
@@ -338,6 +338,7 @@ csi-vxflexos:
   storageCapacity:
     enabled: true
   enableQuota: false
+  externalAccess:
   monitor:
     enabled: false
   vgsnapshotter:

--- a/charts/csi-vxflexos/templates/controller.yaml
+++ b/charts/csi-vxflexos/templates/controller.yaml
@@ -428,6 +428,8 @@ spec:
               value: "{{ .Values.enableQuota }}"
             {{- end }}
             {{- end }}
+            - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
+              value: {{ .Values.externalAccess }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/charts/csi-vxflexos/values.yaml
+++ b/charts/csi-vxflexos/values.yaml
@@ -59,6 +59,11 @@ defaultFsType: ext4
 # Default value: None
 imagePullPolicy: IfNotPresent
 
+# externalAccess: allows to specify additional entries for hostAccess of NFS volumes. Both single IP address and subnet are valid entries.
+# Allowed Values: x.x.x.x/xx or x.x.x.x
+# Default Value: None
+externalAccess:
+
 # enableQuota: a boolean that, when enabled, will set quota limit for a newly provisioned NFS volume.
 # Allowed values:
 #   true: set quota for volume


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Added external access parameter which is required to provide to external network/ip to the NFS export hosts.

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1011

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
