### PR TITLE
charts/csi-powermax: Provide reverse proxy port info when using new secret mount.

### DIFF
--- a/charts/csi-powermax/charts/csireverseproxy/templates/reverseproxy.yaml
+++ b/charts/csi-powermax/charts/csireverseproxy/templates/reverseproxy.yaml
@@ -26,6 +26,8 @@ spec:
               {{- if $useRevProxySecret }}
             - name: X_CSI_REVPROXY_SECRET_FILEPATH
               value: "/etc/powermax/config"
+            - name: X_CSI_POWERMAX_CONFIG_PATH
+              value: "/powermax-config-params/driver-config-params.yaml"
               {{- else }}
             - name: X_CSI_REVPROXY_CONFIG_DIR
               value: /etc/config/configmap

--- a/charts/csi-powermax/templates/controller.yaml
+++ b/charts/csi-powermax/templates/controller.yaml
@@ -535,6 +535,8 @@ spec:
               {{- if $useRevProxySecret }}
             - name: X_CSI_REVPROXY_SECRET_FILEPATH
               value: "/etc/powermax/config"
+            - name: X_CSI_POWERMAX_CONFIG_PATH
+              value: "/powermax-config-params/driver-config-params.yaml"
               {{- else }}
             - name: X_CSI_REVPROXY_CONFIG_DIR
               value: /etc/config/configmap

--- a/charts/csi-powermax/templates/driver-config-params.yaml
+++ b/charts/csi-powermax/templates/driver-config-params.yaml
@@ -7,3 +7,6 @@ data:
   driver-config-params.yaml: |
     CSI_LOG_LEVEL: {{ .Values.global.logLevel | default "debug" }}
     CSI_LOG_FORMAT: {{ .Values.global.logFormat | default "TEXT" }}
+    {{- if and (hasKey .Values.global "useSecret") (.Values.global.useSecret | default false) }}
+    CSI_POWERMAX_REVERSE_PROXY_PORT: {{ .Values.csireverseproxy.port | default 2222 }}
+    {{- end }}


### PR DESCRIPTION
#### Is this a new chart?
No

#### What this PR does / why we need it:
These changes add the reverse proxy port to the existing `powermax-config-params` ConfigMap in order to provide the reverse proxy service port to the driver and proxy containers when using the new secret format.

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1614

#### Special notes for your reviewer:
- Updated reverse proxy container envs to provide the file path for the `powermax-config-params` ConfigMap.

#### Checklist:

- [ ] ~~Chart Version bumped~~
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable

#### Tests:
Using the latest images for the driver and reverse proxy, compiled from https://github.com/dell/csi-powermax/pull/418:
- **Validation:** Manually deployed with `global.useSecret: true` and checked the reverse proxy container directories for the mounted configmap contents in both stand-alone and sidecar reverse proxy modes.
- **Validation:** Manually deployed with `global.useSecret: true` and ran cert-csi volume-io tests for both stand-alone and sidecar reverse proxy modes.
- **Regression:** Manually deployed with `global.useSecret: false` and ran cert-csi volume-io tests for both stand-alone and sidecar reverse proxy modes.