### PR TITLE
[charts/vxflexos] Fix privTgt mount is lost after vxflexos-node pod restart

### DIFF
--- a/charts/csi-vxflexos/templates/node.yaml
+++ b/charts/csi-vxflexos/templates/node.yaml
@@ -230,6 +230,9 @@ spec:
           volumeMounts:
             - name: driver-path
               mountPath: {{ .Values.kubeletConfigDir }}/plugins/vxflexos.emc.dell.com
+            - name: disks-path
+              mountPath: {{ .Values.kubeletConfigDir }}/plugins/vxflexos.emc.dell.com/disks
+              mountPropagation: "Bidirectional"
             - name: volumedevices-path
               mountPath: {{ .Values.kubeletConfigDir }}/plugins/kubernetes.io/csi/volumeDevices
               mountPropagation: "Bidirectional"
@@ -351,6 +354,10 @@ spec:
         - name: driver-path
           hostPath:
             path: {{ .Values.kubeletConfigDir }}/plugins/vxflexos.emc.dell.com
+            type: DirectoryOrCreate
+        - name: disks-path
+          hostPath:
+            path: {{ .Values.kubeletConfigDir }}/plugins/vxflexos.emc.dell.com/disks
             type: DirectoryOrCreate
         - name: volumedevices-path
           hostPath:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
This PR addresses the problem documented in issue 1546.

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1546

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
