### PR TITLE
[csi-powermax/node] Remove redundant volume mount from the pmax driver container

### DIFF
--- a/charts/csi-powermax/templates/node.yaml
+++ b/charts/csi-powermax/templates/node.yaml
@@ -261,9 +261,6 @@ spec:
             - name: volumedevices-path
               mountPath: {{ .Values.kubeletConfigDir }}/plugins/kubernetes.io/csi/volumeDevices
               mountPropagation: "Bidirectional"
-            - name: csi-path
-              mountPath: {{ .Values.kubeletConfigDir }}/plugins/kubernetes.io/csi
-              mountPropagation: "Bidirectional"
             - name: pods-path
               mountPath: {{ .Values.kubeletConfigDir }}/pods
               mountPropagation: "Bidirectional"


### PR DESCRIPTION
#### Is this a new chart?

No

#### What this PR does / why we need it:
Removes the duplicate mount which is not cleaned up on driver uninstall or pod restart. The issue is described in https://github.com/dell/csm/issues/1659.

#### Which issue(s) is this PR associated with:

- #[1659](https://github.com/dell/csm/issues/1659)

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [X] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable

#### Testing

- Ran multiple installation and uninstallation and validated that the problem mount is not there after install and uninstall.
- Ran cert-csi provisioning and volumeio tests to validate operation of the driver.
- Install resiliency which could have been impacted by the changes and Reiliency operation was not impacted.
