### PR TITLE
[charts/csm-authorization-v2.0]: Add OTEL Collector address to storage-service and expose prometheus metrics

### DIFF
--- a/charts/csm-authorization-v2.0/templates/storage-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/storage-service.yaml
@@ -92,9 +92,12 @@ spec:
           - "--redis-sentinel={{ $str }}"
           - "--redis-password=$(REDIS_PASSWORD)"
           - "--leader-election=true"
+          - "--collector-address={{ .Values.authorization.openTelemetryCollectorAddress}}"
         ports:
         - containerPort: 50051
           name: grpc
+        - containerPort: 2112
+          name: promhttp
         volumeMounts:
         - name: config-volume
           mountPath: /etc/karavi-authorization/config
@@ -137,6 +140,9 @@ spec:
   - port: 50051
     targetPort: 50051
     name: grpc
+  - port: 2112
+    targetPort: 2112
+    name: promhttp
 ---
 {{- if .Values.vault.certificateAuthority }}
 {{- $certificateFileContents := .Values.vault.certificateAuthority }}

--- a/charts/csm-authorization-v2.0/values.yaml
+++ b/charts/csm-authorization-v2.0/values.yaml
@@ -45,6 +45,9 @@ authorization:
     # collectoruri: http://DNS-hostname:9411/api/v2/spans
     # probability: 1
 
+  # openTelemetryCollectorAddress: the OTLP receiving endpoint using gRPC
+  openTelemetryCollectorAddress: ""
+
   # proxy-server ingress configuration
   proxyServerIngress:
     ingressClassName: nginx


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

- Adds the `collector-address` argument to the storage-service to pass in the address of the OTLP gRPC receiver.
- Adds container port 2112 on the storage-service which handles [prometheus metrics](https://prometheus.io/docs/guides/go-application/)

#### Which issue(s) is this PR associated with:

https://github.com/dell/csm/issues/1281

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
