### PR TITLE
[charts/csm-authorization-v2.0] Support multiple instances of vault

### DIFF
--- a/charts/csm-authorization-v2.0/crds/csm-authorization.storage.dell.com_storages.yaml
+++ b/charts/csm-authorization-v2.0/crds/csm-authorization.storage.dell.com_storages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: storages.csm-authorization.storage.dell.com
 spec:
   group: csm-authorization.storage.dell.com
@@ -39,10 +39,6 @@ spec:
           spec:
             description: StorageSpec defines the desired state of Storage
             properties:
-              credentialPath:
-                type: string
-              credentialStore:
-                type: string
               endpoint:
                 type: string
               pollInterval:
@@ -56,6 +52,15 @@ spec:
                   INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
                   Important: Run "make" to regenerate code after modifying this file
                 type: string
+              vault:
+                properties:
+                  identifier:
+                    type: string
+                  kvEngine:
+                    type: string
+                  path:
+                    type: string
+                type: object
             required:
             - skipCertificateValidation
             type: object

--- a/charts/csm-authorization-v2.0/templates/csm-config-params.yaml
+++ b/charts/csm-authorization-v2.0/templates/csm-config-params.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   csm-config-params.yaml: |
     CONCURRENT_POWERFLEX_REQUESTS: {{ .Values.authorization.concurrentPowerFlexRequests }}
+    CONCURRENT_POWERSCALE_REQUESTS: {{ .Values.authorization.concurrentPowerScaleRequests }}
     LOG_LEVEL: {{ .Values.authorization.logLevel }}
     STORAGE_CAPACITY_POLL_INTERVAL: {{ .Values.authorization.storageCapacityPollInterval }}
     {{- if (.Values.authorization.zipkin.collectoruri) }}

--- a/charts/csm-authorization-v2.0/templates/storage-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/storage-service.yaml
@@ -11,7 +11,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets", "events"]
-    verbs: ["get", "patch","post", create]
+    verbs: ["get", "patch", "post", "create"]
   - apiGroups: ["csm-authorization.storage.dell.com"]
     resources: ["storages", "csmtenants", "csmroles"]
     verbs: ["get", "list"]

--- a/charts/csm-authorization-v2.0/templates/storage-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/storage-service.yaml
@@ -85,10 +85,9 @@ spec:
                 name: redis-csm-secret
                 key: password
         args:
-          - "--vault-address={{ .Values.vault.address }}"
-          - "--vault-kv-engine-path={{ .Values.vault.kvEnginePath }}"
-          - "--vault-role={{ .Values.vault.role }}"
-          - "--vault-skip-certificate-validation={{ .Values.vault.skipCertificateValidation }}"
+          {{- range .Values.vault }}
+          - "--vault={{.identifier}},{{.address}},{{.role}},{{.skipCertificateValidation}}"
+          {{- end }}
           - "--redis-sentinel={{ $str }}"
           - "--redis-password=$(REDIS_PASSWORD)"
           - "--leader-election=true"
@@ -100,8 +99,10 @@ spec:
           mountPath: /etc/karavi-authorization/config
         - name: csm-config-params
           mountPath: /etc/karavi-authorization/csm-config-params
-        - name: vault-client-certificate
-          mountPath: /etc/vault
+        {{- range .Values.vault }}
+        - name: vault-client-certificate-{{ .identifier }}
+          mountPath: /etc/vault/{{ .identifier }}
+        {{- end }}
       volumes:
       - name: config-volume
         secret:
@@ -109,21 +110,22 @@ spec:
       - name: csm-config-params
         configMap:
           name: csm-config-params
-      - name: vault-client-certificate
+      {{- range .Values.vault }}
+      - name: vault-client-certificate-{{ .identifier }}
         projected:
           sources:
-        {{- if and (.Values.vault.clientCertificate) (.Values.vault.clientKey) }}
+        {{- if and (.clientCertificate) (.clientKey) }}
           - secret:
-              name: vault-client-certificate
+              name: vault-client-certificate-{{ .identifier }}
         {{- else }}
           - secret:
-              name: storage-service-selfsigned-tls
+              name: storage-service-selfsigned-tls-{{ .identifier }}
         {{- end }}
-        {{- if .Values.vault.certificateAuthority }}
+        {{- if .certificateAuthority }}
           - secret:
-              name: vault-certificate-authority
+              name: vault-certificate-authority-{{ .identifier }}
         {{- end }}
-
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -138,46 +140,46 @@ spec:
     targetPort: 50051
     name: grpc
 ---
-{{- if .Values.vault.certificateAuthority }}
-{{- $certificateFileContents := .Values.vault.certificateAuthority }}
+{{- $namespace := . }}
+{{- range .Values.vault }}
+{{- if .certificateAuthority }}
 apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: vault-certificate-authority
-  namespace: {{ include "custom.namespace" . }}
+  name: vault-certificate-authority-{{ .identifier }}
+  namespace: {{ include "custom.namespace" $namespace }}
 data:
-  ca.crt: {{ $certificateFileContents | b64enc }}
+  ca.crt: {{ .certificateAuthority }}
 {{- end }}
 ---
-{{- if and (.Values.vault.clientCertificate) (.Values.vault.clientKey) }}
-{{- $certificateFileContents := .Values.vault.clientCertificate }}
-{{- $keyFileContents := .Values.vault.clientKey }}
+{{- if and (.clientCertificate) (.clientKey) }}
 apiVersion: v1
 data:
-  tls.crt: {{ $certificateFileContents | b64enc }}
-  tls.key: {{ $keyFileContents | b64enc }}
+  tls.crt: {{ .clientCertificate }}
+  tls.key: {{ .clientKey }}
 kind: Secret
 type: kubernetes.io/tls
 metadata:
-  name: vault-client-certificate
-  namespace: {{ include "custom.namespace" . }}
+  name: vault-client-certificate-{{ .identifier }}
+  namespace: {{ include "custom.namespace" $namespace }}
+---
 {{- else }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: storage-service-selfsigned
-  namespace: {{ include "custom.namespace" . }}
+  name: storage-service-selfsigned-{{ .identifier }}
+  namespace: {{ include "custom.namespace" $namespace }}
 spec:
   selfSigned: {}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: storage-service-selfsigned
-  namespace: {{ include "custom.namespace" . }}
+  name: storage-service-selfsigned-{{ .identifier }}
+  namespace: {{ include "custom.namespace" $namespace }}
 spec:
-  secretName: storage-service-selfsigned-tls
+  secretName: storage-service-selfsigned-tls-{{ .identifier }}
   duration: 2160h # 90d
   renewBefore: 360h # 15d
   subject:
@@ -193,7 +195,8 @@ spec:
   dnsNames:
   - csm-authorization-storage-service
   issuerRef:
-    name: storage-service-selfsigned
+    name: storage-service-selfsigned-{{ .identifier }}
     kind: Issuer
     group: cert-manager.io
+{{- end }}
 {{- end }}

--- a/charts/csm-authorization-v2.0/values.yaml
+++ b/charts/csm-authorization-v2.0/values.yaml
@@ -78,17 +78,19 @@ vault:
     address: https://10.0.0.1:8400
     role: csm-authorization
     skipCertificateValidation: true
-    # set clientCertificate and clientKey if you want to use custom certificates for vault
+    # clientCertificate: base64-encoded certificate for cert/private-key pair -- add certificate here to use custom certificates
+    # for self-signed certs, leave empty string
     clientCertificate:
+    # clientKey: base64-encoded private key for cert/private-key pair -- add private key here to use custom certificates
+    # for self-signed certs, leave empty string
     clientKey:
-    # validate vault server certificate with a certificateAuthority certificate
+    # certificateAuthority: base64-encoded certificate authority for validating vault server certificate -- add certificate authority here to use custom certificates
+    #  for self-signed certs, leave empty string
     certificateAuthority:
   # - identifier: vault1
   #   address: https://10.0.0.2:8400
   #   role: csm-authorization
   #   skipCertificateValidation: true
-  #   # set clientCertificate and clientKey if you want to use custom certificates for vault
   #   clientCertificate:
   #   clientKey:
-  #   # validate vault server certificate with a certificateAuthority certificate
   #   certificateAuthority:

--- a/charts/csm-authorization-v2.0/values.yaml
+++ b/charts/csm-authorization-v2.0/values.yaml
@@ -38,6 +38,10 @@ authorization:
   # currently only used with dellctl to list tenant volumes
   concurrentPowerFlexRequests: "10"
 
+  # number, as a string, of concurrent requests for the storage-service to make to PowerScale
+  # currently only used with dellctl to list tenant volumes
+  concurrentPowerScaleRequests: "10"
+
   # tracing configuration
   # this can be updated on the fly via the csm-config-params configMap
   zipkin:
@@ -70,7 +74,21 @@ redis:
     commander: rediscommander/redis-commander:latest
 
 vault:
-  address: https://10.0.0.1:8400
-  kvEnginePath: secret
-  role: csm-authorization
-  skipCertificateValidation: true
+  - identifier: vault0
+    address: https://10.0.0.1:8400
+    role: csm-authorization
+    skipCertificateValidation: true
+    # set clientCertificate and clientKey if you want to use custom certificates for vault
+    clientCertificate:
+    clientKey:
+    # validate vault server certificate with a certificateAuthority certificate
+    certificateAuthority:
+  # - identifier: vault1
+  #   address: https://10.0.0.2:8400
+  #   role: csm-authorization
+  #   skipCertificateValidation: true
+  #   # set clientCertificate and clientKey if you want to use custom certificates for vault
+  #   clientCertificate:
+  #   clientKey:
+  #   # validate vault server certificate with a certificateAuthority certificate
+  #   certificateAuthority:

--- a/charts/csm-authorization/templates/storage-service.yaml
+++ b/charts/csm-authorization/templates/storage-service.yaml
@@ -11,7 +11,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "patch","post"]
+    verbs: ["get", "patch", "post"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
- Supports multiple vault configurations during deployment
- kvEnginePath now configurable in storage CR
- Adds concurrent powerscale requests

Storage CR sample:
```
apiVersion: csm-authorization.storage.dell.com/v1alpha1
kind: Storage
metadata:
  name: powerflex
spec:
  type: powerflex
  endpoint: https://127.0.0.1
  systemID: 1a99aa999999aa9a
  vault:
    identifier: vault0
    kvEngine: secret
    path: powerflex/1a99aa999999aa9a
  skipCertificateValidation: true
  pollInterval: 30s
```

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1281

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
