### PR TITLE
[charts/csi-powerstore] Added env for volume name prefix

### DIFF
--- a/charts/csi-powerstore/templates/controller.yaml
+++ b/charts/csi-powerstore/templates/controller.yaml
@@ -432,6 +432,8 @@ spec:
               value: controller
             - name: X_CSI_DRIVER_NAME
               value: {{ .Values.driverName }}
+            - name: X_CSI_VOL_PREFIX
+              value: "{{ .Values.controller.volumeNamePrefix }}"
             - name: X_CSI_POWERSTORE_EXTERNAL_ACCESS
               value: {{ .Values.externalAccess }}
             - name: X_CSI_NFS_ACLS

--- a/charts/csi-powerstore/templates/node.yaml
+++ b/charts/csi-powerstore/templates/node.yaml
@@ -262,6 +262,8 @@ spec:
               value: "{{ .Values.maxPowerstoreVolumesPerNode }}"
             - name: X_CSI_POWERSTORE_NODE_CHROOT_PATH
               value: /noderoot
+            - name: X_CSI_VOL_PREFIX
+              value: "{{ .Values.controller.volumeNamePrefix }}"
             - name: X_CSI_POWERSTORE_TMP_DIR
               value: {{ .Values.kubeletConfigDir }}/plugins/{{ .Values.driverName }}/tmp
             - name: X_CSI_DRIVER_NAME


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
This introduces a new environment variable which sets volume prefix. This is needed to trim the volume name when using Authorization module.
#### Which issue(s) is this PR associated with:

- #Issue_Number
https://github.com/dell/csm/issues/1947
#### Special notes for your reviewer:
Reference PR: https://github.com/dell/csi-powerstore/pull/529 having all the test results
#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [x] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
