### PR TITLE
Add dependabot compatibility for csi-powerstore images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,7 +31,7 @@ updates:
       # at 6pm UTC
       time: "18:00"
     groups:
-      csi-isilon:
+      csi-powerstore:
         patterns:
           - "*"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,23 @@ updates:
         patterns:
           - "*"
 
+  # csi-powerstore packages
+  - package-ecosystem: docker
+    target-branch: "release-v1.12.0"
+    directories:
+      - /charts/csi-powerstore
+    labels:
+      - dependencies
+    schedule:
+      # check daily
+      interval: daily
+      # at 6pm UTC
+      time: "18:00"
+    groups:
+      csi-isilon:
+        patterns:
+          - "*"
+
   # csi-isilon packages
   - package-ecosystem: docker
     target-branch: "release-v1.12.0"

--- a/charts/csi-powerstore/templates/controller.yaml
+++ b/charts/csi-powerstore/templates/controller.yaml
@@ -197,7 +197,7 @@ spec:
         {{- if hasKey .Values "podmon" }}
         {{- if eq .Values.podmon.enabled true }}
         - name: podmon
-          image: {{ required "Must provide the podmon container image." .Values.images.podmon }}
+          image: {{ required "Must provide the podmon container image." .Values.images.podmon.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             {{- toYaml .Values.podmon.controller.args | nindent 12 }}
@@ -225,7 +225,7 @@ spec:
         {{ if .Values.dev.enableTracing }}{{- include "pstore.tracing" . | nindent 8 }}{{ end }}
         {{- end }}
         - name: attacher
-          image: {{ required "Must provide the CSI attacher container image." .Values.images.attacher }}
+          image: {{ required "Must provide the CSI attacher container image." .Values.images.attacher.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
@@ -243,7 +243,7 @@ spec:
         {{- if hasKey .Values.controller "resizer" }}
         {{- if eq .Values.controller.resizer.enabled true }}
         - name: resizer
-          image: {{ required "Must provide the CSI resizer container image." .Values.images.resizer }}
+          image: {{ required "Must provide the CSI resizer container image." .Values.images.resizer.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
@@ -258,7 +258,7 @@ spec:
         {{end}}
         {{end}}
         - name: provisioner
-          image: {{ required "Must provide the CSI provisioner container image." .Values.images.provisioner }}
+          image: {{ required "Must provide the CSI provisioner container image." .Values.images.provisioner.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
@@ -289,7 +289,7 @@ spec:
         {{- if hasKey .Values.controller "snapshot" }}
         {{- if eq .Values.controller.snapshot.enabled true }}
         - name: snapshotter
-          image: {{ required "Must provide the CSI snapshotter container image." .Values.images.snapshotter }}
+          image: {{ required "Must provide the CSI snapshotter container image." .Values.images.snapshotter.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
@@ -307,7 +307,7 @@ spec:
         {{- if hasKey .Values.controller "vgsnapshot" }}
         {{- if eq .Values.controller.vgsnapshot.enabled true }}
         - name: vg-snapshotter
-          image: {{ required "Must provide the vgsnapshotter container image." .Values.images.vgsnapshotter }}
+          image: {{ required "Must provide the vgsnapshotter container image." .Values.images.vgsnapshotter.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
             - name: ADDRESS
@@ -320,7 +320,7 @@ spec:
         {{- if hasKey .Values.controller "replication" }}
         {{- if eq .Values.controller.replication.enabled true}}
         - name: dell-csi-replicator
-          image: {{ required "Must provide the Dell CSI Replicator image." .Values.images.replication }}
+          image: {{ required "Must provide the Dell CSI Replicator image." .Values.images.replication.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
@@ -348,7 +348,7 @@ spec:
         {{- if hasKey .Values.controller "healthMonitor" }}
         {{- if eq .Values.controller.healthMonitor.enabled true}}
         - name: csi-external-health-monitor-controller
-          image: {{ required "Must provide the CSI external health monitor controller image." .Values.images.healthmonitor }}
+          image: {{ required "Must provide the CSI external health monitor controller image." .Values.images.healthmonitor.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - "--v=5"
@@ -367,7 +367,7 @@ spec:
         {{- end }}
         {{- end }}
         - name: csi-metadata-retriever
-          image: {{ required "Must provide the CSI Metadata retriever container image." .Values.images.metadataretriever }}
+          image: {{ required "Must provide the CSI Metadata retriever container image." .Values.images.metadataretriever.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           command: [ "/csi-metadata-retriever" ]
           env:
@@ -382,7 +382,7 @@ spec:
             - name: socket-dir
               mountPath: /var/run/csi
         - name: driver
-          image: {{ required "Must provide the PowerStore driver image repository." .Values.images.driver }}
+          image: {{ required "Must provide the PowerStore driver image repository." .Values.images.driver.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           command: [ "/csi-powerstore" ]
           env:

--- a/charts/csi-powerstore/templates/node.yaml
+++ b/charts/csi-powerstore/templates/node.yaml
@@ -120,7 +120,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: {{ required "Must provide the podmon container image." .Values.images.podmon }}
+          image: {{ required "Must provide the podmon container image." .Values.images.podmon.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             {{- toYaml .Values.podmon.node.args | nindent 12 }}
@@ -173,7 +173,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: {{ required "Must provide the Powerstore driver image repository." .Values.images.driver }}
+          image: {{ required "Must provide the Powerstore driver image repository." .Values.images.driver.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           command: [ "/csi-powerstore" ]
           env:
@@ -266,7 +266,7 @@ spec:
             - name: powerstore-config-params
               mountPath: /powerstore-config-params
         - name: registrar
-          image: {{ required "Must provide the CSI node registrar container image." .Values.images.registrar }}
+          image: {{ required "Must provide the CSI node registrar container image." .Values.images.registrar.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - "--v=5"

--- a/charts/csi-powerstore/values.yaml
+++ b/charts/csi-powerstore/values.yaml
@@ -29,20 +29,31 @@ version: v2.11.0
 #  To use your own images, or a private registry, change the values here.
 images:
   # "driver" defines the container image, used for the driver container.
-  driver: dellemc/csi-powerstore:v2.11.0
+  driver:
+    image: dellemc/csi-powerstore:v2.11.0
   # CSI sidecars
-  attacher: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
-  provisioner: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1
-  snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1
-  resizer: registry.k8s.io/sig-storage/csi-resizer:v1.11.1
-  registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
-  healthmonitor: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.12.1
+  attacher:
+    image: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
+  provisioner:
+    image: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1
+  snapshotter:
+    image: registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1
+  resizer:
+    image: registry.k8s.io/sig-storage/csi-resizer:v1.11.1
+  registrar:
+    image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
+  healthmonitor:
+    image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.12.1
 
   # CSM sidecars
-  replication: dellemc/dell-csi-replicator:v1.9.0
-  vgsnapshotter: dellemc/csi-volumegroup-snapshotter:v1.6.0
-  podmon: dellemc/podmon:v1.10.0
-  metadataretriever: dellemc/csi-metadata-retriever:v1.8.0
+  replication:
+    image: dellemc/dell-csi-replicator:v1.9.0
+  vgsnapshotter:
+    image: dellemc/csi-volumegroup-snapshotter:v1.6.0
+  podmon:
+    image: dellemc/podmon:v1.10.0
+  metadataretriever:
+    image: dellemc/csi-metadata-retriever:v1.8.0
 
 # Specify kubelet config dir path.
 # Ensure that the config.yaml file is present at this path.


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

This PR includes a dependabot configuration file that instructs dependabot to look for version updates to container images in the following chart:

csi-powerstore

Tested by running `helm template --dependency-update charts/csi-powerstore` and manually inspecting the resulting yaml for proper image specifications.

#### Is this a new chart?

No

#### What this PR does / why we need it:

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1414

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
