### PR TITLE
[charts/csm-authorization-v2.0] Enable dependabot for authorization v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,22 +40,6 @@ updates:
     target-branch: "release-v1.12.0"
     directories:
       - /charts/csm-authorization
-    labels:
-      - dependencies
-    schedule:
-      # check daily
-      interval: daily
-      # at 6pm UTC
-      time: "18:00"
-    groups:
-      csm-authorization:
-        patterns:
-          - "*"
-
-  # csm-authorization-v2.0 packages
-  - package-ecosystem: docker
-    target-branch: "release-v1.12.0"
-    directories:
       - /charts/csm-authorization-v2.0
     labels:
       - dependencies
@@ -65,7 +49,7 @@ updates:
       # at 6pm UTC
       time: "18:00"
     groups:
-      csm-authorization-v2.0:
+      csm-authorization:
         patterns:
           - "*"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,23 @@ updates:
         patterns:
           - "*"
 
+  # csm-authorization-v2.0 packages
+  - package-ecosystem: docker
+    target-branch: "release-v1.12.0"
+    directories:
+      - /charts/csm-authorization-v2.0
+    labels:
+      - dependencies
+    schedule:
+      # check daily
+      interval: daily
+      # at 6pm UTC
+      time: "18:00"
+    groups:
+      csm-authorization-v2.0:
+        patterns:
+          - "*"
+
   # karavi-observability packages
   - package-ecosystem: docker
     target-branch: "release-v1.12.0"


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Update dependabot config to run against authorization v2 chart.

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1414

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
