### PR TITLE
[installation-wizard/container-storage-modules] Adding dependabot compatibility for installation-wizard charts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -174,3 +174,20 @@ updates:
       csm-installer:
         patterns:
           - "*"
+
+  # installation-wizard packages
+  - package-ecosystem: docker
+    target-branch: "release-v1.12.0"
+    directories:
+      - /installation-wizard/container-storage-modules
+    labels:
+      - dependencies
+    schedule:
+      # check daily
+      interval: daily
+      # at 6pm UTC
+      time: "18:00"
+    groups:
+      container-storage-modules:
+        patterns:
+          - "*"


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

This PR includes a dependabot configuration file that instructs dependabot to look for version updates to container images in the following chart:

installation-wizard/container-storage-modules

Tested by generating the `values.yaml` file from the update format through `csm-docs/installation-wizard` and installing that with updated Charts pointing to the local charts for each dependency.

Note: The values.yaml file didn't need updating because it already used image as the value name

#### Is this a new chart?

No

#### What this PR does / why we need it:

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1414

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
