### PR TITLE
Update helm chart validation action

### DIFF
--- a/.github/workflows/helm-validations.yml
+++ b/.github/workflows/helm-validations.yml
@@ -26,9 +26,9 @@ jobs:
           version: latest
 
       - name: Set up Python
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install chart-testing-action
         uses: helm/chart-testing-action@v2.6.1

--- a/.github/workflows/helm-validations.yml
+++ b/.github/workflows/helm-validations.yml
@@ -19,12 +19,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: "0"
-    
+
       - name: Set up Helm
         uses: azure/setup-helm@v4.2.0
         with:
           version: latest
-      
+
       - name: Set up Python
         uses: actions/setup-python@v5.1.0
         with:

--- a/.github/workflows/helm-validations.yml
+++ b/.github/workflows/helm-validations.yml
@@ -1,4 +1,4 @@
-# This action checks the Helm Chart changes for linting and version updates
+# This action checks the Helm Chart changes for linting
 name: helm-validations
 
 # Check runs on PRs created to merge to main branch
@@ -6,64 +6,41 @@ on:
   pull_request:
     branches:
       - main
-      - karavi-observability-release
-      - csm-authorization-release
       - release-v*
 
 jobs:
-  # This job will check to see if any .yaml file is modified
-  check_files:
-    runs-on: ubuntu-latest
-    outputs:
-      run_tests: ${{ steps.diff.outputs.run_tests }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check for files changed
-        id: diff
-        run: |
-          URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
-          FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename')
-          echo $FILES | grep \.yaml && echo '::set-output name=run_tests::true' || true
-
-  # This job will run helm lint and version increment check on updated charts
+  # This job will run helm lint on updated charts
   lint:
+    name: CSM Chart Linter
     runs-on: ubuntu-latest
-    # Only run job when .yaml file is changed
-    needs: check_files
-    if: needs.check_files.outputs.run_tests == 'true'
     steps:
       # Check out the repo
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: "0"
-
-      # Lint and version increment checks on updated charts
-      - name: Run lint/version increment checks
-        id: versionIncrement
-        # Bump to proper version after this issue is fixed : https://github.com/helm/chart-testing-action/issues/132
-        uses: helm/chart-testing-action@cb49023b9227b1097e5eddd8824f48bdea11b1aa
+    
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
         with:
-          command: lint
-          config: lintConfig.yaml
-
-  # This job checks that dependency versions have been updated on the karavi-observability chart
-  dependency:
-    runs-on: ubuntu-latest
-    # Only run job when .yaml file is changed
-    needs: check_files
-    if: needs.check_files.outputs.run_tests == 'true'
-    steps:
-      # Check out the repo
-      - name: Checkout
-        uses: actions/checkout@v4
+          version: latest
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5.1.0
         with:
-          fetch-depth: "0"
+          python-version: '3.10'
 
-      # Run a check on karavi-observability chart for updated dependency versions
-      - name: Run dependency version checks
-        id: lint
-        uses: helm/chart-testing-action@cb49023b9227b1097e5eddd8824f48bdea11b1aa
-        with:
-          command: lint
-          config: dependencyConfig.yaml
+      - name: Install chart-testing-action
+        uses: helm/chart-testing-action@v2.6.1
+
+      - name: Run chart-testing list-changed
+        id: modified-charts
+        run: |
+          modified=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$modified" ]]; then
+            echo "modified=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing linter
+        if: steps.modified-charts.outputs.modified == 'true'
+        run: ct lint --config ct.yaml

--- a/.yamllint
+++ b/.yamllint
@@ -5,7 +5,7 @@ yaml-files:
   - ".yamllint"
 
 rules:
-  braces: enable
+  braces: disable
   brackets: enable
   colons: enable
   commas: enable

--- a/.yamllint
+++ b/.yamllint
@@ -5,7 +5,9 @@ yaml-files:
   - ".yamllint"
 
 rules:
-  braces: disable
+  braces:
+    level: warning
+    max-spaces-inside: 1
   brackets: enable
   colons: enable
   commas: enable

--- a/.yamllint
+++ b/.yamllint
@@ -8,7 +8,9 @@ rules:
   braces:
     level: warning
     max-spaces-inside: 1
-  brackets: enable
+  brackets:
+    level: warning
+    max-spaces-inside: 1
   colons: enable
   commas: enable
   comments:
@@ -31,6 +33,9 @@ rules:
   truthy:
     level: warning
 
-ignore:
-  - .github/workflows/
-  - '*/templates/*.yaml'
+ignore: |
+  .github/workflows/
+  charts/*/templates/
+  charts/*/*/*/templates/
+  charts/csi-powermax/charts/csireverseproxy/conf/config.yaml
+  charts/csm-replication/crds/replicationcrds.all.yaml

--- a/.yamllint
+++ b/.yamllint
@@ -33,4 +33,4 @@ rules:
 
 ignore:
   - .github/workflows/
-  - /templates/*.yaml
+  - '*/templates/*.yaml'

--- a/.yamllint
+++ b/.yamllint
@@ -13,8 +13,7 @@ rules:
   commas: enable
   comments:
     level: warning
-  comments-indentation:
-    level: warning
+  comments-indentation: disable
   document-end: disable
   document-start: disable
   empty-lines: enable
@@ -34,3 +33,4 @@ rules:
 
 ignore:
   - .github/workflows/
+  - /templates/*.yaml

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,6 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+target-branch: main
+# Not executed on installation-wizard because of the dependency on other charts
+chart-dirs:
+  - charts

--- a/ct.yaml
+++ b/ct.yaml
@@ -4,3 +4,4 @@ target-branch: main
 # Not executed on installation-wizard because of the dependency on other charts
 chart-dirs:
   - charts
+validate-maintainers: false

--- a/dependencyConfig.yaml
+++ b/dependencyConfig.yaml
@@ -1,5 +1,0 @@
-target-branch: main
-charts:
- - charts/karavi-observability
-validate-chart-schema: false
-validate-maintainers: false

--- a/lintConfig.yaml
+++ b/lintConfig.yaml
@@ -1,6 +1,0 @@
-target-branch: main
-chart-dirs:
- - charts
-check-version-increment: true
-validate-chart-schema: false
-validate-maintainers: false


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

Updates helm-validations action to run helm lint on charts under the charts directory and removes configurations no longer used in the action. 

Linting errors addressed in https://github.com/dell/helm-charts/pull/450.

Example output of linter:
```
Run ct lint --config ct.yaml
Linting charts...

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 csi-powermax => (version: "2.10.2", path: "charts/csi-powermax")
------------------------------------------------------------------------------------------------------------------------

Saving 1 charts
Dependency csireverseproxy did not declare a repository. Assuming it exists in the charts directory
Deleting outdated charts
Linting chart "csi-powermax => (version: \"2.10.2\", path: \"charts/csi-powermax\")"
Checking chart "csi-powermax => (version: \"2.10.2\", path: \"charts/csi-powermax\")" for a version bump...
Old chart version: 2.10.1
New chart version: 2.10.2
Chart version ok.
Validating /home/runner/work/helm-charts-test/helm-charts-test/charts/csi-powermax/Chart.yaml...
Validation success! 👍
==> Linting charts/csi-powermax

1 chart(s) linted, 0 chart(s) failed

------------------------------------------------------------------------------------------------------------------------
 ✔︎ csi-powermax => (version: "2.10.2", path: "charts/csi-powermax")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1221

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
