### PR TITLE
Added the Topology metrics to Otel for Powerflex and Powermax

### DIFF
--- a/charts/karavi-observability/templates/karavi-observability-configmap.yaml
+++ b/charts/karavi-observability/templates/karavi-observability-configmap.yaml
@@ -16,6 +16,8 @@ data:
     POWERFLEX_STORAGE_POOL_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerflex.storageClassPoolMetricsEnabled }}"
     POWERFLEX_STORAGE_POOL_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerflex.storageClassPoolPollFrequencySeconds }}"
     POWERFLEX_MAX_CONCURRENT_QUERIES: "{{ .Values.karaviMetricsPowerflex.concurrentPowerflexQueries }}"
+    POWERFLEX_TOPOLOGY_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerflex.topologyMetricsEnabled }}"
+    POWERFLEX_TOPOLOGY_METRICS_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerflex.topologyMetricsPollFrequencySeconds }}"    
     LOG_LEVEL: "{{ .Values.karaviMetricsPowerflex.logLevel }}"
     LOG_FORMAT: "{{ .Values.karaviMetricsPowerflex.logFormat }}"
 
@@ -117,6 +119,8 @@ data:
     POWERMAX_PERFORMANCE_METRICS_ENABLED: "{{ .Values.karaviMetricsPowermax.performanceMetricsEnabled }}"
     POWERMAX_CAPACITY_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowermax.capacityPollFrequencySeconds }}"
     POWERMAX_PERFORMANCE_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowermax.performancePollFrequencySeconds }}"
+    POWERMAX_TOPOLOGY_METRICS_ENABLED: "{{ .Values.karaviMetricsPowermax.topologyMetricsEnabled }}"
+    POWERMAX_TOPOLOGY_METRICS_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowermax.topologyMetricsPollFrequencySeconds }}"
     LOG_LEVEL: "{{ .Values.karaviMetricsPowermax.logLevel }}"
     LOG_FORMAT: "{{ .Values.karaviMetricsPowermax.logFormat }}"
 

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -29,6 +29,10 @@ karaviMetricsPowerflex:
   storageClassPoolMetricsEnabled: "true"
   # set the polling frequency to configure the interval which storage class/pool metrics are gathered
   storageClassPoolPollFrequencySeconds: 10
+  # set topologyMetricsEnabled to "false" to disable collection of topology metrics
+  topologyMetricsEnabled: "true"
+  # set polling frequency to get topology metrics
+  topologyMetricsPollFrequencySeconds: 30
   # set the the default max concurrent queries to PowerFlex
   concurrentPowerflexQueries: 10
   # set the default endpoint for PowerFlex service
@@ -154,6 +158,10 @@ karaviMetricsPowermax:
   performancePollFrequencySeconds: 20
   # set the default max concurrent queries to PowerMax
   concurrentPowermaxQueries: 10
+  # set topologyMetricsEnabled to "false" to disable collection of topology metrics
+  topologyMetricsEnabled: "true"
+  # set polling frequency to get topology metrics
+  topologyMetricsPollFrequencySeconds: 30
   # set the default endpoint for PowerMax service
   endpoint: karavi-metrics-powermax
   # useSecret


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Added 2 new parameters TOPOLOGY_METRICS_ENABLED and TOPOLOGY_METRICS_POLL_FREQUENCY. This is required to enable topology metrics data to be pushed to Otel collector

#### Which issue(s) is this PR associated with:

- #Issue_Number 
https://github.com/dell/csm/issues/1896


#### Special notes for your reviewer:

Associated PRs: 
https://github.com/dell/karavi-metrics-powerflex/pull/266


#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
