### PR TITLE
[`charts/csi-unity`] fix: add allowedNetworks parameter

### DIFF
--- a/charts/csi-unity/Chart.yaml
+++ b/charts/csi-unity/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-appVersion: 2.10.0
+appVersion: 2.10.1
 name: csi-unity
-version: 2.10.0
+version: 2.10.1
 description: |
   Unity XT CSI (Container Storage Interface) driver Kubernetes
   integration. This chart includes everything required to provision via CSI as

--- a/charts/csi-unity/templates/node.yaml
+++ b/charts/csi-unity/templates/node.yaml
@@ -160,6 +160,8 @@ spec:
               value: "true"
             - name: X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS
               value: {{ .Values.allowRWOMultiPodAccess | default "false" | lower | quote }}
+            - name: X_CSI_ALLOWED_NETWORKS
+              value: "{{ .Values.allowedNetworks }}"
             - name: X_CSI_PRIVATE_MOUNT_DIR
               value: "{{ .Values.kubeletConfigDir }}/plugins/unity.emc.dell.com/disks"
             - name: X_CSI_EPHEMERAL_STAGING_PATH

--- a/charts/csi-unity/values.yaml
+++ b/charts/csi-unity/values.yaml
@@ -4,11 +4,11 @@
 # version: version of this values file
 # Note: Do not change this value
 # Examples : "v2.9.0" , "nightly"
-version: "v2.10.0"
+version: "v2.10.1"
 
 images:
   # "driver" defines the container image, used for the driver container.
-  driver: dellemc/csi-unity:v2.10.0
+  driver: dellemc/csi-unity:v2.10.1
   # CSI sidecars
   attacher: registry.k8s.io/sig-storage/csi-attacher:v4.5.0
   provisioner: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
@@ -30,6 +30,13 @@ logLevel: "info"
 # Allowed values: n, where n > 0
 # Default value: None
 certSecretCount: 1
+
+# allowedNetworks: Custom networks for Unity export
+# Specify list of networks which can be used for NFS I/O traffic; CIDR format should be used.
+# Allowed values: list of one or more networks
+# Default value: None
+# Examples: [192.168.1.0/24, 192.168.100.0/22]
+allowedNetworks: []
 
 # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
 # Allowed values:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

Mechanism for selecting custom networks for array traffic in `csi-unity`.

#### Which issue(s) is this PR associated with:

- #Issue_Number

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
