### PR TITLE
[charts/csi-powermax]: Adjust podmon container placement in Powermax node 

### DIFF
--- a/charts/csi-powermax/templates/node.yaml
+++ b/charts/csi-powermax/templates/node.yaml
@@ -129,6 +129,58 @@ spec:
         {{- range $i, $array := .Values.global.storageArrays }}
           {{- $arraysStr = trim (cat $arraysStr $array.storageArrayId) }}
         {{- end }}
+        {{- if hasKey .Values "podmon" }}
+        {{- if eq .Values.podmon.enabled true }}
+        - name: podmon
+          securityContext:
+            privileged: true
+            capabilities:
+              add: [ "SYS_ADMIN" ]
+            allowPrivilegeEscalation: true
+          image: {{ required "Must provide the podmon container image." .Values.images.podmon.image }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          args:
+            {{- toYaml .Values.podmon.node.args | nindent 12 }}
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: X_CSI_PRIVATE_MOUNT_DIR
+              value: {{ .Values.kubeletConfigDir }}
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: kubelet-pods
+              mountPath: {{ .Values.kubeletConfigDir }}/pods
+              mountPropagation: "Bidirectional"
+            - name: driver-path
+              mountPath: {{ .Values.kubeletConfigDir }}/plugins/powermax.emc.dell.com
+              mountPropagation: "Bidirectional"
+            - name: csi-path
+              mountPath: {{ .Values.kubeletConfigDir }}/plugins/kubernetes.io/csi
+              mountPropagation: "Bidirectional"
+            - name: dev
+              mountPath: /dev
+            - name: usr-bin
+              mountPath: /usr-bin
+            - name: var-run
+              mountPath: /var/run
+            - name: powermax-config-params
+              mountPath: /powermax-config-params
+        {{- end }}
+        {{- end }}
         - name: driver
           securityContext:
             privileged: true
@@ -402,58 +454,6 @@ spec:
               mountPath: /etc/karavi-authorization
         {{ end }}
         {{ end }}
-        {{- if hasKey .Values "podmon" }}
-        {{- if eq .Values.podmon.enabled true }}
-        - name: podmon
-          securityContext:
-            privileged: true
-            capabilities:
-              add: [ "SYS_ADMIN" ]
-            allowPrivilegeEscalation: true
-          image: {{ required "Must provide the podmon container image." .Values.images.podmon.image }}
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          args:
-            {{- toYaml .Values.podmon.node.args | nindent 12 }}
-          env:
-            - name: KUBE_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: spec.nodeName
-            - name: X_CSI_PRIVATE_MOUNT_DIR
-              value: {{ .Values.kubeletConfigDir }}
-            - name: MY_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-          volumeMounts:
-            - name: kubelet-pods
-              mountPath: {{ .Values.kubeletConfigDir }}/pods
-              mountPropagation: "Bidirectional"
-            - name: driver-path
-              mountPath: {{ .Values.kubeletConfigDir }}/plugins/powermax.emc.dell.com
-              mountPropagation: "Bidirectional"
-            - name: csi-path
-              mountPath: {{ .Values.kubeletConfigDir }}/plugins/kubernetes.io/csi
-              mountPropagation: "Bidirectional"
-            - name: dev
-              mountPath: /dev
-            - name: usr-bin
-              mountPath: /usr-bin
-            - name: var-run
-              mountPath: /var/run
-            - name: powermax-config-params
-              mountPath: /powermax-config-params
-        {{- end }}
-        {{- end }}
       volumes:
         - name: registration-dir
           hostPath:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

- Moves podmon container in the beginning for the Powermax node to make it consistent with other drivers.
- This changes fixes Resiliency E2E tests for PowerMax for the scenario "Driver Pods Down" where it was patching the driver node pod image with incorrect image.

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1870

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable

#### Executed powermax resiliency scenario - "Driver Pods Down"
Logs: [pmax-resiliency-driver-pods-down.txt](https://github.com/user-attachments/files/19974611/pmax-resiliency-driver-pods-down.txt)

![image](https://github.com/user-attachments/assets/1bee0b37-27a8-4347-b5f4-062b6ff16975)
