### PR TITLE
Fix Sentinel stateful set deployment

### DIFF
--- a/charts/csm-authorization/charts/redis/templates/sentinel.yaml
+++ b/charts/csm-authorization/charts/redis/templates/sentinel.yaml
@@ -37,7 +37,7 @@ spec:
            
             foundMaster=false
 
-            while [ "$foundMaster" == "false" ] 
+            while [ "$foundMaster" = "false" ] 
             do  
               for i in $loop
               do
@@ -63,7 +63,7 @@ spec:
                   fi
               done
 
-              if [ "$foundMaster" == "true" ]; then
+              if [ "$foundMaster" = "true" ]; then
                 break
               else   
                  echo "Master not found, wait for 30s before attempting again"
@@ -126,7 +126,6 @@ spec:
  ports:
  - port: 5000
    targetPort: 5000
-   nodePort: 32003
    name: {{ .Values.sentinel }}-svc
  selector:
    app: {{ .Values.sentinel }}


### PR DESCRIPTION
#### Is this a new chart?

Yes

#### What this PR does / why we need it:
Sentinel statefulset deployments failed on certain environments due to variance in the versions of shell. The == operator evaluated to = in some shells but not all of them. Fix is to use single = in comparisons. 

#### Which issue(s) is this PR associated with:

- #Issue_Number

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Tested redis and sentinel deployments on multiple linux versions, such as OCP 4.12, 4.14 as well as RHEL 9.x

