### PR TITLE
[charts/csi-vxflexos]: Enable SDC by default if not explicitly set

### DIFF
--- a/charts/csi-vxflexos/templates/node.yaml
+++ b/charts/csi-vxflexos/templates/node.yaml
@@ -305,7 +305,7 @@ spec:
             - name: host-opt-emc-path
               mountPath: /host_opt_emc_path
         {{- end }}
-      {{- if and (hasKey .Values.node "sdc") (eq .Values.node.sdc.enabled true) }}
+      {{- if or (not (hasKey (.Values.node.sdc) "enabled")) (eq .Values.node.sdc.enabled true) }}
       initContainers:
         - name: sdc
           securityContext:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
This PR fixes the issue when the sdc.enabled field does not exist in values.yaml. We should default the SDC install to true to remain backwards compatible.

The helm template condition is to install the SDC based on following: `If sdc.enabled field is missing or sdc.enabled=true`

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/663

#### Special notes for your reviewer:
Tested by installing the helm chart with a missing sdc.enabled field and by explicitly setting sdc.enabled to true and then false.

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
