### PR TITLE
charts/karavi-observability: update useSecret env var name

### DIFF
--- a/charts/karavi-observability/templates/karavi-metrics-powermax.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powermax.yaml
@@ -54,7 +54,7 @@ spec:
         resources: {}
         env:
         {{- $useRevProxySecret := and (hasKey .Values.karaviMetricsPowermax "useSecret") (.Values.karaviMetricsPowermax.useSecret | default false) }}
-        - name: REVPROXY_USE_SECRET
+        - name: X_CSI_REVPROXY_USE_SECRET
           value: {{ $useRevProxySecret | quote }}
         - name: X_CSI_REVPROXY_SECRET_FILEPATH
           value: "/etc/powermax/config"


### PR DESCRIPTION
#### Is this a new chart?

No

#### What this PR does / why we need it:
Update variable name used in observability to the same name used in csi-powermax.
This var determines whether or not to use the new secret format.

#### Which issue(s) is this PR associated with:

- #Issue_Number
https://github.com/dell/csm/issues/1614

#### Checklist:

- [ ] Chart Version bumped
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
