### PR TITLE
Fix sentinel timeout issue, organize subcharts for redis

### DIFF
--- a/charts/csm-authorization/charts/redis/Chart.yaml
+++ b/charts/csm-authorization/charts/redis/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: redis-csm
+name: redis
 description: Helm Chart for Redis with Sentinels
 type: application
 version: 0.1.0

--- a/charts/csm-authorization/charts/redis/templates/redis.yaml
+++ b/charts/csm-authorization/charts/redis/templates/redis.yaml
@@ -1,40 +1,40 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.redis.name }}
+  name: {{ .Values.name }}
   namespace: {{ include "custom.namespace" . }}
 spec:
   type:
   clusterIP: None
   selector:
-    app: {{ .Values.redis.name }}
+    app: {{ .Values.name }}
   ports:
   - protocol: TCP
     port: 6379
     targetPort: 6379
-    name: {{ .Values.redis.name }}
+    name: {{ .Values.name }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Values.redis.name }}
+  name: {{ .Values.name }}
   namespace: {{ include "custom.namespace" . }}
 spec:
-  serviceName: {{ .Values.redis.name }}
-  replicas: {{ .Values.redis.replicas }}
+  serviceName: {{ .Values.name }}
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app: {{ .Values.redis.name }}
+      app: {{ .Values.name }}
   template:
     metadata:
       labels:
-        app: {{ .Values.redis.name }}
+        app: {{ .Values.name }}
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/redis-secret.yaml") . | sha256sum }}
     spec:
       initContainers:
       - name: config
-        image: {{ .Values.redis.images.redis }}
+        image: {{ .Values.images.redis }}
         env:
           - name: REDIS_PASSWORD
             valueFrom:
@@ -50,11 +50,11 @@ spec:
             echo "requirepass $REDIS_PASSWORD" >> /etc/redis/redis.conf
             
             echo "Finding master..."
-            MASTER_FDQN=`hostname  -f | sed -e 's/{{ .Values.redis.name }}-[0-9]\./{{ .Values.redis.name }}-0./'`
+            MASTER_FDQN=`hostname  -f | sed -e 's/{{ .Values.name }}-[0-9]\./{{ .Values.name }}-0./'`
             echo "Master at " $MASTER_FQDN
             if [ "$(redis-cli -h sentinel -p 5000 ping)" != "PONG" ]; then
               echo "No sentinel found..."
-              if [ "$(hostname)" = "{{ .Values.redis.name }}-0" ]; then
+              if [ "$(hostname)" = "{{ .Values.name }}-0" ]; then
                 echo "This is Redis master, not updating redis.conf..."
               else
                 echo "This is Redis replica, updating redis.conf..."               
@@ -73,13 +73,13 @@ spec:
         - name: config
           mountPath: /etc/redis/
       containers:
-      - name: {{ .Values.redis.name }}
-        image: {{ .Values.redis.images.redis }}
+      - name: {{ .Values.name }}
+        image: {{ .Values.images.redis }}
         command: ["redis-server"]
         args: ["/etc/redis/redis.conf"]
         ports:
         - containerPort: 6379
-          name: {{ .Values.redis.name }}
+          name: {{ .Values.name }}
         volumeMounts:
         - name: redis-primary-volume
           mountPath: /data
@@ -99,30 +99,30 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.redis.rediscommander }}
+  name: {{ .Values.rediscommander }}
   namespace: {{ include "custom.namespace" . }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Values.redis.rediscommander }}
+      app: {{ .Values.rediscommander }}
   template:
     metadata:
       labels:
-        app: {{ .Values.redis.rediscommander }}
+        app: {{ .Values.rediscommander }}
         tier: backend
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/redis-secret.yaml") . | sha256sum }}
     spec:
       containers:
-      - name: {{ .Values.redis.rediscommander }}
-        image: {{ .Values.redis.images.commander }}
+      - name: {{ .Values.rediscommander }}
+        image: {{ .Values.images.commander }}
         imagePullPolicy: IfNotPresent
         env:
           {{- $str := "" -}}
           {{- $ns := include "custom.namespace" . -}} 
-          {{- $replicas := .Values.redis.replicas | int }}
-          {{- $sentinel := .Values.redis.sentinel }}
+          {{- $replicas := .Values.replicas | int }}
+          {{- $sentinel := .Values.sentinel }}
           {{- range $i, $e := until $replicas }} 
           {{- if $i }}         
           {{- $str = print $str "," -}}
@@ -154,7 +154,7 @@ spec:
               name: redis-csm-secret
               key: commander_user         
         ports:
-        - name: {{ .Values.redis.rediscommander }}
+        - name: {{ .Values.rediscommander }}
           containerPort: 8081
         livenessProbe:
           httpGet:
@@ -177,11 +177,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.redis.rediscommander }}
+  name: {{ .Values.rediscommander }}
   namespace: {{ include "custom.namespace" . }}
 spec:
   selector:
-    app: {{ .Values.redis.rediscommander }}
+    app: {{ .Values.rediscommander }}
   ports:
   - protocol: TCP
     port: 8081

--- a/charts/csm-authorization/charts/redis/templates/sentinel.yaml
+++ b/charts/csm-authorization/charts/redis/templates/sentinel.yaml
@@ -35,9 +35,9 @@ spec:
             done            
             loop=$(echo $nodes | sed -e "s/"*"/\n/g")
            
-            foundMaster=$false
+            foundMaster=false
 
-            while [ $foundMaster == $false ] 
+            while [ "$foundMaster" == "false" ] 
             do  
               for i in $loop
               do
@@ -46,7 +46,7 @@ spec:
                   if [ "$ROLE" = "master" ]; then
                       MASTER=$i.authorization.svc.cluster.local
                       echo "Master found at $MASTER..."
-                      foundMaster=$true
+                      foundMaster=true
                       break
                   else
                     MASTER=$(redis-cli --no-auth-warning --raw -h $i -a $REDIS_PASSWORD info replication | awk '{print $1}' | grep master_host: | cut -d ":" -f2)
@@ -57,13 +57,13 @@ spec:
                         MASTER=
                     else
                         echo "Master found at $MASTER..."
-                        foundMaster=$true
+                        foundMaster=true
                         break
                     fi
                   fi
               done
 
-              if [ $foundMaster == $true ]; then
+              if [ "$foundMaster" == "true" ]; then
                 break
               else   
                  echo "Master not found, sleep for 30s before attempting again"

--- a/charts/csm-authorization/charts/redis/templates/sentinel.yaml
+++ b/charts/csm-authorization/charts/redis/templates/sentinel.yaml
@@ -1,23 +1,23 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Values.redis.sentinel }}
+  name: {{ .Values.sentinel }}
 spec:
-  serviceName: {{ .Values.redis.sentinel }}
-  replicas: {{ .Values.redis.replicas }}
+  serviceName: {{ .Values.sentinel }}
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app: {{ .Values.redis.sentinel }}
+      app: {{ .Values.sentinel }}
   template:
     metadata:
       labels:
-        app: {{ .Values.redis.sentinel }}
+        app: {{ .Values.sentinel }}
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/redis-secret.yaml") . | sha256sum }}
     spec:
       initContainers:
       - name: config
-        image: {{ .Values.redis.images.redis }}
+        image: {{ .Values.images.redis }}
         command: [ "sh", "-c" ]
         env:
           - name: REDIS_PASSWORD
@@ -27,10 +27,10 @@ spec:
                 key: password
         args:         
           - |         
-            replicas=$( expr {{ .Values.redis.replicas | int }} - 1)          
+            replicas=$( expr {{ .Values.replicas | int }} - 1)          
             for i in $(seq 0 $replicas)
             do               
-                node=$( echo "{{ .Values.redis.name }}-$i.{{ .Values.redis.name }}" )
+                node=$( echo "{{ .Values.name }}-$i.{{ .Values.name }}" )
                 nodes=$( echo "$nodes*$node" )
             done            
             loop=$(echo $nodes | sed -e "s/"*"/\n/g")
@@ -87,12 +87,12 @@ spec:
           mountPath: /etc/redis/
       containers:
       - name: sentinel
-        image: {{ .Values.redis.images.redis }}
+        image: {{ .Values.images.redis }}
         command: ["redis-sentinel"]
         args: ["/etc/redis/sentinel.conf"]
         ports:
         - containerPort: 5000
-          name: {{ .Values.redis.sentinel }}
+          name: {{ .Values.sentinel }}
         volumeMounts:
         - name: redis-config
           mountPath: /etc/redis/
@@ -107,7 +107,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.redis.sentinel }}
+  name: {{ .Values.sentinel }}
 spec:
   clusterIP: None
   ports:
@@ -120,13 +120,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
- name: {{ .Values.redis.sentinel }}-svc
+ name: {{ .Values.sentinel }}-svc
 spec: 
  type: NodePort
  ports:
  - port: 5000
    targetPort: 5000
    nodePort: 32003
-   name: {{ .Values.redis.sentinel }}-svc
+   name: {{ .Values.sentinel }}-svc
  selector:
-   app: {{ .Values.redis.sentinel }}
+   app: {{ .Values.sentinel }}

--- a/charts/csm-authorization/charts/redis/templates/sentinel.yaml
+++ b/charts/csm-authorization/charts/redis/templates/sentinel.yaml
@@ -35,9 +35,9 @@ spec:
             done            
             loop=$(echo $nodes | sed -e "s/"*"/\n/g")
            
-            foundMaster=false
+            foundMaster=$false
 
-            while [ "$foundMaster" == "false" ] 
+            while [ $foundMaster == $false ] 
             do  
               for i in $loop
               do
@@ -46,27 +46,27 @@ spec:
                   if [ "$ROLE" = "master" ]; then
                       MASTER=$i.authorization.svc.cluster.local
                       echo "Master found at $MASTER..."
-                      foundMaster=true
+                      foundMaster=$true
                       break
                   else
                     MASTER=$(redis-cli --no-auth-warning --raw -h $i -a $REDIS_PASSWORD info replication | awk '{print $1}' | grep master_host: | cut -d ":" -f2)
                     if [ "$MASTER" = "" ]; then
                         echo "Master not found..."
-                        echo "Waiting 5 seconds for redis pods to come up..."
+                        echo "Sleeping 5 seconds for redis pods to come up..."
                         sleep 5
                         MASTER=
                     else
                         echo "Master found at $MASTER..."
-                        foundMaster=true
+                        foundMaster=$true
                         break
                     fi
                   fi
               done
 
-              if [ "$foundMaster" == "true" ]; then
+              if [ $foundMaster == $true ]; then
                 break
               else   
-                 echo "Master not found, waiting for 30s before attempting again"
+                 echo "Master not found, sleep for 30s before attempting again"
                  sleep 30
               fi
             done

--- a/charts/csm-authorization/charts/redis/templates/sentinel.yaml
+++ b/charts/csm-authorization/charts/redis/templates/sentinel.yaml
@@ -52,7 +52,7 @@ spec:
                     MASTER=$(redis-cli --no-auth-warning --raw -h $i -a $REDIS_PASSWORD info replication | awk '{print $1}' | grep master_host: | cut -d ":" -f2)
                     if [ "$MASTER" = "" ]; then
                         echo "Master not found..."
-                        echo "Sleeping 5 seconds for redis pods to come up..."
+                        echo "Waiting 5 seconds for redis pods to come up..."
                         sleep 5
                         MASTER=
                     else
@@ -66,7 +66,7 @@ spec:
               if [ "$foundMaster" == "true" ]; then
                 break
               else   
-                 echo "Master not found, sleep for 30s before attempting again"
+                 echo "Master not found, wait for 30s before attempting again"
                  sleep 30
               fi
             done

--- a/charts/csm-authorization/charts/redis/values.yaml
+++ b/charts/csm-authorization/charts/redis/values.yaml
@@ -1,9 +1,12 @@
-redis:
-  name: redis-csm
-  sentinel: sentinel
-  rediscommander: rediscommander
-  replicas: 5
-  images:
-    redis: redis:7.2.4-alpine
-    commander: rediscommander/redis-commander:latest
+# Redis and sentinel chart values 
+# This file enables testing of redis charts without having to deploy authorization charts
+# Global values take predence over the values specified in here. 
+
+name: redis-csm
+sentinel: sentinel
+rediscommander: rediscommander
+replicas: 5
+images:
+  redis: redis:7.2.4-alpine
+  commander: rediscommander/redis-commander:latest
  

--- a/charts/csm-authorization/charts/redis/values.yaml
+++ b/charts/csm-authorization/charts/redis/values.yaml
@@ -1,0 +1,9 @@
+redis:
+  name: redis-csm
+  sentinel: sentinel
+  rediscommander: rediscommander
+  replicas: 5
+  images:
+    redis: redis:7.2.4-alpine
+    commander: rediscommander/redis-commander:latest
+ 

--- a/charts/csm-authorization/values.yaml
+++ b/charts/csm-authorization/values.yaml
@@ -57,6 +57,9 @@ authorization:
   # storage capacity poll interval
   storageCapacityPollInterval: 5m
 
+
+# Redis chart values. 
+# Modifications here will take precedence over the values specified in charts/redis/
 redis:
   name: redis-csm
   sentinel: sentinel


### PR DESCRIPTION
1. Fix sentinel deployment timeout issue noticed on some setups. Generalized the checks in bash. 
2. Organize sub-charts for redis to be able to independently deployable, ensure root values take precedence over sub-chart values.

#### Is this a new chart?

Yes

#### What this PR does / why we need it:

See above

#### Which issue(s) is this PR associated with:

https://github.com/dell/csm/issues/1281

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
- [ ] - [ ] 