### PR TITLE
[feature-1091]: Expose proxy-server via cluster node IP and use local storage for Redis by default

### DIFF
--- a/charts/csm-authorization/charts/redis/templates/redis.yaml
+++ b/charts/csm-authorization/charts/redis/templates/redis.yaml
@@ -57,7 +57,7 @@ spec:
   volumeMode: Filesystem
   accessModes:
   - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Delete
+  persistentVolumeReclaimPolicy: Recycle
   storageClassName: csm-authorization-local-storage
   hostPath:
     path: /csm-authorization/redis

--- a/charts/csm-authorization/charts/redis/templates/redis.yaml
+++ b/charts/csm-authorization/charts/redis/templates/redis.yaml
@@ -38,6 +38,31 @@ spec:
           persistentVolumeClaim:
             claimName: redis-primary-pv-claim
 ---
+{{- if not (.Values.storageClass) }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csm-authorization-local-storage
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: csm-authorization-redis
+spec:
+  capacity:
+    storage: 8Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: csm-authorization-local-storage
+  hostPath:
+    path: /csm-authorization/redis
+{{- end}}
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -50,6 +75,8 @@ spec:
     - ReadWriteOnce
   {{- if (.Values.storageClass) }}
   storageClassName: {{.Values.storageClass }}
+  {{ else }}
+  storageClassName: csm-authorization-local-storage
   {{- end}}
   resources:
     requests:

--- a/charts/csm-authorization/templates/ingress.yaml
+++ b/charts/csm-authorization/templates/ingress.yaml
@@ -23,7 +23,7 @@ spec:
     secretName: user-provided-tls
     {{- else }}
     secretName: karavi-selfsigned-tls
-    {{- end}}
+    {{- end }}
   rules:
   - host: {{ .Values.authorization.hostname }}
     http:
@@ -48,7 +48,7 @@ spec:
               port:
                 number: 8080
   {{- end }}
-  {{- end}}
+  {{- end }}
   - http:
       paths:
       - backend:

--- a/charts/csm-authorization/templates/ingress.yaml
+++ b/charts/csm-authorization/templates/ingress.yaml
@@ -49,3 +49,12 @@ spec:
                 number: 8080
   {{- end }}
   {{- end}}
+  - http:
+      paths:
+      - backend:
+          service:
+            name: proxy-server
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix

--- a/charts/csm-authorization/values.yaml
+++ b/charts/csm-authorization/values.yaml
@@ -18,9 +18,9 @@ authorization:
     opa: openpolicyagent/opa
     opaKubeMgmt: openpolicyagent/kube-mgmt:0.11
 
-  # base hostname for the ingress rules that expose the services
-  # the proxy-server ingress will use this hostname
-  # the role-service ingress will use role.hostname
+  # proxy-server ingress will use this hostname
+  # NOTE: additional hostnames can be configured in authorization.proxyServerIngress.hosts
+  # NOTE: proxy-server ingress is configured to accept IP address connections so hostnames are not required
   hostname: csm-authorization.com
 
   # log level for csm-authorization
@@ -54,5 +54,5 @@ redis:
 
   # by default, csm-authorization will deploy a local (https://kubernetes.io/docs/concepts/storage/storage-classes/#local) volume for redis
   # to use a different storage class for redis, uncomment the following line and specify the name of the storage class
-  # NOTE: the storage class must NOT be a storage class provisioned by a CSI driver using CSM Authorization
+  # NOTE: the storage class must NOT be a storage class provisioned by a CSI driver to be configured with this instance of CSM Authorization
   #storageClass:

--- a/charts/csm-authorization/values.yaml
+++ b/charts/csm-authorization/values.yaml
@@ -52,7 +52,7 @@ redis:
     redis: redis:6.0.8-alpine
     commander: rediscommander/redis-commander:latest
 
-  # by default, csm-authorization will deploy a local (https://kubernetes.io/docs/concepts/storage/storage-classes/#local) volume for redis.
+  # by default, csm-authorization will deploy a local (https://kubernetes.io/docs/concepts/storage/storage-classes/#local) volume for redis
   # to use a different storage class for redis, uncomment the following line and specify the name of the storage class
   # NOTE: the storage class must NOT be a storage class provisioned by a CSI driver using CSM Authorization
   #storageClass:

--- a/charts/csm-authorization/values.yaml
+++ b/charts/csm-authorization/values.yaml
@@ -52,5 +52,7 @@ redis:
     redis: redis:6.0.8-alpine
     commander: rediscommander/redis-commander:latest
 
-  # set the storageClass for redis to use. otherwise, the default storage class is used
-  # storageClass: local-storage
+  # by default, csm-authorization will deploy a local (https://kubernetes.io/docs/concepts/storage/storage-classes/#local) volume for redis.
+  # to use a different storage class for redis, uncomment the following line and specify the name of the storage class
+  # NOTE: the storage class must NOT be a storage class provisioned by a CSI driver using CSM Authorization
+  #storageClass:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

It enables access to the proxy-server by the IP address of the cluster master node instead of requiring access by one of the hostnames configured in the Ingress.

This also configures a local provisioner for Redis to use by default so the user does not have to worry about what storage class to use for Redis. They can still provide a storage class if they wish.

#### Which issue(s) is this PR associated with:

https://github.com/dell/csm/issues/1091

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
