### PR TITLE
Fixed sidecar's timeout across helm and operator for each platform

### DIFF
--- a/charts/csi-powermax/templates/controller.yaml
+++ b/charts/csi-powermax/templates/controller.yaml
@@ -255,7 +255,7 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--volume-name-prefix={{ required "Must provide a Volume Name Prefix." .Values.controller.volumeNamePrefix }}"
             - "--volume-name-uuid-length=10"
-            - "--timeout=180s"
+            - "--timeout=120s"
             - "--worker-threads=6"
             - "--v=5"
             - "--default-fstype={{ .Values.defaultFsType | default "ext4" }}"


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Fixed sidecar's timeout across helm and operator for each platform and made them consistent and unified between installation methods.

#### Which issue(s) is this PR associated with:

- #Issue_Number

https://github.com/dell/csm/issues/1905

#### Special notes for your reviewer:
The changes have been validated for powermax driver 
![image](https://github.com/user-attachments/assets/480e46c7-7b68-4dcc-b511-a1085b609b3b)


#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
