### PR TITLE
[charts/csi-powerflex] Resolve stale and duplicate disk mounts

### DIFF
--- a/charts/csi-vxflexos/templates/node.yaml
+++ b/charts/csi-vxflexos/templates/node.yaml
@@ -237,8 +237,9 @@ spec:
             - name: pods-path
               mountPath: {{ .Values.kubeletConfigDir }}/pods
               mountPropagation: "Bidirectional"
-            - name: noderoot
-              mountPath: /noderoot
+            - name: scaleio-path-bin
+              mountPath: /bin/emc/scaleio/
+              readOnly: true
             - name: dev
               mountPath: /dev
             - name: vxflexos-config
@@ -361,13 +362,13 @@ spec:
           hostPath:
             path: {{ .Values.kubeletConfigDir }}/pods
             type: Directory
-        - name: noderoot
-          hostPath:
-            path: /
-            type: Directory
         - name: dev
           hostPath:
             path: /dev
+            type: Directory
+        - name: scaleio-path-bin
+          hostPath:
+            path: /bin/emc/scaleio/
             type: Directory
         - name: scaleio-path-opt
           hostPath:

--- a/charts/csi-vxflexos/templates/node.yaml
+++ b/charts/csi-vxflexos/templates/node.yaml
@@ -230,8 +230,6 @@ spec:
           volumeMounts:
             - name: driver-path
               mountPath: {{ .Values.kubeletConfigDir }}/plugins/vxflexos.emc.dell.com
-            - name: disks-path
-              mountPath: {{ .Values.kubeletConfigDir }}/plugins/vxflexos.emc.dell.com/disks
               mountPropagation: "Bidirectional"
             - name: volumedevices-path
               mountPath: {{ .Values.kubeletConfigDir }}/plugins/kubernetes.io/csi/volumeDevices
@@ -354,10 +352,6 @@ spec:
         - name: driver-path
           hostPath:
             path: {{ .Values.kubeletConfigDir }}/plugins/vxflexos.emc.dell.com
-            type: DirectoryOrCreate
-        - name: disks-path
-          hostPath:
-            path: {{ .Values.kubeletConfigDir }}/plugins/vxflexos.emc.dell.com/disks
             type: DirectoryOrCreate
         - name: volumedevices-path
           hostPath:

--- a/charts/csi-vxflexos/templates/node.yaml
+++ b/charts/csi-vxflexos/templates/node.yaml
@@ -240,6 +240,9 @@ spec:
             - name: scaleio-path-bin
               mountPath: /bin/emc/scaleio/
               readOnly: true
+            - name: scaleio-path-opt
+              mountPath: /opt/emc/scaleio/sdc/bin/
+              readOnly: true
             - name: dev
               mountPath: /dev
             - name: vxflexos-config
@@ -369,7 +372,7 @@ spec:
         - name: scaleio-path-bin
           hostPath:
             path: /bin/emc/scaleio/
-            type: Directory
+            type: DirectoryOrCreate
         - name: scaleio-path-opt
           hostPath:
             path: /opt/emc/scaleio/sdc/bin


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

- Removes the `<KUBELET_CONFIG_DIR>/plugins/vxflexos.emc.dell.com/disks` volume mount to not cause duplicate mounts with the `<KUBELET_CONFIG_DIR>/plugins/vxflexos.emc.dell.com` mount
- Removes the `/noderoot` mount so that duplicate mounts are not under `/noderoot`
- Mounts `/bin/emc/scaleio/` and `/opt/emc/scaleio/sdc/bin/` for drv_cfg execution instead of the entire root filesystem

#### Which issue(s) is this PR associated with:

https://github.com/dell/csm/issues/1782

#### Special notes for your reviewer:

#### Checklist:

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
N/A
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
- [x] tested with cert-csi
[cert-csi.log](https://github.com/user-attachments/files/19169783/cert-csi.log)

