### PR TITLE
[charts/csi-powerscale]: Added csi-vol prefix variable

### DIFF
--- a/charts/csi-isilon/templates/controller.yaml
+++ b/charts/csi-isilon/templates/controller.yaml
@@ -461,6 +461,8 @@ spec:
               value: /isilon-configs/config
             - name: X_CSI_MAX_PATH_LIMIT
               value: "{{ .Values.maxPathLen }}"
+            - name: CSI_VOL_PREFIX
+              value: "{{ .Values.controller.volumeNamePrefix }}"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/charts/csi-isilon/templates/controller.yaml
+++ b/charts/csi-isilon/templates/controller.yaml
@@ -461,7 +461,7 @@ spec:
               value: /isilon-configs/config
             - name: X_CSI_MAX_PATH_LIMIT
               value: "{{ .Values.maxPathLen }}"
-            - name: CSI_VOL_PREFIX
+            - name: X_CSI_VOL_PREFIX
               value: "{{ .Values.controller.volumeNamePrefix }}"
           volumeMounts:
             - name: socket-dir


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Added new env variable X_CSI_VOL_PREFIX 

#### Which issue(s) is this PR associated with:

- [#Issue_Number](https://github.com/dell/csm/issues/1487)

#### Special notes for your reviewer:

Associated PRs :
https://github.com/dell/csi-powerscale/pull/383
https://github.com/dell/csm-operator/pull/974
https://github.com/dell/csm-docs/pull/1521



#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
