### PR TITLE
Add retry logic for sentinel start-up

### DIFF
--- a/charts/csm-authorization/charts/redis/templates/sentinel.yaml
+++ b/charts/csm-authorization/charts/redis/templates/sentinel.yaml
@@ -35,21 +35,42 @@ spec:
             done            
             loop=$(echo $nodes | sed -e "s/"*"/\n/g")
            
-            for i in $loop
-            do                
-                echo "Finding master at $i"
-                MASTER=$(redis-cli --no-auth-warning --raw -h $i -a $REDIS_PASSWORD info replication | awk '{print $1}' | grep master_host: | cut -d ":" -f2)
-                if [ "$MASTER" = "" ]; then
-                    echo "Master not found..."
-                    echo "Sleeping 5 seconds for pods to come up..."
-                    sleep 5
-                    MASTER=
-                else
-                    echo "Master found at $MASTER..."
-                    break
-                fi
-            done
+            foundMaster=$false
 
+            while [ $foundMaster == $false ] 
+            do  
+              for i in $loop
+              do
+                  echo "Finding master at $i"
+                  ROLE=$(redis-cli --no-auth-warning --raw -h $i -a $REDIS_PASSWORD info replication | awk '{print $1}' | grep role | cut -d ":" -f2)
+                  if [ "$ROLE" = "master" ]; then
+                      MASTER=$i.authorization.svc.cluster.local
+                      echo "Master found at $MASTER..."
+                      foundMaster=$true
+                      break
+                  else
+                    MASTER=$(redis-cli --no-auth-warning --raw -h $i -a $REDIS_PASSWORD info replication | awk '{print $1}' | grep master_host: | cut -d ":" -f2)
+                    if [ "$MASTER" = "" ]; then
+                        echo "Master not found..."
+                        echo "Sleeping 5 seconds for redis pods to come up..."
+                        sleep 5
+                        MASTER=
+                    else
+                        echo "Master found at $MASTER..."
+                        foundMaster=$true
+                        break
+                    fi
+                  fi
+              done
+
+              if [ $foundMaster == $true ]; then
+                break
+              else   
+                 echo "Master not found, sleep for 30s before attempting again"
+                 sleep 30
+              fi
+            done
+            
             echo "sentinel monitor mymaster $MASTER 6379 2" >> /tmp/master
             echo "port 5000
             sentinel resolve-hostnames yes


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Sentinel pod deployment occasionally cycles through all redis pods even before they come up and then fails.
Adding retry logic in sentinel deployment (init container) to keep checking for redis pods with a delay of 30s if all redis pods have been checked and none of them are ready.

This is not consistently reproducible and it depends on the particular environment when this manifests. The retry logic added should help.

#### Which issue(s) is this PR associated with:
https://github.com/dell/csm/issues/1281

- #Issue_Number

#### Special notes for your reviewer:
The changes are only in the init container deployment of sentinel pods, its a minor change to beef up the retry logic.

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
