### PR TITLE
Make NFS exports path and ports configurable

### DIFF
--- a/charts/csi-powerstore/templates/controller.yaml
+++ b/charts/csi-powerstore/templates/controller.yaml
@@ -419,9 +419,9 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: X_CSI_NFS_CLIENT_PORT
-              value: "{{ .Values.node.nfsClientPort | default 2050 }}"
+              value: "{{ .Values.nfsClientPort }}"
             - name: X_CSI_NFS_SERVER_PORT
-              value: "{{ .Values.node.nfsServerPort | default 2049 }}"
+              value: "{{ .Values.nfsServerPort }}"
             {{- if hasKey .Values "podmon" }}
             - name: X_CSI_PODMON_ENABLED
               value: "{{ .Values.podmon.enabled }}"

--- a/charts/csi-powerstore/templates/controller.yaml
+++ b/charts/csi-powerstore/templates/controller.yaml
@@ -419,9 +419,9 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: X_CSI_NFS_CLIENT_PORT
-              value: "{{ .Values.nfsClientPort }}"
+              value: "{{ .Values.nfsClientPort | default 2050 }}"
             - name: X_CSI_NFS_SERVER_PORT
-              value: "{{ .Values.nfsServerPort }}"
+              value: "{{ .Values.nfsServerPort | default 2049 }}"
             {{- if hasKey .Values "podmon" }}
             - name: X_CSI_PODMON_ENABLED
               value: "{{ .Values.podmon.enabled }}"

--- a/charts/csi-powerstore/templates/controller.yaml
+++ b/charts/csi-powerstore/templates/controller.yaml
@@ -418,6 +418,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: X_CSI_NFS_CLIENT_PORT
+              value: "{{ .Values.node.nfsClientPort | default 2050 }}"
+            - name: X_CSI_NFS_SERVER_PORT
+              value: "{{ .Values.node.nfsServerPort | default 2049 }}"
             {{- if hasKey .Values "podmon" }}
             - name: X_CSI_PODMON_ENABLED
               value: "{{ .Values.podmon.enabled }}"

--- a/charts/csi-powerstore/templates/node.yaml
+++ b/charts/csi-powerstore/templates/node.yaml
@@ -213,11 +213,11 @@ spec:
             - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
               value: {{ .Values.nodeFCPortsFilterFile }}    
             - name: X_CSI_NFS_EXPORT_DIRECTORY
-              value: {{ .Values.node.nfsExportDirectory | default "/var/lib/dell/nfs" }}
+              value: {{ .Values.nfsExportDirectory | default "/var/lib/dell/nfs" }}
             - name: X_CSI_NFS_CLIENT_PORT
-              value: "{{ .Values.node.nfsClientPort | default 2050 }}"
+              value: "{{ .Values.nfsClientPort | default 2050 }}"
             - name: X_CSI_NFS_SERVER_PORT
-              value: "{{ .Values.node.nfsServerPort | default 2049 }}"
+              value: "{{ .Values.nfsServerPort | default 2049 }}"
             {{- if eq .Values.connection.enableCHAP  true }}
             - name: X_CSI_POWERSTORE_ENABLE_CHAP
               value: "true"

--- a/charts/csi-powerstore/templates/node.yaml
+++ b/charts/csi-powerstore/templates/node.yaml
@@ -211,7 +211,13 @@ spec:
             - name: X_CSI_DRIVER_NAME
               value: {{ .Values.driverName }}
             - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
-              value: {{ .Values.nodeFCPortsFilterFile }}
+              value: {{ .Values.nodeFCPortsFilterFile }}    
+            - name: X_CSI_NFS_EXPORT_DIRECTORY
+              value: {{ .Values.node.nfsExportDirectory | default "/var/lib/dell/nfs" }}
+            - name: X_CSI_NFS_CLIENT_PORT
+              value: "{{ .Values.node.nfsClientPort | default 2050 }}"
+            - name: X_CSI_NFS_SERVER_PORT
+              value: "{{ .Values.node.nfsServerPort | default 2049 }}"
             {{- if eq .Values.connection.enableCHAP  true }}
             - name: X_CSI_POWERSTORE_ENABLE_CHAP
               value: "true"
@@ -276,7 +282,7 @@ spec:
               mountPath: /powerstore-config-params
             # for csi-nfs
             - name: nfs-powerstore
-              mountPath: /var/lib/dell/nfs
+              mountPath: {{ .Values.node.nfsExportDirectory | default "/var/lib/dell/nfs"}}
               mountPropagation: "Bidirectional"
         - name: registrar
           image: {{ required "Must provide the CSI node registrar container image." .Values.images.registrar.image }}
@@ -302,7 +308,7 @@ spec:
         # for csi-nfs
         - name: nfs-powerstore
           hostPath:
-            path: /var/lib/dell/nfs
+            path: {{ .Values.node.nfsExportDirectory | default "/var/lib/dell/nfs"}}
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:

--- a/charts/csi-powerstore/values.yaml
+++ b/charts/csi-powerstore/values.yaml
@@ -30,8 +30,7 @@ version: v2.12.0
 images:
   # "driver" defines the container image, used for the driver container.
   driver:
-    #image: quay.io/dell/container-storage-modules/csi-powerstore:v2.12.0
-    image: csm.artifactory.cec.lab.emc.com/csm-users/sreekb/csi-powerstore:sreekb-v1
+    image: quay.io/dell/container-storage-modules/csi-powerstore:v2.12.0
   # CSI sidecars
   attacher:
     image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
@@ -105,6 +104,24 @@ maxPowerstoreVolumesPerNode: 0
 # Optional: true
 # Default value: "0777"
 nfsAcls: "0777"
+
+# nfsExportDirectory: Define mount path for host based nfs volumes
+# Define this only during deployment time, DO NOT change afterwards
+# Allowed values:
+# Default value: /var/lib/dell/nfs
+nfsExportDirectory: /var/lib/dell/nfs
+
+# nfsServerPort: Define port for nfs server
+# By default nfs server port is 2049. This value should match what port the nfs-server is configured on. 
+# /etc/nfs.conf contains the port information. If none is specified in that file, then it is 2049.
+# Allowed values:  Any valid and free port.
+# Default value: 2049
+nfsServerPort: 2049
+
+# nfsClientPort: Define port for nfs client(used in hostbased nfs)
+# Allowed values:  Any valid and free port.
+# Default value: 2050
+nfsClientPort: 2050
 
 # podmonAPIPort: Defines the port to be used within the kubernetes cluster
 # Allowed values:
@@ -292,24 +309,7 @@ node:
   #  - key: "powerstore.podmon.storage.dell.com"
   #    operator: "Exists"
   #    effect: "NoSchedule"
-
-  # nfsExportDirectory: Define mount path for host based nfs volumes 
-  # Define this only during deployment time, DO NOT change afterwards
-  # Allowed values: 
-  # Default value: /var/lib/dell/nfs
-  nfsExportDirectory: /var/lib/dell/nfs
-
-  # nfsServerPort: Define port for nfs server (used for hostbased nfs volumes)
-  # Allowed values:  Any valid and free port.
-  # Default value: 2049
-  nfsServerPort: 2049
-
-  # nfsClientPort: Define port for nfs client
-  # Allowed values:  Any valid and free port.
-  # Default value: 2050
-  nfsclientPort: 2050
-
-
+  #
 ## PLATFORM ATTRIBUTES
 ######################
 

--- a/charts/csi-powerstore/values.yaml
+++ b/charts/csi-powerstore/values.yaml
@@ -30,7 +30,8 @@ version: v2.12.0
 images:
   # "driver" defines the container image, used for the driver container.
   driver:
-    image: quay.io/dell/container-storage-modules/csi-powerstore:v2.12.0
+    #image: quay.io/dell/container-storage-modules/csi-powerstore:v2.12.0
+    image: csm.artifactory.cec.lab.emc.com/csm-users/sreekb/csi-powerstore:sreekb-v1
   # CSI sidecars
   attacher:
     image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
@@ -81,7 +82,7 @@ externalAccess:
 #  IfNotPresent: Only pull the image if it does not already exist on the node.
 #  Never: Never pull the image.
 # Default value: None
-imagePullPolicy: IfNotPresent
+imagePullPolicy: Always
 
 # maxPowerstoreVolumesPerNode: Specify default value for maximum number of volumes that controller can publish to the node.
 # If value is zero CO SHALL decide how many volumes of this type can be published by the controller to the node.
@@ -117,7 +118,7 @@ controller:
   # the Kubernetes release.
   # Allowed values: n, where n > 0
   # Default value: None
-  controllerCount: 2
+  controllerCount: 1
 
   # volumeNamePrefix: defines a string prepended to each volume created by the CSI driver.
   # Allowed values: string
@@ -291,6 +292,23 @@ node:
   #  - key: "powerstore.podmon.storage.dell.com"
   #    operator: "Exists"
   #    effect: "NoSchedule"
+
+  # nfsExportDirectory: Define mount path for host based nfs volumes 
+  # Define this only during deployment time, DO NOT change afterwards
+  # Allowed values: 
+  # Default value: /var/lib/dell/nfs
+  nfsExportDirectory: /var/lib/dell/nfs
+
+  # nfsServerPort: Define port for nfs server (used for hostbased nfs volumes)
+  # Allowed values:  Any valid and free port.
+  # Default value: 2049
+  nfsServerPort: 2049
+
+  # nfsClientPort: Define port for nfs client
+  # Allowed values:  Any valid and free port.
+  # Default value: 2050
+  nfsclientPort: 2050
+
 
 ## PLATFORM ATTRIBUTES
 ######################

--- a/charts/csi-powerstore/values.yaml
+++ b/charts/csi-powerstore/values.yaml
@@ -81,7 +81,7 @@ externalAccess:
 #  IfNotPresent: Only pull the image if it does not already exist on the node.
 #  Never: Never pull the image.
 # Default value: None
-imagePullPolicy: Always
+imagePullPolicy: IfNotPresent
 
 # maxPowerstoreVolumesPerNode: Specify default value for maximum number of volumes that controller can publish to the node.
 # If value is zero CO SHALL decide how many volumes of this type can be published by the controller to the node.
@@ -135,7 +135,7 @@ controller:
   # the Kubernetes release.
   # Allowed values: n, where n > 0
   # Default value: None
-  controllerCount: 1
+  controllerCount: 2
 
   # volumeNamePrefix: defines a string prepended to each volume created by the CSI driver.
   # Allowed values: string


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
PR adds flexibility to allow users to specify a port for their NFS traffic for host based NFS volumes (both server and client side ports). It also adds flexibility to allow users to specify export path for host based NFS volumes. If none specified, it defaults to a default value. 

#### Which issue(s) is this PR associated with:

- #Issue_Number
[https://github.com/https://github.com/dell/csm/issues/1742]

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [x] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
