### PR TITLE
[charts/csi-powerscale]: Remove csi-vol prefix variable

### DIFF
--- a/charts/csi-isilon/templates/controller.yaml
+++ b/charts/csi-isilon/templates/controller.yaml
@@ -480,8 +480,6 @@ spec:
               value: /isilon-configs/config
             - name: X_CSI_MAX_PATH_LIMIT
               value: "{{ .Values.maxPathLen }}"
-            - name: X_CSI_VOL_PREFIX
-              value: "{{ .Values.controller.volumeNamePrefix }}"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi


### PR DESCRIPTION
#### Is this a new chart?

No

#### What this PR does / why we need it:

For the PowerScale CreateSnapshot call, the required isiPath is now retrieved from the source volume's export path like it is done in the replication code. So, there will be no need to get PV's 'Path' value or remove any prefix. Hence, reverting the changes made in previous PR https://github.com/dell/helm-charts/pull/715

Related PRs:
https://github.com/dell/csi-powerscale/pull/406
https://github.com/dell/csm-operator/pull/1012

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1920

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable


Please see test results added in PR https://github.com/dell/csi-powerscale/pull/406
