### PR TITLE
[charts/csi-powerstore] Add Environment Variables for Configuring Multi-NAS in PowerStore 

### DIFF
--- a/charts/csi-powerstore/templates/controller.yaml
+++ b/charts/csi-powerstore/templates/controller.yaml
@@ -1,6 +1,6 @@
 #
 #
-# Copyright © 2020-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2020-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charts/csi-powerstore/templates/controller.yaml
+++ b/charts/csi-powerstore/templates/controller.yaml
@@ -431,7 +431,7 @@ spec:
             - name: X_CSI_MULTI_NAS_FAILURE_THRESHOLD
               value: "{{ .Values.multiNas.threshold | default 5 }}"
             - name: X_CSI_MULTI_NAS_COOLDOWN_PERIOD
-              value: "{{ .Values.multiNas.cooldownPeriod | default 5m }}"
+              value: {{ .Values.multiNas.cooldownPeriod | default "5m" }}
             {{- if hasKey .Values "podmon" }}
             - name: X_CSI_PODMON_ENABLED
               value: "{{ .Values.podmon.enabled }}"

--- a/charts/csi-powerstore/templates/controller.yaml
+++ b/charts/csi-powerstore/templates/controller.yaml
@@ -428,6 +428,10 @@ spec:
               value: "{{ .Values.nfsClientPort | default 2050 }}"
             - name: X_CSI_NFS_SERVER_PORT
               value: "{{ .Values.nfsServerPort | default 2049 }}"
+            - name: X_CSI_MULTI_NAS_FAILURE_THRESHOLD
+              value: "{{ .Values.multiNas.threshold | default 5 }}"
+            - name: X_CSI_MULTI_NAS_COOLDOWN_PERIOD
+              value: "{{ .Values.multiNas.cooldownPeriod | default 5m }}"
             {{- if hasKey .Values "podmon" }}
             - name: X_CSI_PODMON_ENABLED
               value: "{{ .Values.podmon.enabled }}"

--- a/charts/csi-powerstore/values.yaml
+++ b/charts/csi-powerstore/values.yaml
@@ -379,3 +379,16 @@ podmon:
       - "--driver-config-params=/powerstore-config-params/driver-config-params.yaml"
       - "--driverPodLabelValue=dell-storage"
       - "--ignoreVolumelessPods=false"
+
+# Define multi NAS parameters
+multiNas:
+  # threshold: Number of consecutive FS creation failures after which a NAS is put into cooldown.
+  # If a NAS is in cooldown, it will not be considered for new FS creation attempts for cooldownPeriod amount of time.
+  # Allowed values: n, where n >= 0
+  # Default value: 5
+  threshold: 5
+  # cooldownPeriod: Duration for which a NAS remains in cooldown once the threshold is reached.
+  # During this period, the NAS will not be considered for new FS creation attempts.
+  # Allowed values: Number followed by unit (s,m,h) e.g. 60s,1m,2m,3m,...,1h etc
+  # Default value: 5m
+  cooldownPeriod: 5m

--- a/charts/csi-powerstore/values.yaml
+++ b/charts/csi-powerstore/values.yaml
@@ -1,6 +1,6 @@
 #
 #
-# Copyright © 2020-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2020-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/installation-wizard/container-storage-modules/values.yaml
+++ b/installation-wizard/container-storage-modules/values.yaml
@@ -1,6 +1,6 @@
 #
 #
-# Copyright © 2023-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2023-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -122,7 +122,9 @@ csi-powerstore:
         - "--ignoreVolumelessPods=false"
   # maxPowerstoreVolumesPerNode: Specify default value for maximum number of volumes that controller can publish to the node.
   maxPowerstoreVolumesPerNode: 0
-
+  multiNas:
+    threshold: 5
+    cooldownPeriod: 5m
 ## CSI PowerMax
 ########################
 csi-powermax:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
This PR adds following 2 environment variables for configuring multi-NAS in powerstore.
- `X_CSI_MULTI_NAS_FAILURE_THRESHOLD`: Number of consecutive FS creation failures after which a NAS is put into cooldown.
- `X_CSI_MULTI_NAS_COOLDOWN_PERIOD`: Duration for which a NAS remains in cooldown once the threshold is reached.

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1758

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
![image](https://github.com/user-attachments/assets/50d37861-e91c-4884-a869-74b876a8cbcb)