### PR TITLE
Adding dependabot compatibility for csi-unity

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,7 +68,22 @@ updates:
       csi-vxflexos:
         patterns:
           - "*"
-
+  # csi-unity packages
+  - package-ecosystem: docker
+    target-branch: "release-v1.12.0"
+    directories:
+      - /charts/csi-unity
+    labels:
+      - dependencies
+    schedule:
+      # check daily
+      interval: daily
+      # at 6pm UTC
+      time: "18:00"
+    groups:
+      csi-unity:
+        patterns:
+          - "*"
   # csm-authorization packages
   - package-ecosystem: docker
     target-branch: "release-v1.12.0"


### PR DESCRIPTION
Is this a new chart?
No

What this PR does / why we need it:
Update dependabot config to run against csi-unity chart.

Which issue(s) is this PR associated with:
https://github.com/dell/csm/issues/1414
Special notes for your reviewer:
#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
