### PR TITLE
[charts/csi-powermax]: Add watch permission to secrets

### DIFF
--- a/charts/csi-powermax/templates/controller.yaml
+++ b/charts/csi-powermax/templates/controller.yaml
@@ -143,7 +143,7 @@ rules:
     verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["replicasets"]
     verbs: ["get"]


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it: 
This PR adds watch permission to secrets required by the reverseproxy.

```
Name:         powermax-controller
Labels:       app.kubernetes.io/managed-by=Helm
Annotations:  meta.helm.sh/release-name: powermax
              meta.helm.sh/release-namespace: powermax
PolicyRule:
  Resources                   Non-Resource URLs  Resource Names  Verbs
  ---------                   -----------------  --------------  -----
  secrets                     []                 []              [get list]
  leases.coordination.k8s.io  []                 []              [get watch list delete update create]
  replicasets.apps            []                 []              [get]
  pods                        []                 []              [update patch]
[root@master-1-E4hZ2l1eQqy9q dell-csi-helm-installer]# 
[root@master-1-E4hZ2l1eQqy9q dell-csi-helm-installer]# k logs powermax-controller-7bddb97fb6-slbsp -n powermax -c reverseproxy | grep "forbidden: User"
E0505 05:45:41.365231       1 reflector.go:166] "Unhandled Error" err="pkg/mod/k8s.io/client-go@v0.32.1/tools/cache/reflector.go:251: Failed to watch *v1.Secret: secrets is forbidden: User \"system:serviceaccount:powermax:powermax-controller\" cannot watch resource \"secrets\" in API group \"\" in the namespace \"powermax\"" logger="UnhandledError"
```

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1751

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
