### PR TITLE
[charts/csi-vxflexos] Add probe timeout to PowerFlex controller and node

### DIFF
--- a/charts/csi-vxflexos/templates/controller.yaml
+++ b/charts/csi-vxflexos/templates/controller.yaml
@@ -454,6 +454,8 @@ spec:
             {{- end }}
             - name: X_CSI_POWERFLEX_EXTERNAL_ACCESS
               value: {{ .Values.externalAccess }}
+            - name: X_CSI_PROBE_TIMEOUT
+              value: {{ .Values.probeTimeout | default "10s"}}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/charts/csi-vxflexos/templates/node.yaml
+++ b/charts/csi-vxflexos/templates/node.yaml
@@ -259,6 +259,8 @@ spec:
                   fieldPath: spec.nodeName
             - name: RELEASE_NAME
               value: {{ .Release.Name }}
+            - name: X_CSI_PROBE_TIMEOUT
+              value: {{ .Values.probeTimeout | default "10s"}}
           volumeMounts:
             - name: driver-path
               mountPath: {{ .Values.kubeletConfigDir }}/plugins/vxflexos.emc.dell.com

--- a/charts/csi-vxflexos/values.yaml
+++ b/charts/csi-vxflexos/values.yaml
@@ -124,6 +124,12 @@ fsGroupPolicy: File
 # Default value: 0
 maxVxflexosVolumesPerNode: 0
 
+# probeTimeout: Specify the timeout limit for controller and node to communicate with the array.
+# Allowed values: 1s, 10s, etc.
+  # In the format of a duration.
+# Default value: 10s
+probeTimeout: "10s"
+
 # "controller" allows to configure controller specific parameters
 controller:
   # replication: allows to configure replication


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

**Note:** This is ported from https://github.com/dell/helm-charts/pull/771.

In an attempt to align with the PowerFlex array default timeout of 10 seconds, we are adding the ability to make this parameter configurable through charts such that the customer has that flexibility during the Probe workflow in the PowerFlex driver. Originally, this parameter defaulted to 1 seconds which caused issues during boot when an array took time to respond to probes. Increasing the default and making it configurable adds an extra level of customizability for the array.

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1956

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
