### PR TITLE
[charts/csi-vxflexos] Add a precheck to check volume name prefix length with Authorization and Replication modules enabled.

### DIFF
--- a/charts/csi-vxflexos/templates/_helpers.tpl
+++ b/charts/csi-vxflexos/templates/_helpers.tpl
@@ -8,3 +8,11 @@ Return true if storage capacity tracking is enabled and is supported based on k8
     {{- end -}}
   {{- end -}}
 {{- end -}}
+
+{{- define "vxflexos.validateVolumeNamePrefix" -}}
+{{- if and .Values.authorization.enabled .Values.controller.replication.enabled -}}
+  {{- if gt (len .Values.controller.volumeNamePrefix) 5 -}}
+    {{- fail (printf "The volumeNamePrefix '%s' should not exceed the 5-character limit when both authorization and replication are enabled." .Values.volumeNamePrefix) -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/csi-vxflexos/templates/controller.yaml
+++ b/charts/csi-vxflexos/templates/controller.yaml
@@ -163,6 +163,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 
+{{ include "vxflexos.validateVolumeNamePrefix" . }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
When using CSM Authorization and CSM Replication together with PowerFlex, the generated volume names can exceed the platform's maximum allowed length of 31 characters. This leads to truncation of the volume name, which reduces its uniqueness and may result in naming conflicts or duplicate volume names.
This PR adds a precheck during the driver deployment to ensure the volume name prefix length < 5 chars with Authorization and Replication module enabled.

#### Which issue(s) is this PR associated with:

(https://github.com/dell/csm/issues/1992)

#### Special notes for your reviewer:
None

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
