### PR TITLE
charts/csi-powermax: Mount ConfigMap with log details to reverse proxy containers

### DIFF
--- a/charts/csi-powermax/charts/csireverseproxy/templates/reverseproxy.yaml
+++ b/charts/csi-powermax/charts/csireverseproxy/templates/reverseproxy.yaml
@@ -46,6 +46,8 @@ spec:
             - name: configmap-volume
               mountPath: /etc/config/configmap
               {{- end }}
+            - name: powermax-config-params
+              mountPath: /powermax-config-params
             - name: tls-secret
               mountPath: /app/tls
             - name: cert-dir
@@ -61,6 +63,9 @@ spec:
             name: {{ .Release.Name }}-reverseproxy-config
             optional: true
           {{- end }}
+        - name: powermax-config-params
+          configMap:
+            name: {{ .Release.Name }}-config-params
         - name: tls-secret
           secret:
             secretName: {{ .Values.tlsSecret }}

--- a/charts/csi-powermax/charts/csireverseproxy/templates/reverseproxy.yaml
+++ b/charts/csi-powermax/charts/csireverseproxy/templates/reverseproxy.yaml
@@ -42,12 +42,12 @@ spec:
               {{- if and (hasKey .Values.global "useSecret") (.Values.global.useSecret | default false) }}
             - name: powermax-reverseproxy-secret
               mountPath: /etc/powermax
+            - name: powermax-config-params
+              mountPath: /powermax-config-params
               {{- else }}
             - name: configmap-volume
               mountPath: /etc/config/configmap
               {{- end }}
-            - name: powermax-config-params
-              mountPath: /powermax-config-params
             - name: tls-secret
               mountPath: /app/tls
             - name: cert-dir
@@ -57,15 +57,15 @@ spec:
         - name: powermax-reverseproxy-secret
           secret:
             secretName: {{ required "Must provide defaultCredentialsSecret secret name." .Values.global.defaultCredentialsSecret }}
+        - name: powermax-config-params
+          configMap:
+            name: {{ .Release.Name }}-config-params
           {{- else }}
         - name: configmap-volume
           configMap:
             name: {{ .Release.Name }}-reverseproxy-config
             optional: true
           {{- end }}
-        - name: powermax-config-params
-          configMap:
-            name: {{ .Release.Name }}-config-params
         - name: tls-secret
           secret:
             secretName: {{ .Values.tlsSecret }}

--- a/charts/csi-powermax/templates/controller.yaml
+++ b/charts/csi-powermax/templates/controller.yaml
@@ -551,6 +551,8 @@ spec:
               {{- if and (hasKey .Values.global "useSecret") (.Values.global.useSecret | default false) }}
             - name: powermax-reverseproxy-secret
               mountPath: /etc/powermax
+            - name: powermax-config-params
+              mountPath: /powermax-config-params
               {{- else }}
             - name: configmap-volume
               mountPath: /etc/config/configmap


### PR DESCRIPTION
#### Is this a new chart?
No

#### What this PR does / why we need it:
These changes mount the existing `powermax-config-params` ConfigMap to the reverse proxy containers (for sidecar and stand-alone deployments) in order to provide global log configuration parameters to the reverse proxy when using the new secret format.

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1614

#### Special notes for your reviewer:
- Because the log parameters are already captured in the `powermax-config-params` ConfigMap, it will be mounted as a volume to the reverse proxy container. All of the volume configurations for the reverse proxy container match the existing configuration to containers that already utilize this ConfigMap.

#### Checklist:

- [ ] ~~Chart Version bumped~~
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable

#### Tests:
Using the latest images for the driver and reverse proxy, compiled from https://github.com/dell/csi-powermax/pull/418:
- **Validation:** Manually deployed with `global.useSecret: true` and checked the reverse proxy container directories for the mounted configmap contents in both stand-alone and sidecar reverse proxy modes.
- **Regression:** Manually deployed with `global.useSecret: false` and ran cert-csi volume-io tests for both stand-alone and sidecar reverse proxy modes.