### PR TITLE
[charts/csi-powerflex] patch for /noderoot volume

### DIFF
--- a/charts/csi-vxflexos/templates/node.yaml
+++ b/charts/csi-vxflexos/templates/node.yaml
@@ -237,8 +237,12 @@ spec:
             - name: pods-path
               mountPath: {{ .Values.kubeletConfigDir }}/pods
               mountPropagation: "Bidirectional"
-            - name: noderoot
-              mountPath: /noderoot
+            - name: scaleio-path-bin
+              mountPath: /bin/emc/scaleio/
+              readOnly: true
+            - name: scaleio-path-opt
+              mountPath: /opt/emc/scaleio/sdc/bin/
+              readOnly: true
             - name: dev
               mountPath: /dev
             - name: vxflexos-config
@@ -361,14 +365,14 @@ spec:
           hostPath:
             path: {{ .Values.kubeletConfigDir }}/pods
             type: Directory
-        - name: noderoot
-          hostPath:
-            path: /
-            type: Directory
         - name: dev
           hostPath:
             path: /dev
             type: Directory
+        - name: scaleio-path-bin
+          hostPath:
+            path: /bin/emc/scaleio/
+            type: DirectoryOrCreate
         - name: scaleio-path-opt
           hostPath:
             path: /opt/emc/scaleio/sdc/bin


### PR DESCRIPTION
Cherry-picked fix for the /noderoot volume issue from PR #674.

<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

Yes/No

#### What this PR does / why we need it:

#### Which issue(s) is this PR associated with:

- #Issue_Number

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
