### PR TITLE
[charts/csi-powerstore] Adding Host Based NFS for Powerstore

### DIFF
--- a/charts/csi-powerstore/templates/controller.yaml
+++ b/charts/csi-powerstore/templates/controller.yaml
@@ -447,6 +447,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: X_CSI_NFS_CLIENT_PORT
+              value: "{{ .Values.nfsClientPort | default 2050 }}"
+            - name: X_CSI_NFS_SERVER_PORT
+              value: "{{ .Values.nfsServerPort | default 2049 }}"
             {{- if hasKey .Values "podmon" }}
             - name: X_CSI_PODMON_ENABLED
               value: "{{ .Values.podmon.enabled }}"

--- a/charts/csi-powerstore/templates/controller.yaml
+++ b/charts/csi-powerstore/templates/controller.yaml
@@ -124,9 +124,6 @@ rules:
     resources: [ "csistoragecapacities" ]
     verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
   {{- end }}
-<<<<<<< HEAD
-
-=======
   # for csi-nfs
   - apiGroups: ["discovery.k8s.io"]
     resources: ["endpointslices"]
@@ -134,7 +131,6 @@ rules:
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]
->>>>>>> 0ff8068 (csi-nfs changes)
 ---
 
 kind: ClusterRoleBinding

--- a/charts/csi-powerstore/templates/controller.yaml
+++ b/charts/csi-powerstore/templates/controller.yaml
@@ -447,6 +447,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: X_CSI_NFS_EXPORT_DIRECTORY
+              value: {{ .Values.nfsExportDirectory | default "/var/lib/dell/nfs" }}
             - name: X_CSI_NFS_CLIENT_PORT
               value: "{{ .Values.nfsClientPort | default 2050 }}"
             - name: X_CSI_NFS_SERVER_PORT

--- a/charts/csi-powerstore/templates/controller.yaml
+++ b/charts/csi-powerstore/templates/controller.yaml
@@ -124,7 +124,17 @@ rules:
     resources: [ "csistoragecapacities" ]
     verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
   {{- end }}
+<<<<<<< HEAD
 
+=======
+  # for csi-nfs
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]
+>>>>>>> 0ff8068 (csi-nfs changes)
 ---
 
 kind: ClusterRoleBinding
@@ -433,6 +443,10 @@ spec:
               value: /powerstore-config/config
             - name: X_CSI_POWERSTORE_CONFIG_PARAMS_PATH
               value: /powerstore-config-params/driver-config-params.yaml
+            - name: X_CSI_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             {{- if hasKey .Values "podmon" }}
             - name: X_CSI_PODMON_ENABLED
               value: "{{ .Values.podmon.enabled }}"

--- a/charts/csi-powerstore/templates/node.yaml
+++ b/charts/csi-powerstore/templates/node.yaml
@@ -301,7 +301,7 @@ spec:
               mountPath: /powerstore-config-params
             # for csi-nfs
             - name: nfs-powerstore
-              mountPath: {{ .Values.node.nfsExportDirectory | default "/var/lib/dell/nfs"}}
+              mountPath: {{ .Values.nfsExportDirectory | default "/var/lib/dell/nfs"}}
               mountPropagation: "Bidirectional"
         - name: registrar
           image: {{ required "Must provide the CSI node registrar container image." .Values.images.registrar.image }}
@@ -327,7 +327,7 @@ spec:
         # for csi-nfs
         - name: nfs-powerstore
           hostPath:
-            path: {{ .Values.node.nfsExportDirectory | default "/var/lib/dell/nfs"}}
+            path: {{ .Values.nfsExportDirectory | default "/var/lib/dell/nfs"}}
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:

--- a/charts/csi-powerstore/templates/node.yaml
+++ b/charts/csi-powerstore/templates/node.yaml
@@ -295,7 +295,7 @@ spec:
               mountPath: /powerstore-config-params
             # for csi-nfs
             - name: nfs-powerstore
-              mountPath: /nfs/powerstore
+              mountPath: /var/lib/dell/nfs
               mountPropagation: "Bidirectional"
         - name: registrar
           image: {{ required "Must provide the CSI node registrar container image." .Values.images.registrar.image }}
@@ -321,7 +321,7 @@ spec:
         # for csi-nfs
         - name: nfs-powerstore
           hostPath:
-            path: /nfs/powerstore
+            path: /var/lib/dell/nfs
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:

--- a/charts/csi-powerstore/templates/node.yaml
+++ b/charts/csi-powerstore/templates/node.yaml
@@ -230,7 +230,13 @@ spec:
             - name: X_CSI_DRIVER_NAME
               value: {{ .Values.driverName }}
             - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
-              value: {{ .Values.nodeFCPortsFilterFile }}
+              value: {{ .Values.nodeFCPortsFilterFile }}    
+            - name: X_CSI_NFS_EXPORT_DIRECTORY
+              value: {{ .Values.nfsExportDirectory | default "/var/lib/dell/nfs" }}
+            - name: X_CSI_NFS_CLIENT_PORT
+              value: "{{ .Values.nfsClientPort | default 2050 }}"
+            - name: X_CSI_NFS_SERVER_PORT
+              value: "{{ .Values.nfsServerPort | default 2049 }}"
             {{- if eq .Values.connection.enableCHAP  true }}
             - name: X_CSI_POWERSTORE_ENABLE_CHAP
               value: "true"
@@ -295,7 +301,7 @@ spec:
               mountPath: /powerstore-config-params
             # for csi-nfs
             - name: nfs-powerstore
-              mountPath: /var/lib/dell/nfs
+              mountPath: {{ .Values.node.nfsExportDirectory | default "/var/lib/dell/nfs"}}
               mountPropagation: "Bidirectional"
         - name: registrar
           image: {{ required "Must provide the CSI node registrar container image." .Values.images.registrar.image }}
@@ -321,7 +327,7 @@ spec:
         # for csi-nfs
         - name: nfs-powerstore
           hostPath:
-            path: /var/lib/dell/nfs
+            path: {{ .Values.node.nfsExportDirectory | default "/var/lib/dell/nfs"}}
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:

--- a/charts/csi-powerstore/templates/node.yaml
+++ b/charts/csi-powerstore/templates/node.yaml
@@ -46,6 +46,13 @@ rules:
     resourceNames: ["privileged"]
     resources: ["securitycontextconstraints"]
     verbs: ["use"]
+  # for csi-nfs
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]
   {{- if hasKey .Values "podmon" }}
   {{- if eq .Values.podmon.enabled true }}
   - apiGroups: [""]
@@ -257,6 +264,8 @@ spec:
             {{- end }}
             - name: X_CSI_PODMON_API_PORT
               value: "{{ .Values.podmonAPIPort }}"
+          ports:
+            - containerPort: 2050
           volumeMounts:
             - name: driver-path
               mountPath: {{ .Values.kubeletConfigDir }}/plugins/{{ .Values.driverName }}
@@ -284,6 +293,10 @@ spec:
               mountPath: /powerstore-config
             - name: powerstore-config-params
               mountPath: /powerstore-config-params
+            # for csi-nfs
+            - name: nfs-powerstore
+              mountPath: /nfs/powerstore
+              mountPropagation: "Bidirectional"
         - name: registrar
           image: {{ required "Must provide the CSI node registrar container image." .Values.images.registrar.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -305,6 +318,11 @@ spec:
             - name: driver-path
               mountPath: /csi
       volumes:
+        # for csi-nfs
+        - name: nfs-powerstore
+          hostPath:
+            path: /nfs/powerstore
+            type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
             path: {{ .Values.kubeletConfigDir }}/plugins_registry/

--- a/charts/csi-powerstore/values.yaml
+++ b/charts/csi-powerstore/values.yaml
@@ -105,6 +105,24 @@ maxPowerstoreVolumesPerNode: 0
 # Default value: "0777"
 nfsAcls: "0777"
 
+# nfsExportDirectory: Define mount path for host based nfs volumes
+# Define this only during deployment time, DO NOT change afterwards
+# Allowed values:
+# Default value: /var/lib/dell/nfs
+nfsExportDirectory: /var/lib/dell/nfs
+
+# nfsServerPort: Define port for nfs server
+# By default nfs server port is 2049. This value should match what port the nfs-server is configured on. 
+# /etc/nfs.conf contains the port information. If none is specified in that file, then it is 2049.
+# Allowed values:  Any valid and free port.
+# Default value: 2049
+nfsServerPort: 2049
+
+# nfsClientPort: Define port for nfs client(used in hostbased nfs)
+# Allowed values:  Any valid and free port.
+# Default value: 2050
+nfsClientPort: 2050
+
 # podmonAPIPort: Defines the port to be used within the kubernetes cluster
 # Allowed values:
 #   Any valid and free port.
@@ -291,7 +309,7 @@ node:
   #  - key: "powerstore.podmon.storage.dell.com"
   #    operator: "Exists"
   #    effect: "NoSchedule"
-
+  #
 ## PLATFORM ATTRIBUTES
 ######################
 

--- a/charts/csi-powerstore/values.yaml
+++ b/charts/csi-powerstore/values.yaml
@@ -112,7 +112,7 @@ nfsAcls: "0777"
 nfsExportDirectory: /var/lib/dell/nfs
 
 # nfsServerPort: Define port for nfs server
-# By default nfs server port is 2049. This value should match what port the nfs-server is configured on. 
+# By default nfs server port is 2049. This value should match what port the nfs-server is configured on.
 # /etc/nfs.conf contains the port information. If none is specified in that file, then it is 2049.
 # Allowed values:  Any valid and free port.
 # Default value: 2049
@@ -309,7 +309,7 @@ node:
   #  - key: "powerstore.podmon.storage.dell.com"
   #    operator: "Exists"
   #    effect: "NoSchedule"
-  #
+
 ## PLATFORM ATTRIBUTES
 ######################
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Add HBNFS support for PowerStore. This introduces the necessary RBAC for PowerStore which are needed for HBNFS. Also, it makes it so that all NFS parameters are configurable based on the desired setup.

#### Which issue(s) is this PR associated with:

- #Issue_Number
https://github.com/dell/csm/issues/1742
#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
