### PR TITLE
Revert "[charts/csi-powerstore]: Updating RBAC rules in csi-powerstore"

### DIFF
--- a/charts/csi-powerstore/templates/controller.yaml
+++ b/charts/csi-powerstore/templates/controller.yaml
@@ -21,15 +21,18 @@ metadata:
   namespace: {{ .Release.Namespace }}
 
 ---
-# ClusterRole for Cluster-specific Permissions
+
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-controller
 rules:
-  - apiGroups: [ "" ]
-    resources: [ "events" ]
-    verbs: [ "list", "watch", "create", "update", "patch" ]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
   - apiGroups: [""]
     resources: ["nodes"]
   {{- if hasKey .Values "podmon" }}
@@ -39,28 +42,31 @@ rules:
     verbs: ["get", "list", "watch"]
   {{- end }}
   {{- end }}
-  - apiGroups: [ "" ]
-    resources: [ "persistentvolumes" ]
-    verbs: [ "get", "list", "watch", "create", "delete", "patch" ]
-  - apiGroups: [ "" ]
-    resources: [ "persistentvolumeclaims" ]
-    verbs: [ "get", "list", "watch", "update" ]
-  - apiGroups: [ "storage.k8s.io" ]
-    resources: [ "storageclasses" ]
-    verbs: [ "get", "list", "watch" ]
-  - apiGroups: [ "storage.k8s.io" ]
-    resources: [ "volumeattachments" ]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
   {{- if hasKey .Values "podmon" }}
   {{- if eq .Values.podmon.enabled true }}
-    verbs: ["get", "list", "watch", "patch", "delete"]
+    verbs: ["get", "list", "watch", "update", "patch", "delete"]
   {{- else }}
-    verbs: ["get", "list", "watch", "patch"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   {{- end }}
   {{- end }}
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
   {{- if hasKey .Values.controller "vgsnapshot" }}
   {{- if eq .Values.controller.vgsnapshot.enabled true }}
   - apiGroups: ["volumegroup.storage.dell.com"]
-    resources: ["dellcsivolumegroupsnapshots", "dellcsivolumegroupsnapshots/status"]
+    resources: ["dellcsivolumegroupsnapshots","dellcsivolumegroupsnapshots/status"]
     verbs: ["create", "list", "watch", "delete", "update"]
   {{- end }}
   {{- end }}
@@ -69,7 +75,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["get", "list", "watch", "patch"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update", "patch"]
@@ -79,19 +85,19 @@ rules:
   {{- if eq .Values.controller.vgsnapshot.enabled true }}
     verbs: ["get", "list", "watch", "update", "create", "delete"]
   {{- else }}
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch", "update"]
   {{- end }}
   {{- end }}
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments/status"]
-    verbs: ["patch"]          
-  - apiGroups: [ "" ]
-    resources: [ "pods" ]
-  {{- if hasKey .Values "podmon" }}    
-  {{- if .Values.podmon.enabled }}
-    verbs: [ "get", "list", "watch", "delete" ]
+    verbs: ["patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+  {{- if hasKey .Values "podmon" }}
+  {{- if eq .Values.podmon.enabled true }}
+    verbs: ["get", "list", "watch", "update", "delete"]
   {{- else }}
-    verbs: [ "get", "list", "watch" ]
+    verbs: ["get", "list", "watch"]
   {{- end }}
   {{- end }}
   - apiGroups: ["apiextensions.k8s.io"]
@@ -103,7 +109,7 @@ rules:
   # below for resizer
   - apiGroups: [""]
     resources: ["persistentvolumeclaims/status"]
-    verbs: ["patch"]
+    verbs: ["update", "patch"]
   # below for dell-csi-replicator
   {{- if hasKey .Values.controller "replication" }}
   {{- if eq .Values.controller.replication.enabled true}}
@@ -120,11 +126,16 @@ rules:
   {{- end}}
   # Permissions for CSIStorageCapacity
   {{- if eq (include "csi-powerstore.isStorageCapacitySupported" .) "true" }}
-  - apiGroups: [ "storage.k8s.io" ]
-    resources: [ "csistoragecapacities" ]
-    verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csistoragecapacities"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
   {{- end }}
-
 ---
 
 kind: ClusterRoleBinding
@@ -140,43 +151,6 @@ roleRef:
   name: {{ .Release.Name }}-controller
   apiGroup: rbac.authorization.k8s.io
 
----
-
-# Role for Driver-specific Permissions in a Namespace
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ .Release.Name }}-controller
-  namespace: {{ .Release.Namespace }}
-rules:
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["update", "patch"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
-  - apiGroups: ["apps"]
-    resources: ["replicasets"]
-    verbs: ["get"]
-
----
-# RoleBinding for Driver-specific Role
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ .Release.Name }}-controller
-  namespace: {{ .Release.Namespace }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Release.Name }}-controller
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: Role
-  name: {{ .Release.Name }}-controller
-  apiGroup: rbac.authorization.k8s.io
 ---
 
 kind: Deployment

--- a/charts/csi-powerstore/templates/node.yaml
+++ b/charts/csi-powerstore/templates/node.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 
 ---
-# ClusterRole for Cluster-specific Permissions
+
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -29,19 +29,25 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["create", "delete", "get", "list", "watch"]
-  - apiGroups: [ "" ]
-    resources: [ "persistentvolumeclaims" ]
-    verbs: [ "get", "list", "watch", "update" ]
+    verbs: ["create", "delete", "get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumesclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["security.openshift.io"]
     resourceNames: ["privileged"]
     resources: ["securitycontextconstraints"]
@@ -50,11 +56,15 @@ rules:
   {{- if eq .Values.podmon.enabled true }}
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update", "delete"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
   {{ end }}
-  {{ end }}    
+  {{ end }}
+
 ---
-# ClusterRoleBinding for Cluster-specific
+
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -69,36 +79,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 
 ---
-{{- if hasKey .Values "podmon" }}
-{{- if eq .Values.podmon.enabled true }}
-# RoleBinding for Driver-specific Role
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ .Release.Name }}-node
-  namespace: {{ .Release.Namespace }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Release.Name }}-node
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: Role
-  name: {{ .Release.Name }}-node
-  apiGroup: rbac.authorization.k8s.io
----
-# Role for Driver-specific Permissions in a Namespace
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ .Release.Name }}-node
-  namespace: {{ .Release.Namespace }}
-rules:
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]  
-{{ end }}
-{{ end }}    
----
+
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:


### PR DESCRIPTION
Reverts dell/helm-charts#684

Even though these changes work well for the driver, they might not be reliable when modules are enabled. We'll keep these updates in a feature branch for now and merge them into the main branch once we've completed the RBAC updates for all components.