### PR TITLE
[charts/csi-vxflexos]: Fix SDC mount for OCP

### DIFF
--- a/charts/csi-vxflexos/templates/node.yaml
+++ b/charts/csi-vxflexos/templates/node.yaml
@@ -1,11 +1,5 @@
-{{- define "is_openshift" -}}
-{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints" -}}
-true
-{{- else -}}
-false
-{{- end -}}
-{{- end -}}
----
+{{- $is_openshift := .Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints" -}}
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -245,7 +239,7 @@ spec:
             - name: pods-path
               mountPath: {{ .Values.kubeletConfigDir }}/pods
               mountPropagation: "Bidirectional"
-            {{- if not (include "is_openshift" .) }}
+            {{- if not $is_openshift }}
             - name: scaleio-path-bin
               mountPath: /bin/emc/scaleio/
               readOnly: true
@@ -379,7 +373,7 @@ spec:
           hostPath:
             path: /dev
             type: Directory
-        {{- if not (include "is_openshift" .) }}
+        {{- if not $is_openshift }}
         - name: scaleio-path-bin
           hostPath:
             path: /bin/emc/scaleio/

--- a/charts/csi-vxflexos/templates/node.yaml
+++ b/charts/csi-vxflexos/templates/node.yaml
@@ -1,3 +1,11 @@
+{{- define "is_openshift" -}}
+{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints" -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -237,9 +245,11 @@ spec:
             - name: pods-path
               mountPath: {{ .Values.kubeletConfigDir }}/pods
               mountPropagation: "Bidirectional"
+            {{- if not (include "is_openshift" .) }}
             - name: scaleio-path-bin
               mountPath: /bin/emc/scaleio/
               readOnly: true
+            {{- end }}
             - name: scaleio-path-opt
               mountPath: /opt/emc/scaleio/sdc/bin/
               readOnly: true
@@ -369,10 +379,12 @@ spec:
           hostPath:
             path: /dev
             type: Directory
+        {{- if not (include "is_openshift" .) }}
         - name: scaleio-path-bin
           hostPath:
             path: /bin/emc/scaleio/
             type: DirectoryOrCreate
+        {{- end }}
         - name: scaleio-path-opt
           hostPath:
             path: /opt/emc/scaleio/sdc/bin


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
 
Don't mount `/bin/emc/scaleio/` into vxflexos-node for OCP.

#### Which issue(s) is this PR associated with:

https://github.com/dell/csm/issues/1811

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
