### PR TITLE
Setting allowAutoRoundOffFilesystemSize param to true

### DIFF
--- a/charts/csi-powerstore/values.yaml
+++ b/charts/csi-powerstore/values.yaml
@@ -306,7 +306,7 @@ logFormat: "JSON"
 fsGroupPolicy: ReadWriteOnceWithFSType
 
 # Allows the controller to round off filesystem to 3Gi which is the minimum supported value
-allowAutoRoundOffFilesystemSize: false
+allowAutoRoundOffFilesystemSize: true
 
 # Storage Capacity Tracking
 # Note: Capacity tracking is supported in kubernetes v1.24 and above, this feature will be automatically disabled in older versions.


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Making default value of allowAutoRoundOffFilesystemSize param for powerstore true. So that the non-supported min size volume provisioning won't fail. 

#### Which issue(s) is this PR associated with:

- #Issue_Number
- https://github.com/dell/csm/issues/1377

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
