### PR TITLE
[charts/csi-powermax]: Add dependabot compatibility for csi-powermax images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -84,6 +84,24 @@ updates:
       csi-unity:
         patterns:
           - "*"
+
+  # csi-powermax packages
+  - package-ecosystem: docker
+    target-branch: "release-v1.12.0"
+    directories:
+      - /charts/csi-powermax
+    labels:
+      - dependencies
+    schedule:
+      # check daily
+      interval: daily
+      # at 6pm UTC
+      time: "18:00"
+    groups:
+      csi-powermax:
+        patterns:
+          - "*"
+
   # csm-authorization packages
   - package-ecosystem: docker
     target-branch: "release-v1.12.0"

--- a/charts/csi-powermax/templates/controller.yaml
+++ b/charts/csi-powermax/templates/controller.yaml
@@ -183,7 +183,7 @@ spec:
         {{- if hasKey .Values "podmon" }}
         {{- if eq .Values.podmon.enabled true }}
         - name: podmon
-          image: {{ required "Must provide the podmon container image." .Values.images.podmon }}
+          image: {{ required "Must provide the podmon container image." .Values.images.podmon.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             {{- toYaml .Values.podmon.controller.args | nindent 12 }}
@@ -208,7 +208,7 @@ spec:
                 {{- end }}
                 {{- end }}
         - name: attacher
-          image: {{ required "Must provide the CSI attacher container image." .Values.images.attacher }}
+          image: {{ required "Must provide the CSI attacher container image." .Values.images.attacher.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
@@ -223,7 +223,7 @@ spec:
             - name: socket-dir
               mountPath: /var/run/csi
         - name: provisioner
-          image: {{ required "Must provide the CSI provisioner container image." .Values.images.provisioner }}
+          image: {{ required "Must provide the CSI provisioner container image." .Values.images.provisioner.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
@@ -256,7 +256,7 @@ spec:
         {{- if hasKey .Values.controller "snapshot" }}
         {{- if eq .Values.controller.snapshot.enabled true }}
         - name: snapshotter
-          image: {{ required "Must provide the CSI snapshotter container image." .Values.images.snapshotter }}
+          image: {{ required "Must provide the CSI snapshotter container image." .Values.images.snapshotter.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
@@ -275,7 +275,7 @@ spec:
         {{- end }}
         {{- if eq .Values.replication.enabled true}}
         - name: dell-csi-replicator
-          image: {{ required "Must provide the Dell CSI Replicator Resizer image." .Values.images.replication }}
+          image: {{ required "Must provide the Dell CSI Replicator Resizer image." .Values.images.replication.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
@@ -301,7 +301,7 @@ spec:
         {{- end }}
         {{- if eq .Values.migration.enabled true}}
         - name: dell-csi-migrator
-          image: {{ required "Must provide the Dell CSI Migrator Resizer image." .Values.images.migration }}
+          image: {{ required "Must provide the Dell CSI Migrator Resizer image." .Values.images.migration.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
@@ -327,7 +327,7 @@ spec:
         {{- if hasKey .Values.controller "resizer" }}
         {{- if eq .Values.controller.resizer.enabled true }}
         - name: resizer
-          image: {{ required "Must provide the CSI resizer container image." .Values.images.resizer }}
+          image: {{ required "Must provide the CSI resizer container image." .Values.images.resizer.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
@@ -346,7 +346,7 @@ spec:
         {{- if eq .Values.authorization.enabled true }}
         - name: karavi-authorization-proxy
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          image: {{ required "Must provide the authorization sidecar container image." .Values.images.authorization }}
+          image: {{ required "Must provide the authorization sidecar container image." .Values.images.authorization.image }}
           env:
             - name: PROXY_HOST
               value: "{{ .Values.authorization.proxyHost }}"
@@ -377,7 +377,7 @@ spec:
         {{- if eq .Values.controller.healthMonitor.enabled true }}
         - name: csi-external-health-monitor-controller
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          image: {{ required "Must provide the CSI external health monitor controller image." .Values.images.healthmonitor }}
+          image: {{ required "Must provide the CSI external health monitor controller image." .Values.images.healthmonitor.image }}
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -395,7 +395,7 @@ spec:
         {{- end }}
         {{- end }}
         - name: driver
-          image: {{ required "Must provide the PowerMax driver image repository." .Values.images.driver }}
+          image: {{ required "Must provide the PowerMax driver image repository." .Values.images.driver.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           command: [ "/csi-powermax.sh" ]
           env:
@@ -511,7 +511,7 @@ spec:
               mountPath: /powermax-config-params
         {{- if eq .Values.csireverseproxy.deployAsSidecar true }}
         - name: reverseproxy
-          image: {{ required "Must provided an image for reverseproxy container." .Values.images.csireverseproxy }}
+          image: {{ required "Must provided an image for reverseproxy container." .Values.images.csireverseproxy.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
             - name: X_CSI_REVPROXY_CONFIG_DIR

--- a/charts/csi-powermax/templates/node.yaml
+++ b/charts/csi-powermax/templates/node.yaml
@@ -135,7 +135,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: {{ required "Must provide the PowerMax driver image repository." .Values.images.driver }}
+          image: {{ required "Must provide the PowerMax driver image repository." .Values.images.driver.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           command: [ "/csi-powermax.sh" ]
           env:
@@ -291,7 +291,7 @@ spec:
             {{- end }}
             {{- end }}
         - name: registrar
-          image: {{ required "Must provide the CSI node registrar container image." .Values.images.registrar }}
+          image: {{ required "Must provide the CSI node registrar container image." .Values.images.registrar.image }}
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -321,7 +321,7 @@ spec:
               add: [ "SYS_ADMIN" ]
             allowPrivilegeEscalation: true
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          image: {{  required "Must provide the node rescanner sidecar container image." .Values.images.noderescan }}
+          image: {{  required "Must provide the node rescanner sidecar container image." .Values.images.noderescan.image }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--retry-interval-start=1s"
@@ -359,7 +359,7 @@ spec:
         {{- if eq .Values.authorization.enabled true }}
         - name: karavi-authorization-proxy
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          image: {{ required "Must provide the authorization sidecar container image." .Values.images.authorization }}
+          image: {{ required "Must provide the authorization sidecar container image." .Values.images.authorization.image }}
           env:
             - name: PROXY_HOST
               value: "{{ .Values.authorization.proxyHost }}"
@@ -394,7 +394,7 @@ spec:
             capabilities:
               add: [ "SYS_ADMIN" ]
             allowPrivilegeEscalation: true
-          image: {{ required "Must provide the podmon container image." .Values.images.podmon }}
+          image: {{ required "Must provide the podmon container image." .Values.images.podmon.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             {{- toYaml .Values.podmon.node.args | nindent 12 }}

--- a/charts/csi-powermax/values.yaml
+++ b/charts/csi-powermax/values.yaml
@@ -54,23 +54,36 @@ version: "v2.11.0"
 #  To use your own images, or a private registry, change the values here.
 images:
   # "driver" defines the container image, used for the driver container.
-  driver: dellemc/csi-powermax:v2.11.0
-  csireverseproxy: dellemc/csipowermax-reverseproxy:v2.10.0
+  driver:
+    image: dellemc/csi-powermax:v2.11.0
+  csireverseproxy:
+    image: dellemc/csipowermax-reverseproxy:v2.10.0
   # CSI sidecars
-  attacher: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
-  provisioner: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1
-  snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1
-  resizer: registry.k8s.io/sig-storage/csi-resizer:v1.11.1
-  registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
-  healthmonitor: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.12.1
+  attacher:
+    image: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
+  provisioner:
+    image: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1
+  snapshotter:
+    image: registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1
+  resizer:
+    image: registry.k8s.io/sig-storage/csi-resizer:v1.11.1
+  registrar:
+    image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
+  healthmonitor:
+    image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.12.1
   # CSM sidecars
-  replication: dellemc/dell-csi-replicator:v1.10.0
-  authorization: dellemc/csm-authorization-sidecar:v1.11.0
-  migration: dellemc/dell-csi-migrator:v1.5.0
-  podmon: dellemc/podmon:v1.11.0
+  replication:
+    image: dellemc/dell-csi-replicator:v1.10.0
+  authorization:
+    image: dellemc/csm-authorization-sidecar:v1.11.0
+  migration:
+    image: dellemc/dell-csi-migrator:v1.5.0
+  podmon:
+    image: dellemc/podmon:v1.11.0
   # Node rescan sidecar does a rescan on nodes for identifying new paths
   # Default value: dellemc/dell-csi-node-rescanner:v1.4.0
-  noderescan: dellemc/dell-csi-node-rescanner:v1.4.0
+  noderescan:
+    image: dellemc/dell-csi-node-rescanner:v1.4.0
 ## K8S/DRIVER ATTRIBUTES
 ########################
 # customDriverName: If enabled, sets the driver name to the


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

This PR includes a dependabot configuration file that instructs dependabot to look for version updates to container images in the following chart:

csi-powermax

Tested by running `helm template --dependency-update charts/csi-powermax` and manually inspecting the resulting yaml for proper image specifications.

#### Is this a new chart?

No

#### What this PR does / why we need it:

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1414

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
