### PR TITLE
[KRV-21812] Storage capacity poll interval

### DIFF
--- a/charts/csm-authorization/templates/csm-config-params.yaml
+++ b/charts/csm-authorization/templates/csm-config-params.yaml
@@ -7,7 +7,7 @@ data:
   csm-config-params.yaml: |
     CONCURRENT_POWERFLEX_REQUESTS: {{ .Values.authorization.concurrentPowerFlexRequests }}
     LOG_LEVEL: {{ .Values.authorization.logLevel }}
-    storageCapacityPollInterval: {{ .Values.authorization.storageCapacityPollInterval }}
+    STORAGE_CAPACITY_POLL_INTERVAL: {{ .Values.authorization.storageCapacityPollInterval }}
     {{- if (.Values.authorization.zipkin.collectoruri) }}
     zipkin.collectoruri: {{ .Values.authorization.zipkin.collectoruri }}
     zipkin.probability: {{ .Values.authorization.zipkin.probability }}

--- a/charts/csm-authorization/templates/csm-config-params.yaml
+++ b/charts/csm-authorization/templates/csm-config-params.yaml
@@ -10,5 +10,5 @@ data:
     {{- if (.Values.authorization.zipkin.collectoruri) }}
     zipkin.collectoruri: {{ .Values.authorization.zipkin.collectoruri }}
     zipkin.probability: {{ .Values.authorization.zipkin.probability }}
-    storagePollInterval: {{ .Values.authorization.storagePollInterval }}
+    storageCapacityPollInterval: {{ .Values.authorization.storageCapacityPollInterval }}
     {{- end }}

--- a/charts/csm-authorization/templates/csm-config-params.yaml
+++ b/charts/csm-authorization/templates/csm-config-params.yaml
@@ -7,8 +7,8 @@ data:
   csm-config-params.yaml: |
     CONCURRENT_POWERFLEX_REQUESTS: {{ .Values.authorization.concurrentPowerFlexRequests }}
     LOG_LEVEL: {{ .Values.authorization.logLevel }}
+    storageCapacityPollInterval: {{ .Values.authorization.storageCapacityPollInterval }}
     {{- if (.Values.authorization.zipkin.collectoruri) }}
     zipkin.collectoruri: {{ .Values.authorization.zipkin.collectoruri }}
     zipkin.probability: {{ .Values.authorization.zipkin.probability }}
-    storageCapacityPollInterval: {{ .Values.authorization.storageCapacityPollInterval }}
     {{- end }}

--- a/charts/csm-authorization/templates/csm-config-params.yaml
+++ b/charts/csm-authorization/templates/csm-config-params.yaml
@@ -10,4 +10,5 @@ data:
     {{- if (.Values.authorization.zipkin.collectoruri) }}
     zipkin.collectoruri: {{ .Values.authorization.zipkin.collectoruri }}
     zipkin.probability: {{ .Values.authorization.zipkin.probability }}
+    storagePollInterval: {{ .Values.authorization.storagePollInterval }}
     {{- end }}

--- a/charts/csm-authorization/values.yaml
+++ b/charts/csm-authorization/values.yaml
@@ -46,6 +46,9 @@ authorization:
 
     # additional annotations for the proxy-server ingress
     annotations: {}
+  
+  # storage poll interval in seconds
+  storagePollInterval: 30
 
 redis:
   images:

--- a/charts/csm-authorization/values.yaml
+++ b/charts/csm-authorization/values.yaml
@@ -47,7 +47,7 @@ authorization:
     # additional annotations for the proxy-server ingress
     annotations: {}
   
-  # storage poll interval in seconds
+  # storage capacity poll interval
   storageCapacityPollInterval: 5m
 
 redis:

--- a/charts/csm-authorization/values.yaml
+++ b/charts/csm-authorization/values.yaml
@@ -48,7 +48,7 @@ authorization:
     annotations: {}
   
   # storage poll interval in seconds
-  storagePollInterval: 30
+  storageCapacityPollInterval: 5m
 
 redis:
   images:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Added new parameter for storage capacity polling interval for csm-authorization

#### Which issue(s) is this PR associated with:

- #Issue_Number

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
