### PR TITLE
csi-isilon: second csi-metadata-retriever instance eliminated

### DIFF
--- a/charts/csi-isilon/templates/controller.yaml
+++ b/charts/csi-isilon/templates/controller.yaml
@@ -273,20 +273,6 @@ spec:
               mountPath: /var/run/csi
         {{ end }}
         {{ end }}
-        - name: csi-metadata-retriever{{ $csiSidecarSuffix }}
-          image: {{ required "Must provide the CSI metadata retriever container image." .Values.images.metadataretriever }}
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          args:
-            - "--csi-address={{ $driverSockPath }}"
-            - "--timeout=120s"
-            - "--v=5"
-          command: [ "/csi-metadata-retriever" ]
-          env:
-            - name: CSI_RETRIEVER_ENDPOINT
-              value: /var/run/csi/csi_retriever{{ $csiSidecarSuffix }}.sock
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /var/run/csi
         - name: attacher{{ $csiSidecarSuffix }}
           image: {{ required "Must provide the CSI attacher container image." .Values.images.attacher }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -310,6 +296,16 @@ spec:
             - name: socket-dir
               mountPath: /var/run/csi
         {{- if not $encrypted }}
+        - name: csi-metadata-retriever
+          image: {{ required "Must provide the CSI metadata retriever container image." .Values.images.metadataretriever }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          command: [ "/csi-metadata-retriever" ]
+          env:
+            - name: CSI_RETRIEVER_ENDPOINT
+              value: /var/run/csi/csi_retriever.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
         {{- if hasKey .Values.controller "healthMonitor" }}
         {{- if eq .Values.controller.healthMonitor.enabled true }}
         - name: external-health-monitor-controller


### PR DESCRIPTION
Do not install additional instance of retriever when Encryption is enabled.

<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

Do not install additional instance of retriever when Encryption is enabled.

#### Which issue(s) is this PR associated with:

[1309](https://github.com/dell/csm/issues/1309)

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
