### PR TITLE
[installation-wizard/container-storage-modules] Adding dependabot compatibility for installation-wizard charts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -173,3 +173,21 @@ updates:
       csm-installer:
         patterns:
           - "*"
+
+  # installation-wizard packages
+  - package-ecosystem: docker
+    target-branch: "release-v1.12.0"
+    directories:
+      - /installation-wizard/container-storage-modules
+    labels:
+      - dependencies
+    schedule:
+      # check daily
+      interval: daily
+      # at 6pm UTC
+      time: "18:00"
+    groups:
+      container-storage-modules:
+        patterns:
+          - "*"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -190,4 +190,3 @@ updates:
       container-storage-modules:
         patterns:
           - "*"
-

--- a/installation-wizard/container-storage-modules/values.yaml
+++ b/installation-wizard/container-storage-modules/values.yaml
@@ -23,30 +23,30 @@ csi-powerstore:
   version: "v2.12.0"
   images:
     # "driver" defines the container image, used for the driver container.
-    driver: 
+    driver:
       image: dellemc/csi-powerstore:v2.12.0
     # CSI sidecars
-    attacher: 
+    attacher:
       image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
-    provisioner: 
+    provisioner:
       image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
-    snapshotter: 
+    snapshotter:
       image: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
-    resizer: 
+    resizer:
       image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
-    registrar: 
+    registrar:
       image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
-    healthmonitor: 
+    healthmonitor:
       image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.13.0
 
     # CSM sidecars
-    replication: 
+    replication:
       image: dellemc/dell-csi-replicator:v1.10.0
-    vgsnapshotter: 
+    vgsnapshotter:
       image: dellemc/csi-volumegroup-snapshotter:v1.6.0
-    podmon: 
+    podmon:
       image: dellemc/podmon:v1.11.0
-    metadataretriever: 
+    metadataretriever:
       image: dellemc/csi-metadata-retriever:v1.8.0
   ## Controller ATTRIBUTES
   controller:
@@ -143,29 +143,29 @@ csi-powermax:
   version: "v2.12.0"
   images:
     # "driver" defines the container image, used for the driver container.
-    driver: 
+    driver:
       image: dellemc/csi-powermax:v2.12.0
-    csireverseproxy: 
+    csireverseproxy:
       image: dellemc/csipowermax-reverseproxy:v2.10.0
     # CSI sidecars
-    attacher: 
+    attacher:
       image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
-    provisioner: 
+    provisioner:
       image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
-    snapshotter: 
+    snapshotter:
       image: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
-    resizer: 
+    resizer:
       image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
-    registrar: 
+    registrar:
       image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
-    healthmonitor: 
+    healthmonitor:
       image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.13.0
     # CSM sidecars
-    replication: 
+    replication:
       image: dellemc/dell-csi-replicator:v1.10.0
-    authorization: 
+    authorization:
       image: dellemc/csm-authorization-sidecar:v1.11.0
-    migration: 
+    migration:
       image: dellemc/dell-csi-migrator:v1.5.0
     podmon:
       image: dellemc/podmon:v1.11.0
@@ -214,29 +214,29 @@ csi-isilon:
   version: "v2.12.0"
   images:
     # "driver" defines the container image, used for the driver container.
-    driver: 
+    driver:
       image: dellemc/csi-isilon:v2.12.0
     # CSI sidecars
-    attacher: 
+    attacher:
       image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
-    provisioner: 
+    provisioner:
       image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
-    snapshotter: 
+    snapshotter:
       image: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
-    resizer: 
+    resizer:
       image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
-    registrar: 
+    registrar:
       image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
-    healthmonitor: 
+    healthmonitor:
       image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.13.0
     # CSM sidecars
-    replication: 
+    replication:
       image: dellemc/dell-csi-replicator:v1.10.0
-    podmon: 
+    podmon:
       image: dellemc/podmon:v1.11.0
-    authorization: 
+    authorization:
       image: dellemc/csm-authorization-sidecar:v1.11.0
-    metadataretriever: 
+    metadataretriever:
       image: dellemc/csi-metadata-retriever:v1.8.0
   ## Controller ATTRIBUTES
   controller:
@@ -313,32 +313,32 @@ csi-vxflexos:
   version: v2.12.0
   images:
     # "driver" defines the container image, used for the driver container.
-    driver: 
+    driver:
       image: dellemc/csi-vxflexos:v2.12.0
     # "powerflexSdc" defines the SDC image for init container.
-    powerflexSdc: 
+    powerflexSdc:
       image: dellemc/sdc:4.5.2.1
     # CSI sidecars
-    attacher: 
+    attacher:
       image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
-    provisioner: 
+    provisioner:
       image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
-    snapshotter: 
+    snapshotter:
       image: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
-    resizer: 
+    resizer:
       image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
-    registrar: 
+    registrar:
       image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
-    healthmonitor: 
+    healthmonitor:
       image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.13.0
     # CSM sidecars
-    replication: 
+    replication:
       image: dellemc/dell-csi-replicator:v1.10.0
-    vgsnapshotter: 
+    vgsnapshotter:
       image: dellemc/csi-volumegroup-snapshotter:v1.6.0
-    podmon: 
+    podmon:
       image: dellemc/podmon:v1.11.0
-    authorization: 
+    authorization:
       image: dellemc/csm-authorization-sidecar:v1.11.0
   certSecretCount: 0
   controller:
@@ -427,20 +427,20 @@ csi-unity:
     driver:
       image: dellemc/csi-unity:v2.12.0
     # CSI sidecars
-    attacher: 
+    attacher:
       image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
-    provisioner: 
+    provisioner:
       image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
-    snapshotter: 
+    snapshotter:
       image: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
-    resizer: 
+    resizer:
       image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
-    registrar: 
+    registrar:
       image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
-    healthmonitor: 
+    healthmonitor:
       image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.13.0
     # CSM sidecars
-    podmon: 
+    podmon:
       image: dellemc/podmon:v1.11.0
   # certSecretCount: Represents number of certificate secrets, which user is going to create for
   # ssl authentication. (unity-cert-0..unity-cert-n)

--- a/installation-wizard/container-storage-modules/values.yaml
+++ b/installation-wizard/container-storage-modules/values.yaml
@@ -20,23 +20,34 @@
 ########################
 csi-powerstore:
   enabled: false
-  version: "v2.11.0"
+  version: "v2.12.0"
   images:
     # "driver" defines the container image, used for the driver container.
-    driver: dellemc/csi-powerstore:v2.11.0
+    driver: 
+      image: dellemc/csi-powerstore:v2.12.0
     # CSI sidecars
-    attacher: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
-    provisioner: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1
-    snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1
-    resizer: registry.k8s.io/sig-storage/csi-resizer:v1.11.1
-    registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
-    healthmonitor: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.12.1
+    attacher: 
+      image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
+    provisioner: 
+      image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+    snapshotter: 
+      image: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
+    resizer: 
+      image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
+    registrar: 
+      image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
+    healthmonitor: 
+      image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.13.0
 
     # CSM sidecars
-    replication: dellemc/dell-csi-replicator:v1.10.0
-    vgsnapshotter: dellemc/csi-volumegroup-snapshotter:v1.6.0
-    podmon: dellemc/podmon:v1.11.0
-    metadataretriever: dellemc/csi-metadata-retriever:v1.8.0
+    replication: 
+      image: dellemc/dell-csi-replicator:v1.10.0
+    vgsnapshotter: 
+      image: dellemc/csi-volumegroup-snapshotter:v1.6.0
+    podmon: 
+      image: dellemc/podmon:v1.11.0
+    metadataretriever: 
+      image: dellemc/csi-metadata-retriever:v1.8.0
   ## Controller ATTRIBUTES
   controller:
     controllerCount: 2
@@ -129,23 +140,39 @@ csi-powermax:
       - endpoint: https://backup-1.unisphe.re:8443
   #    - endpoint: https://primary-2.unisphe.re:8443
   #    - endpoint: https://backup-2.unisphe.re:8443
-  version: "v2.11.0"
+  version: "v2.12.0"
   images:
     # "driver" defines the container image, used for the driver container.
-    driver: dellemc/csi-powermax:v2.11.0
-    csireverseproxy: dellemc/csipowermax-reverseproxy:v2.10.0
+    driver: 
+      image: dellemc/csi-powermax:v2.12.0
+    csireverseproxy: 
+      image: dellemc/csipowermax-reverseproxy:v2.10.0
     # CSI sidecars
-    attacher: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
-    provisioner: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1
-    snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1
-    resizer: registry.k8s.io/sig-storage/csi-resizer:v1.11.1
-    registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
-    healthmonitor: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.12.1
+    attacher: 
+      image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
+    provisioner: 
+      image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+    snapshotter: 
+      image: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
+    resizer: 
+      image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
+    registrar: 
+      image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
+    healthmonitor: 
+      image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.13.0
     # CSM sidecars
-    replication: dellemc/dell-csi-replicator:v1.10.0
-    authorization: dellemc/csm-authorization-sidecar:v1.11.0
-    migration: dellemc/dell-csi-migrator:v1.5.0
-    noderescan: dellemc/dell-csi-node-rescanner:v1.4.0
+    replication: 
+      image: dellemc/dell-csi-replicator:v1.10.0
+    authorization: 
+      image: dellemc/csm-authorization-sidecar:v1.11.0
+    migration: 
+      image: dellemc/dell-csi-migrator:v1.5.0
+    podmon:
+      image: dellemc/podmon:v1.11.0
+    # Node rescan sidecar does a rescan on nodes for identifying new paths
+    # Default value: dellemc/dell-csi-node-rescanner:v1.4.0
+    noderescan:
+      image: dellemc/dell-csi-node-rescanner:v1.4.0
   clusterPrefix: ABC
   portGroups: PortGroup1, PortGroup2, PortGroup3
   controller:
@@ -184,22 +211,33 @@ csi-powermax:
 ########################
 csi-isilon:
   enabled: false
-  version: "v2.11.0"
+  version: "v2.12.0"
   images:
     # "driver" defines the container image, used for the driver container.
-    driver: dellemc/csi-isilon:v2.11.0
+    driver: 
+      image: dellemc/csi-isilon:v2.12.0
     # CSI sidecars
-    attacher: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
-    provisioner: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1
-    snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1
-    resizer: registry.k8s.io/sig-storage/csi-resizer:v1.11.1
-    registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
-    healthmonitor: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.12.1
+    attacher: 
+      image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
+    provisioner: 
+      image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+    snapshotter: 
+      image: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
+    resizer: 
+      image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
+    registrar: 
+      image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
+    healthmonitor: 
+      image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.13.0
     # CSM sidecars
-    replication: dellemc/dell-csi-replicator:v1.10.0
-    podmon: dellemc/podmon:v1.11.0
-    authorization: dellemc/csm-authorization-sidecar:v1.11.0
-    metadataretriever: dellemc/csi-metadata-retriever:v1.8.0
+    replication: 
+      image: dellemc/dell-csi-replicator:v1.10.0
+    podmon: 
+      image: dellemc/podmon:v1.11.0
+    authorization: 
+      image: dellemc/csm-authorization-sidecar:v1.11.0
+    metadataretriever: 
+      image: dellemc/csi-metadata-retriever:v1.8.0
   ## Controller ATTRIBUTES
   controller:
     controllerCount: 2
@@ -275,21 +313,33 @@ csi-vxflexos:
   version: v2.12.0
   images:
     # "driver" defines the container image, used for the driver container.
-    driver: dellemc/csi-vxflexos:v2.12.0
+    driver: 
+      image: dellemc/csi-vxflexos:v2.12.0
     # "powerflexSdc" defines the SDC image for init container.
-    powerflexSdc: dellemc/sdc:4.5.2.1
+    powerflexSdc: 
+      image: dellemc/sdc:4.5.2.1
     # CSI sidecars
-    attacher: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
-    provisioner: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1
-    snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1
-    resizer: registry.k8s.io/sig-storage/csi-resizer:v1.11.1
-    registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
-    healthmonitor: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.12.1
+    attacher: 
+      image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
+    provisioner: 
+      image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+    snapshotter: 
+      image: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
+    resizer: 
+      image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
+    registrar: 
+      image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
+    healthmonitor: 
+      image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.13.0
     # CSM sidecars
-    replication: dellemc/dell-csi-replicator:v1.10.0
-    vgsnapshotter: dellemc/csi-volumegroup-snapshotter:v1.6.0
-    podmon: dellemc/podmon:v1.11.0
-    authorization: dellemc/csm-authorization-sidecar:v1.11.0
+    replication: 
+      image: dellemc/dell-csi-replicator:v1.10.0
+    vgsnapshotter: 
+      image: dellemc/csi-volumegroup-snapshotter:v1.6.0
+    podmon: 
+      image: dellemc/podmon:v1.11.0
+    authorization: 
+      image: dellemc/csm-authorization-sidecar:v1.11.0
   certSecretCount: 0
   controller:
     replication:
@@ -374,16 +424,24 @@ csi-unity:
   version: "v2.12.0"
   images:
     # "driver" defines the container image, used for the driver container.
-    driver: dellemc/csi-unity:v2.12.0
+    driver:
+      image: dellemc/csi-unity:v2.12.0
     # CSI sidecars
-    attacher: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
-    provisioner: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1
-    snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1
-    resizer: registry.k8s.io/sig-storage/csi-resizer:v1.11.1
-    registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
-    healthmonitor: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.12.1
+    attacher: 
+      image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
+    provisioner: 
+      image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+    snapshotter: 
+      image: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
+    resizer: 
+      image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
+    registrar: 
+      image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
+    healthmonitor: 
+      image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.13.0
     # CSM sidecars
-    podmon: dellemc/podmon:v1.11.0
+    podmon: 
+      image: dellemc/podmon:v1.11.0
   # certSecretCount: Represents number of certificate secrets, which user is going to create for
   # ssl authentication. (unity-cert-0..unity-cert-n)
   # Allowed values: n, where n > 0


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

This PR includes a dependabot configuration file that instructs dependabot to look for version updates to container images in the following chart:

installation-wizard/container-storage-modules

Tested by generating the `values.yaml` file from the update format through `csm-docs/installation-wizard` and installing that with updated Charts pointing to the local charts for each dependency.

Note: The values.yaml file didn't need updating because it already used image as the value name

#### Is this a new chart?

No

#### What this PR does / why we need it:

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1414

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
