### PR TITLE
csi-vxflexos: Updated SDC images to quay.io

### DIFF
--- a/charts/csi-vxflexos/values.yaml
+++ b/charts/csi-vxflexos/values.yaml
@@ -14,7 +14,7 @@ images:
     image: quay.io/dell/container-storage-modules/csi-vxflexos:v2.13.0
   # "powerflexSdc" defines the SDC image for init container.
   powerflexSdc:
-    image: dellemc/sdc:4.5.2.1
+    image: quay.io/dell/storage/powerflex/sdc:4.5.2.1
   # CSI sidecars
   attacher:
     image: registry.k8s.io/sig-storage/csi-attacher:v4.8.0

--- a/installation-wizard/container-storage-modules/values.yaml
+++ b/installation-wizard/container-storage-modules/values.yaml
@@ -316,7 +316,7 @@ csi-vxflexos:
       image: quay.io/dell/container-storage-modules/csi-vxflexos:v2.13.0
     # "powerflexSdc" defines the SDC image for init container.
     powerflexSdc:
-      image: dellemc/sdc:4.5.2.1
+      image: quay.io/dell/storage/powerflex/sdc:4.5.2.1
     # CSI sidecars
     attacher:
       image: registry.k8s.io/sig-storage/csi-attacher:v4.8.0


### PR DESCRIPTION
#### Is this a new chart?

No

#### What this PR does / why we need it:

Images that pointed to dockerhub for the PowerFlex SDC have been updated to point to quay.io instead. 

#### Which issue(s) is this PR associated with:

N/A

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [X] ~~Chart Version bumped~~ (Version is already v2.13.0)
- [ ] ~~Variables are documented in the chart README.md~~ N/A
- [X] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
