### PR TITLE
[csm-application-mobility] Revert app mobility version changes

### DIFF
--- a/charts/csm-application-mobility/Chart.yaml
+++ b/charts/csm-application-mobility/Chart.yaml
@@ -6,13 +6,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.3"
+appVersion: "0.3.0"
 
 dependencies:
 - name: cert-manager

--- a/charts/csm-application-mobility/values.yaml
+++ b/charts/csm-application-mobility/values.yaml
@@ -8,7 +8,7 @@ image:
   pullPolicy: IfNotPresent
 
 controller:
-  image: dellemc/csm-application-mobility-controller:v1.0.3
+  image: dellemc/csm-application-mobility-controller:v0.3.0
 
 # csm-application-mobility requires cert-manager. If cert-manager is not already present in cluster, set enabled to true to install it too.
 cert-manager:
@@ -70,7 +70,7 @@ velero:
 
   initContainers:
   - name: dell-custom-velero-plugin
-    image: dellemc/csm-application-mobility-velero-plugin:v1.0.3
+    image: dellemc/csm-application-mobility-velero-plugin:v0.3.0
     volumeMounts:
     - mountPath: /target
       name: plugins


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

Reverting the recent app mobility version back to 0.3.0

#### Which issue(s) is this PR associated with:

- N/A

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [X] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
