### PR TITLE
[csm-authorization] Update ClusterRole view name

### DIFF
--- a/charts/csm-authorization-v2.0/templates/proxy-server.yaml
+++ b/charts/csm-authorization-v2.0/templates/proxy-server.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: view
+  name:  csm-auth-view
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -15,7 +15,7 @@ metadata:
   name: opa-viewer
 roleRef:
   kind: ClusterRole
-  name: view
+  name:  csm-auth-view
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: Group

--- a/charts/csm-authorization/templates/proxy-server.yaml
+++ b/charts/csm-authorization/templates/proxy-server.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: view
+  name: csm-auth-view
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -15,7 +15,7 @@ metadata:
   name: opa-viewer
 roleRef:
   kind: ClusterRole
-  name: view
+  name:  csm-auth-view
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: Group


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
ClusterRole "view" already exists on K8s 1.31 cluster. This changes the name of the ClusterRole to not conflict with the existing resource.

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1662

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
