### PR TITLE
[charts/csi-vxflexos] Add flag to enable or disable the SDC init container

### DIFF
--- a/charts/csi-vxflexos/templates/node.yaml
+++ b/charts/csi-vxflexos/templates/node.yaml
@@ -305,6 +305,7 @@ spec:
             - name: host-opt-emc-path
               mountPath: /host_opt_emc_path
         {{- end }}
+      {{- if and (hasKey .Values.node "sdc") (eq .Values.node.sdc.enabled true) }}
       initContainers:
         - name: sdc
           securityContext:
@@ -338,6 +339,7 @@ spec:
               mountPath: /rules.d
             - name: scaleio-path-opt
               mountPath: /host_drv_cfg_path
+      {{- end }}
       volumes:
         - name: registration-dir
           hostPath:

--- a/charts/csi-vxflexos/values.yaml
+++ b/charts/csi-vxflexos/values.yaml
@@ -259,6 +259,10 @@ node:
   #   operator: "Exists"
   #   effect: "NoSchedule"
 
+  sdc:
+    # enabled: Enable/Disable SDC
+    enabled: true
+
   # "renameSDC" defines the rename operation for SDC
   # Default value: None
   renameSDC:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Adds an option to disable installation of the SDC via the init-container.

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/663

#### Special notes for your reviewer:
Tested by installing the CSI PowerFlex driver without the SDC init-container. Confirmed that the SDC was not installed.

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] ~~Variables are documented in the chart README.md~~ No README for this chart
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
