### PR TITLE
pvc on target param

### DIFF
--- a/charts/csm-replication/templates/controller.yaml
+++ b/charts/csm-replication/templates/controller.yaml
@@ -270,6 +270,7 @@ spec:
       containers:
         - args:
             - disable-pvc-remap={{ .Values.disablePVCRemap }}
+            - allow-pvc-creation-on-target={{ .Values.allowPvcCreationOnTarget }}
             - prefix=replication.storage.dell.com
         {{- if eq .Values.leaderElection "true" }}
             - enable-leader-election

--- a/charts/csm-replication/values.yaml
+++ b/charts/csm-replication/values.yaml
@@ -32,6 +32,13 @@ retryIntervalMax: 5m
 # Default value: "false"
 disablePVCRemap: "false"
 
+# allowPvcCreationOnTarget: It Creates PVC on target cluster using replicated PV.
+# Allowed values:
+#   true: It creates a PVC on target cluster against replicated PV
+#   false: simply updates claimref on replicated PV on target cluster without actually creating a PVC
+# Default value: false
+allowPvcCreationOnTarget: "false"
+
 # HostAliases: Optional features that allows <hostname:IP> entries injection into pod's /etc/hosts file
 # hostAliases:
 #  - ip: "10.10.10.10"


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
It provides end user a configurable param which can be set to enable PVC creation on target cluster.
param added -> **allowPvcCreationOnTarget**

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1862

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable


  
![image](https://github.com/user-attachments/assets/00f67a0a-e359-4c68-b9b3-51277a180c8d)


