### PR TITLE
[charts/csi-powermax] Updated migrator and node-rescanner versions with correct versions for 1.11

### DIFF
--- a/charts/csi-powermax/values.yaml
+++ b/charts/csi-powermax/values.yaml
@@ -66,11 +66,11 @@ images:
   # CSM sidecars
   replication: dellemc/dell-csi-replicator:v1.9.0
   authorization: dellemc/csm-authorization-sidecar:v1.11.0
-  migration: dellemc/dell-csi-migrator:v1.4.0
+  migration: dellemc/dell-csi-migrator:v1.5.0
   podmon: dellemc/podmon:v1.10.0
   # Node rescan sidecar does a rescan on nodes for identifying new paths
-  # Default value: dellemc/dell-csi-node-rescanner:v1.3.0
-  noderescan: dellemc/dell-csi-node-rescanner:v1.3.0
+  # Default value: dellemc/dell-csi-node-rescanner:v1.4.0
+  noderescan: dellemc/dell-csi-node-rescanner:v1.4.0
 ## K8S/DRIVER ATTRIBUTES
 ########################
 # customDriverName: If enabled, sets the driver name to the

--- a/installation-wizard/container-storage-modules/values.yaml
+++ b/installation-wizard/container-storage-modules/values.yaml
@@ -144,8 +144,8 @@ csi-powermax:
     # CSM sidecars
     replication: dellemc/dell-csi-replicator:v1.9.0
     authorization: dellemc/csm-authorization-sidecar:v1.11.0
-    migration: dellemc/dell-csi-migrator:v1.4.0
-    noderescan: dellemc/dell-csi-node-rescanner:v1.3.0
+    migration: dellemc/dell-csi-migrator:v1.5.0
+    noderescan: dellemc/dell-csi-node-rescanner:v1.4.0
   clusterPrefix: ABC
   portGroups: PortGroup1, PortGroup2, PortGroup3
   controller:


### PR DESCRIPTION
#### Is this a new chart?

No

#### What this PR does / why we need it:

I noticed that migrator and node-rescanner image versions need an update for CSM 1.11 release. Previously pointed out versions have already been released. Last PR for reference - https://github.com/dell/helm-charts/pull/407

https://hub.docker.com/repository/docker/dellemc/dell-csi-replicator/general
https://hub.docker.com/repository/docker/dellemc/dell-csi-migrator/general
https://hub.docker.com/repository/docker/dellemc/dell-csi-node-rescanner/general

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1221

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable


No tests necessary since this is just an image version update and the versions are yet to be released.
