### PR TITLE
Revert "[charts/csi-unity]: Updating RBAC rules in csi-unity "

### DIFF
--- a/charts/csi-unity/templates/controller.yaml
+++ b/charts/csi-unity/templates/controller.yaml
@@ -4,12 +4,14 @@ metadata:
   name: {{ .Release.Name }}-controller
   namespace: {{ .Release.Namespace }}
 ---
-# ClusterRole for Cluster-specific Permissions
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-controller
 rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
@@ -22,40 +24,46 @@ rules:
 {{- end }}
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "delete", "patch"]
+    verbs: ["get", "list", "watch", "create", "delete", "update","patch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "create", "watch", "update"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
 {{- if .Values.podmon.enabled }}
-    verbs: ["get", "list", "watch", "patch", "delete"]
+    verbs: ["get", "list", "watch", "update", "patch", "delete"]
 {{- else }}
-    verbs: ["get", "list", "watch", "patch"]
+    verbs: ["get", "list", "watch", "update","patch"]
 {{- end }}
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments/status"]
     verbs: ["patch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["pods"]
 {{- if .Values.podmon.enabled }}
-    verbs: ["get", "list", "watch", "delete"]
+    verbs: ["get", "list", "watch", "update", "delete"]
 {{- else }}
     verbs: ["get", "list", "watch"]
 {{- end }}
-  # below for snapshotter
+# below for snapshotter
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["get", "list", "watch", "patch"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots/status"]
     verbs: ["update"]
@@ -64,7 +72,7 @@ rules:
     verbs: ["patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create", "list", "watch", "delete"]
@@ -74,12 +82,18 @@ rules:
   # below for resizer
   - apiGroups: [""]
     resources: ["persistentvolumeclaims/status"]
-    verbs: ["patch"]
+    verbs: ["update", "patch"]
   # Permissions for CSIStorageCapacity
   {{- if eq (include "csi-unity.isStorageCapacitySupported" .) "true" }}
   - apiGroups: ["storage.k8s.io"]
     resources: ["csistoragecapacities"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
   {{- end }}
 ---
 kind: ClusterRoleBinding
@@ -92,41 +106,6 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Release.Name }}-controller
-  apiGroup: rbac.authorization.k8s.io
----
-# Role for Driver-specific Permissions in a Namespace
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ .Release.Name }}-controller
-  namespace: {{ .Release.Namespace }}
-rules:
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["update", "patch"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
-  - apiGroups: ["apps"]
-    resources: ["replicasets"]
-    verbs: ["get"]
----
-# RoleBinding for Driver-specific Role
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ .Release.Name }}-controller
-  namespace: {{ .Release.Namespace }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Release.Name }}-controller
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: Role
   name: {{ .Release.Name }}-controller
   apiGroup: rbac.authorization.k8s.io
 ---
@@ -347,4 +326,3 @@ spec:
         - name: unity-secret
           secret:
               secretName: {{ .Release.Name }}-creds
----

--- a/charts/csi-unity/templates/node.yaml
+++ b/charts/csi-unity/templates/node.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ .Release.Name }}-node
   namespace: {{ .Release.Namespace }}
 ---
-# ClusterRole for Cluster-specific Permissions
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -12,19 +11,25 @@ metadata:
 rules:
   - apiGroups: [ "" ]
     resources: [ "persistentvolumes" ]
-    verbs: [ "create", "delete", "get", "list", "watch" ]
+    verbs: [ "create", "delete", "get", "list", "watch", "update" ]
   - apiGroups: [ "" ]
-    resources: [ "persistentvolumeclaims" ]
+    resources: [ "persistentvolumesclaims" ]
     verbs: [ "get", "list", "watch", "update" ]
+  - apiGroups: [ "" ]
+    resources: [ "events" ]
+    verbs: [ "get", "list", "watch", "create", "update", "patch" ]
   - apiGroups: [ "" ]
     resources: [ "nodes" ]
     verbs: [ "get", "list", "watch", "update", "patch" ]
   - apiGroups: [ "storage.k8s.io" ]
     resources: [ "volumeattachments" ]
-    verbs: [ "get", "list", "watch" ]
+    verbs: [ "get", "list", "watch", "update" ]
   - apiGroups: [ "storage.k8s.io" ]
     resources: [ "storageclasses" ]
     verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "volumeattachments" ]
+    verbs: [ "get", "list", "watch", "update" ]
   - apiGroups: [ "security.openshift.io" ]
     resourceNames: [ "privileged" ]
     resources: [ "securitycontextconstraints" ]
@@ -32,10 +37,12 @@ rules:
 {{- if .Values.podmon.enabled }}
   - apiGroups: [ "" ]
     resources: [ "pods" ]
-    verbs: [ "get", "list", "watch" ]
+    verbs: [ "get", "list", "watch", "update", "delete" ]
+  - apiGroups: [ "coordination.k8s.io" ]
+    resources: [ "leases" ]
+    verbs: [ "get", "watch", "list", "delete", "update", "create" ]
 {{- end }}
 ---
-# ClusterRoleBinding for Cluster-specific 
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -48,34 +55,6 @@ roleRef:
   kind: ClusterRole
   name: {{ .Release.Name }}-node
   apiGroup: rbac.authorization.k8s.io
-{{- if .Values.podmon.enabled }}
----
-# Role for Driver-specific Permissions in a Namespace
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ .Release.Name }}-node
-  namespace: {{ .Release.Namespace }}
-rules:
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]
----
-# RoleBinding for Driver-specific Role
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ .Release.Name }}-node
-  namespace: {{ .Release.Namespace }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Release.Name }}-node
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: Role
-  name: {{ .Release.Name }}-node
-  apiGroup: rbac.authorization.k8s.io
-{{- end }}
 ---
 {{ $releaseName := .Release.Name }}
 kind: DaemonSet


### PR DESCRIPTION
Reverts dell/helm-charts#681

Even though these changes work well for the driver, they might not be reliable when modules are enabled. We'll keep these updates in a feature branch for now and merge them into the main branch once we've completed the RBAC updates for all components.
