### PR TITLE
[charts/csi-unity] Update usage of allowedNetworks in values.yaml

### DIFF
--- a/charts/csi-unity/values.yaml
+++ b/charts/csi-unity/values.yaml
@@ -33,10 +33,10 @@ certSecretCount: 1
 
 # allowedNetworks: Custom networks for Unity export
 # Specify list of networks which can be used for NFS I/O traffic; CIDR format should be used.
-# Allowed values: list of one or more networks
+# Allowed values: list of one or more networks (comma separated)
 # Default value: None
-# Examples: [192.168.1.0/24, 192.168.100.0/22]
-allowedNetworks: []
+# Examples: 192.168.1.0/24, 192.168.100.0/22
+allowedNetworks:
 
 # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
 # Allowed values:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it: This PR updates the usage of allowedNetworks parameter in values.yaml

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1335

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable

Driver pods running:
![image](https://github.com/dell/helm-charts/assets/109594002/36202295-6d33-4030-8ad9-650bd873efe0)
