### PR TITLE
Adding dependabot compatibility for csi-unity

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,7 +51,22 @@ updates:
       csi-vxflexos:
         patterns:
           - "*"
-
+  # csi-unity packages
+  - package-ecosystem: docker
+    target-branch: "release-v1.12.0"
+    directories:
+      - /charts/csi-unity
+    labels:
+      - dependencies
+    schedule:
+      # check daily
+      interval: daily
+      # at 6pm UTC
+      time: "18:00"
+    groups:
+      csi-unity:
+        patterns:
+          - "*"
   # csm-authorization packages
   - package-ecosystem: docker
     target-branch: "release-v1.12.0"

--- a/charts/csi-unity/templates/controller.yaml
+++ b/charts/csi-unity/templates/controller.yaml
@@ -154,7 +154,7 @@ spec:
 {{- if .Values.podmon.enabled }}
         - name: podmon
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          image: {{ required "Must provide the podmon container image." .Values.images.podmon }}
+          image: {{ required "Must provide the podmon container image." .Values.images.podmon.image }}
           args:
             {{- toYaml .Values.podmon.controller.args | nindent 12 }}
           env:
@@ -177,7 +177,7 @@ spec:
               mountPath: /unity-config
 {{- end }}
         - name: attacher
-          image: {{ required "Must provide the CSI attacher container image." .Values.images.attacher }}
+          image: {{ required "Must provide the CSI attacher container image." .Values.images.attacher.image }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -189,7 +189,7 @@ spec:
             - name: socket-dir
               mountPath: /var/run/csi
         - name: provisioner
-          image: {{ required "Must provide the CSI provisioner container image." .Values.images.provisioner }}
+          image: {{ required "Must provide the CSI provisioner container image." .Values.images.provisioner.image }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--volume-name-prefix={{ required "Must provide a Volume Name Prefix." .Values.controller.volumeNamePrefix }}"
@@ -222,7 +222,7 @@ spec:
         {{- if hasKey .Values.controller "snapshot" }}
         {{- if eq .Values.controller.snapshot.enabled true }}
         - name: snapshotter
-          image: {{ required "Must provide the CSI snapshotter container image. " .Values.images.snapshotter }}
+          image: {{ required "Must provide the CSI snapshotter container image. " .Values.images.snapshotter.image }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--snapshot-name-prefix={{ required "Must privided a Snapshot Name Prefix" .Values.controller.snapshot.snapNamePrefix }}"
@@ -241,7 +241,7 @@ spec:
         {{- if hasKey .Values.controller "resizer" }}
         {{- if eq .Values.controller.resizer.enabled true }}
         - name: resizer
-          image: {{ required "Must provide the CSI resizer container image." .Values.images.resizer }}
+          image: {{ required "Must provide the CSI resizer container image." .Values.images.resizer.image }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -257,7 +257,7 @@ spec:
         {{- if hasKey .Values.controller "healthMonitor" }}
         {{- if eq .Values.controller.healthMonitor.enabled true }}
         - name: csi-external-health-monitor-controller
-          image: {{ required "Must provide the CSI external health monitor image." .Values.images.healthmonitor }}
+          image: {{ required "Must provide the CSI external health monitor image." .Values.images.healthmonitor.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - "--v=5"
@@ -276,7 +276,7 @@ spec:
         {{- end }}
         {{- end }}
         - name: driver
-          image: "{{ required "Must provide the driver image repository." .Values.images.driver }}"
+          image: "{{ required "Must provide the driver image repository." .Values.images.driver.image }}"
           args:
             - "--driver-name=csi-unity.dellemc.com"
             - "--driver-config=/unity-config/driver-config-params.yaml"

--- a/charts/csi-unity/templates/node.yaml
+++ b/charts/csi-unity/templates/node.yaml
@@ -99,7 +99,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          image: {{ required "Must provide the podmon container image." .Values.images.podmon }}
+          image: {{ required "Must provide the podmon container image." .Values.images.podmon.image }}
           args:
           {{- toYaml .Values.podmon.node.args | nindent 12 }}
           env:
@@ -147,7 +147,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: "{{ required "Must provide the driver image repository." .Values.images.driver }}"
+          image: "{{ required "Must provide the driver image repository." .Values.images.driver.image }}"
           args:
             - "--driver-name=csi-unity.dellemc.com"
             - "--driver-config=/unity-config/driver-config-params.yaml"
@@ -208,7 +208,7 @@ spec:
             - name: unity-secret
               mountPath: /unity-secret
         - name: registrar
-          image: {{ required "Must provide the CSI registrar container image." .Values.images.registrar }}
+          image: {{ required "Must provide the CSI registrar container image." .Values.images.registrar.image }}
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/charts/csi-unity/values.yaml
+++ b/charts/csi-unity/values.yaml
@@ -8,17 +8,25 @@ version: "v2.12.0"
 
 images:
   # "driver" defines the container image, used for the driver container.
-  driver: dellemc/csi-unity:v2.12.0
+  driver:
+    image: dellemc/csi-unity:v2.12.0
   # CSI sidecars
-  attacher: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
-  provisioner: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1
-  snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1
-  resizer: registry.k8s.io/sig-storage/csi-resizer:v1.11.1
-  registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
-  healthmonitor: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.12.1
+  attacher: 
+    image: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
+  provisioner: 
+    image: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1
+  snapshotter: 
+    image: registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1
+  resizer: 
+    image: registry.k8s.io/sig-storage/csi-resizer:v1.11.1
+  registrar: 
+    image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
+  healthmonitor: 
+    image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.12.1
 
   # CSM sidecars
-  podmon: dellemc/podmon:v1.10.0
+  podmon: 
+    image: dellemc/podmon:v1.10.0
 
 # LogLevel is used to set the logging level of the driver.
 # Allowed values: "error", "warn"/"warning", "info", "debug"

--- a/charts/csi-unity/values.yaml
+++ b/charts/csi-unity/values.yaml
@@ -11,21 +11,21 @@ images:
   driver:
     image: dellemc/csi-unity:v2.12.0
   # CSI sidecars
-  attacher: 
+  attacher:
     image: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
-  provisioner: 
+  provisioner:
     image: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1
-  snapshotter: 
+  snapshotter:
     image: registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1
-  resizer: 
+  resizer:
     image: registry.k8s.io/sig-storage/csi-resizer:v1.11.1
-  registrar: 
+  registrar:
     image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
-  healthmonitor: 
+  healthmonitor:
     image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.12.1
 
   # CSM sidecars
-  podmon: 
+  podmon:
     image: dellemc/podmon:v1.10.0
 
 # LogLevel is used to set the logging level of the driver.


### PR DESCRIPTION
This PR includes a dependabot configuration file that instructs dependabot to look for version updates to container images in the following chart:

csi-unity

Tested by running helm template --dependency-update charts/csi-unity and manually inspecting the resulting yaml for proper image specifications.

Is this a new chart?
No

What this PR does / why we need it:
Which issue(s) is this PR associated with:
https://github.com/dell/csm/issues/1414
Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
