### PR TITLE
[csm-authorization/redis] Add username and password to rediscommander

### DIFF
--- a/charts/csm-authorization/charts/redis/templates/redis-secret.yaml
+++ b/charts/csm-authorization/charts/redis/templates/redis-secret.yaml
@@ -6,3 +6,4 @@ metadata:
 type: kubernetes.io/basic-auth
 stringData:
   password: K@ravi123!
+  commander_user: dev

--- a/charts/csm-authorization/charts/redis/templates/redis.yaml
+++ b/charts/csm-authorization/charts/redis/templates/redis.yaml
@@ -143,6 +143,16 @@ spec:
             secretKeyRef:
               name: redis-csm-secret
               key: password          
+        - name: HTTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: redis-csm-secret
+              key: password          
+        - name: HTTP_USER
+          valueFrom:
+            secretKeyRef:
+              name: redis-csm-secret
+              key: commander_user         
         ports:
         - name: {{ .Values.redis.rediscommander }}
           containerPort: 8081


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

Add login username and password to rediscommander web portal so that it's not exposed to anyone on the cluster.

#### Which issue(s) is this PR associated with:

- [#1281](https://github.com/dell/csm/issues/1281)

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
