### PR TITLE
Adding Interfaces for disabling SDC dependency on Powerflex NFS Volumes

### DIFF
--- a/charts/csi-vxflexos/templates/controller.yaml
+++ b/charts/csi-vxflexos/templates/controller.yaml
@@ -63,6 +63,9 @@ rules:
     verbs: ["get", "list", "watch"]
 {{- end }}
 {{- end }}
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "update"]
 # below for snapshotter
   - apiGroups: [""]
     resources: ["secrets"]

--- a/charts/csi-vxflexos/templates/driver-config-params.yaml
+++ b/charts/csi-vxflexos/templates/driver-config-params.yaml
@@ -13,3 +13,8 @@ data:
     PODMON_NODE_LOG_LEVEL: "{{ .Values.logLevel }}"
     PODMON_NODE_LOG_FORMAT: "{{ .Values.logFormat }}"
     {{ end }}
+    interfaceNames:
+      {{- range $node, $interfaces := .Values.interfaceNames}}
+      {{ $node }}: "{{ $interfaces }}"
+      {{- end }}
+

--- a/charts/csi-vxflexos/templates/driver-config-params.yaml
+++ b/charts/csi-vxflexos/templates/driver-config-params.yaml
@@ -14,7 +14,7 @@ data:
     PODMON_NODE_LOG_FORMAT: "{{ .Values.logFormat }}"
     {{ end }}
     interfaceNames:
-      {{- range $node, $interfaces := .Values.interfaceNames}}
+      {{- range $node, $interfaces := .Values.interfaceNames }}
       {{ $node }}: "{{ $interfaces }}"
       {{- end }}
 

--- a/charts/csi-vxflexos/templates/node.yaml
+++ b/charts/csi-vxflexos/templates/node.yaml
@@ -44,6 +44,9 @@ rules:
     verbs: ["get", "watch", "list", "delete", "update", "create"]
 {{ end }}
 {{ end }}
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "update"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/csi-vxflexos/values.yaml
+++ b/charts/csi-vxflexos/values.yaml
@@ -372,3 +372,7 @@ authorization:
   #   "false" - TLS certificate will be verified
   # Default value: "true"
   skipCertificateValidation: true
+
+interfaceNames:
+  # worker1: interface1
+  # worker2: interface2


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

- Permissions to perform get and update on the configMap to get the Interface IPs required for disabling the SDC dependency while provisioning NFS Volumes with PowerFlex

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/663

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable


#### How was this tested:
- [x] The ConfigMap is getting the right interfaceNames which is getting updated with the Network IPs.
- [x] Driver is getting installed successfully.
