### PR TITLE
charts/karavi-observability: Mount powermax-reverseproxy-secret to karavi container.

### DIFF
--- a/charts/karavi-observability/templates/karavi-metrics-powermax.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powermax.yaml
@@ -53,6 +53,11 @@ spec:
         image: {{ .Values.karaviMetricsPowermax.image }}
         resources: {}
         env:
+        {{- $useRevProxySecret := and (hasKey .Values.karaviMetricsPowermax "useSecret") (.Values.karaviMetricsPowermax.useSecret | default false) }}
+        - name: REVPROXY_USE_SECRET
+          value: {{ $useRevProxySecret | quote }}
+        - name: X_CSI_REVPROXY_SECRET_FILEPATH
+          value: "/etc/powermax/config"
         - name: POWERMAX_METRICS_ENDPOINT
           value: "{{ .Values.karaviMetricsPowermax.endpoint }}"
         - name: POWERMAX_METRICS_NAMESPACE
@@ -64,8 +69,13 @@ spec:
         - name: SSL_CERT_DIR
           value: /certs
         volumeMounts:
+            {{- if and (hasKey .Values.karaviMetricsPowermax "useSecret") (.Values.karaviMetricsPowermax.useSecret | default false) }}
+        - name: powermax-reverseproxy-secret
+          mountPath: /etc/powermax
+            {{- else }}
         - name: powermax-reverseproxy-config
           mountPath: /etc/reverseproxy
+            {{- end }}
         - name: tls-secret
           mountPath: /etc/ssl/certs
           readOnly: true
@@ -105,9 +115,15 @@ spec:
       {{ end }}
       {{ end }}
       volumes:
+          {{- if and (hasKey .Values.karaviMetricsPowermax "useSecret") (.Values.karaviMetricsPowermax.useSecret | default false) }}
+      - name: powermax-reverseproxy-secret
+        secret:
+          secretName: {{ required "Must provide defaultCredentialsSecret secret name." .Values.karaviMetricsPowermax.defaultCredentialsSecret }}
+          {{- else }}
       - name: powermax-reverseproxy-config
         configMap:
           name: powermax-reverseproxy-config
+          {{- end }}
       - name: tls-secret
         secret:
           secretName: otel-collector-tls

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -148,6 +148,8 @@ karaviMetricsPowermax:
   concurrentPowermaxQueries: 10
   # set the default endpoint for PowerMax service
   endpoint: karavi-metrics-powermax
+  useSecret: true
+  defaultCredentialsSecret: ""
   service:
     type: ClusterIP
   logLevel: INFO

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -148,7 +148,19 @@ karaviMetricsPowermax:
   concurrentPowermaxQueries: 10
   # set the default endpoint for PowerMax service
   endpoint: karavi-metrics-powermax
-  useSecret: true
+  # useSecret
+  # Defines if a Secret should be used to provide Unisphere for PowerMax endpoints
+  # and login credentials instead of the deprecated powermax-reverseproxy-config ConfigMap.
+  # If set to true, the contents of the secret specified by defaultCredentialsSecret
+  # will be used, in the new format, to specify Unisphere for PowerMax endpoints, array IDs,
+  # and login credentials. If set to false, the deprecated ConfigMap will be automatically
+  # created and used.
+  # Default value: false
+  useSecret: false
+  # defaultCredentialsSecret
+  # The name of the Kubernetes Secret containing the details of the PowerMax arrays,
+  # their Unisphere endpoints and their login credentials if useSecret is set to true.
+  # Default value: ""
   defaultCredentialsSecret: ""
   service:
     type: ClusterIP


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

The changes mount the `powermax-reverseproxy-secret` to the karavi-metrics container for the Observability module to read the configuration from the secret in case of useSecret is set to true. 

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1614

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
