### PR TITLE
Patch helm charts to remove references for shared nfs

### DIFF
--- a/charts/csi-powerstore/templates/node.yaml
+++ b/charts/csi-powerstore/templates/node.yaml
@@ -46,6 +46,13 @@ rules:
     resourceNames: ["privileged"]
     resources: ["securitycontextconstraints"]
     verbs: ["use"]
+  # for Shared NFS
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]
   {{- if hasKey .Values "podmon" }}
   {{- if eq .Values.podmon.enabled true }}
   - apiGroups: [""]
@@ -228,6 +235,12 @@ spec:
               value: {{ .Values.driverName }}
             - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
               value: {{ .Values.nodeFCPortsFilterFile }}    
+            - name: X_CSI_NFS_EXPORT_DIRECTORY
+              value: {{ .Values.nfsExportDirectory | default "/var/lib/dell/nfs" }}
+            - name: X_CSI_NFS_CLIENT_PORT
+              value: "{{ .Values.nfsClientPort | default 2050 }}"
+            - name: X_CSI_NFS_SERVER_PORT
+              value: "{{ .Values.nfsServerPort | default 2049 }}"
             {{- if eq .Values.connection.enableCHAP  true }}
             - name: X_CSI_POWERSTORE_ENABLE_CHAP
               value: "true"
@@ -290,6 +303,9 @@ spec:
               mountPath: /powerstore-config
             - name: powerstore-config-params
               mountPath: /powerstore-config-params
+            # for Shared NFS
+            - name: nfs-powerstore
+              mountPath: {{ .Values.nfsExportDirectory | default "/var/lib/dell/nfs"}}
               mountPropagation: "Bidirectional"
         - name: registrar
           image: {{ required "Must provide the CSI node registrar container image." .Values.images.registrar.image }}
@@ -312,6 +328,11 @@ spec:
             - name: driver-path
               mountPath: /csi
       volumes:
+        # for Shared NFS
+        - name: nfs-powerstore
+          hostPath:
+            path: {{ .Values.nfsExportDirectory | default "/var/lib/dell/nfs"}}
+            type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
             path: {{ .Values.kubeletConfigDir }}/plugins_registry/

--- a/charts/csi-powerstore/templates/node.yaml
+++ b/charts/csi-powerstore/templates/node.yaml
@@ -46,13 +46,6 @@ rules:
     resourceNames: ["privileged"]
     resources: ["securitycontextconstraints"]
     verbs: ["use"]
-  # for Shared NFS
-  - apiGroups: ["discovery.k8s.io"]
-    resources: ["endpointslices"]
-    verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["services"]
-    verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]
   {{- if hasKey .Values "podmon" }}
   {{- if eq .Values.podmon.enabled true }}
   - apiGroups: [""]
@@ -235,12 +228,6 @@ spec:
               value: {{ .Values.driverName }}
             - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
               value: {{ .Values.nodeFCPortsFilterFile }}    
-            - name: X_CSI_NFS_EXPORT_DIRECTORY
-              value: {{ .Values.nfsExportDirectory | default "/var/lib/dell/nfs" }}
-            - name: X_CSI_NFS_CLIENT_PORT
-              value: "{{ .Values.nfsClientPort | default 2050 }}"
-            - name: X_CSI_NFS_SERVER_PORT
-              value: "{{ .Values.nfsServerPort | default 2049 }}"
             {{- if eq .Values.connection.enableCHAP  true }}
             - name: X_CSI_POWERSTORE_ENABLE_CHAP
               value: "true"
@@ -303,9 +290,6 @@ spec:
               mountPath: /powerstore-config
             - name: powerstore-config-params
               mountPath: /powerstore-config-params
-            # for Shared NFS
-            - name: nfs-powerstore
-              mountPath: {{ .Values.nfsExportDirectory | default "/var/lib/dell/nfs"}}
               mountPropagation: "Bidirectional"
         - name: registrar
           image: {{ required "Must provide the CSI node registrar container image." .Values.images.registrar.image }}
@@ -328,11 +312,6 @@ spec:
             - name: driver-path
               mountPath: /csi
       volumes:
-        # for Shared NFS
-        - name: nfs-powerstore
-          hostPath:
-            path: {{ .Values.nfsExportDirectory | default "/var/lib/dell/nfs"}}
-            type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
             path: {{ .Values.kubeletConfigDir }}/plugins_registry/

--- a/charts/csi-powerstore/values.yaml
+++ b/charts/csi-powerstore/values.yaml
@@ -105,24 +105,6 @@ maxPowerstoreVolumesPerNode: 0
 # Default value: "0777"
 nfsAcls: "0777"
 
-# nfsExportDirectory: Define mount path for host based nfs volumes
-# Define this only during deployment time, DO NOT change afterwards
-# Allowed values:
-# Default value: /var/lib/dell/nfs
-nfsExportDirectory: /var/lib/dell/nfs
-
-# nfsServerPort: Define port for nfs server
-# By default nfs server port is 2049. This value should match what port the nfs-server is configured on.
-# /etc/nfs.conf contains the port information. If none is specified in that file, then it is 2049.
-# Allowed values:  Any valid and free port.
-# Default value: 2049
-nfsServerPort: 2049
-
-# nfsClientPort: Define port for nfs client(used in hostbased nfs)
-# Allowed values:  Any valid and free port.
-# Default value: 2050
-nfsClientPort: 2050
-
 # podmonAPIPort: Defines the port to be used within the kubernetes cluster
 # Allowed values:
 #   Any valid and free port.


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
References to variables etc used for shared NFS have been removed. 

Remove references to shared NFS

#### Which issue(s) is this PR associated with:

- #Issue_Number

#### Special notes for your reviewer:

Testing done:  Re-deployed with these changes, verified cert-csi tests for iscsi are successful. 

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable


TEST RESULTS:
`[2025-05-20 14:50:32]  INFO Starting cert-csi; ver. 1.8.0
[2025-05-20 14:50:32]  INFO Created test_runs table
[2025-05-20 14:50:32]  INFO Created test_cases table
[2025-05-20 14:50:32]  INFO Created events table
[2025-05-20 14:50:32]  INFO Created entities table
[2025-05-20 14:50:32]  INFO Created number_entities table
[2025-05-20 14:50:32]  INFO Created resource_usage table
[2025-05-20 14:50:32]  INFO Created entities_relations table
[2025-05-20 14:50:32]  INFO Created tables
[2025-05-20 14:50:32]  INFO Using EVENT observer type
[2025-05-20 14:50:32]  INFO Using config from /DEV/CSM/kubeconfigs/kubeconfig-63-111
[2025-05-20 14:50:32]  INFO Successfully loaded config. Host: 
[2025-05-20 14:50:32]  INFO Created new KubeClient
[2025-05-20 14:50:32]  INFO Running 1 iteration(s)
[2025-05-20 14:50:32]  INFO     *** ITERATION NUMBER 1 ***
[2025-05-20 14:50:32]  INFO Starting ScalingSuite with powerstore-xfs storage class
[2025-05-20 14:50:32]  INFO Successfully created namespace scale-test-8e014d20
[2025-05-20 14:50:32]  INFO Using default volume size 3Gi
[2025-05-20 14:50:32]  INFO Using default image: quay.io/centos/centos:latest
[2025-05-20 14:50:32]  INFO Created stateful set sts-scale-testx4btb
[2025-05-20 14:50:32]  INFO Waiting for sts pods to become ready
[2025-05-20 14:50:56]  INFO Scaling to 3 replicas
[2025-05-20 14:50:56]  INFO Waiting for sts pods to become ready
[2025-05-20 14:51:16]  INFO Scaling to 0 replicas
[2025-05-20 14:51:16]  INFO Waiting for sts pods to become ready
[2025-05-20 14:51:20]  INFO Deleting all resources in namespace scale-test-8e014d20
[2025-05-20 14:51:32]  INFO Namespace scale-test-8e014d20 was deleted in 12.025091265s
[2025-05-20 14:51:37]  INFO SUCCESS: ScalingSuite in 1m5.130271105s
[2025-05-20 14:51:37]  INFO 1 1 1
[2025-05-20 14:51:37]  INFO 1
[2025-05-20 14:51:37]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-05-20 14:51:37]  INFO Started generating reports...
Collecting metrics
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/sGenerating plots
1 / 1 [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s[2025-05-20 14:51:38]  WARN No ResourceUsageMetrics provided
[2025-05-20 14:51:38] ERROR no ResourceUsageMetrics provided
report-test-run-7add446d:
Name: test-run-7add446d
Host: 
StorageClass: powerstore-xfs
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/reports/test-run-7add446d/PodsCreatingOverTime.png

/root/.cert-csi/reports/test-run-7add446d/PodsReadyOverTime.png

/root/.cert-csi/reports/test-run-7add446d/PodsTerminatingOverTime.png

/root/.cert-csi/reports/test-run-7add446d/PvcsCreatingOverTime.png

/root/.cert-csi/reports/test-run-7add446d/PvcsBoundOverTime.png

Tests:
--------------------------------------------------------------
1. TestCase: ScalingSuite
            Started:   2025-05-20 14:50:32.755598973 +0000 UTC
            Ended:     2025-05-20 14:51:37.934349353 +0000 UTC
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 1.188715169s
                        Min: 1.076197339s
                        Max: 1.2775614s
                        Histogram:
        /root/.cert-csi/reports/test-run-7add446d/ScalingSuite1/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-7add446d/ScalingSuite1/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 874.597291ms
                        Min: 615.728329ms
                        Max: 1.022696274s
                        Histogram:
        /root/.cert-csi/reports/test-run-7add446d/ScalingSuite1/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-7add446d/ScalingSuite1/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 3.148553173s
                        Min: 3.011501475s
                        Max: 3.225355451s
                        Histogram:
        /root/.cert-csi/reports/test-run-7add446d/ScalingSuite1/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-7add446d/ScalingSuite1/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 117.658513ms
                        Min: 44.2481ms
                        Max: 203.05406ms
                        Histogram:
        /root/.cert-csi/reports/test-run-7add446d/ScalingSuite1/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-7add446d/ScalingSuite1/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 556.163488ms
                        Min: 444.818715ms
                        Max: 742.343853ms
                        Histogram:
        /root/.cert-csi/reports/test-run-7add446d/ScalingSuite1/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-7add446d/ScalingSuite1/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 20.217983063s
                        Min: 18.348860813s
                        Max: 22.344639426s
                        Histogram:
        /root/.cert-csi/reports/test-run-7add446d/ScalingSuite1/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-7add446d/ScalingSuite1/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 1.661893826s
                        Min: 1.352820569s
                        Max: 2.262300767s
                        Histogram:
        /root/.cert-csi/reports/test-run-7add446d/ScalingSuite1/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-7add446d/ScalingSuite1/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-7add446d/ScalingSuite1/EntityNumberOverTime.png

[2025-05-20 14:51:38]  INFO Avg time of a run:   48.07s
[2025-05-20 14:51:38]  INFO Avg time of a del:   12.03s
[2025-05-20 14:51:38]  INFO Avg time of all:     65.13s
[2025-05-20 14:51:38]  INFO During this run 100.0% of suites succeeded`