### PR TITLE
[charts/csi-isilion] AZ Network labels are reconciled on an interval

### DIFF
--- a/charts/csi-isilon/Chart.yaml
+++ b/charts/csi-isilon/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: csi-isilon
-version: 2.14.0
-appVersion: "2.14.0"
+version: 2.14.1
+appVersion: "2.14.1"
 kubeVersion: ">= 1.21.0"
 # If you are using a complex K8s version like "v1.22.3-mirantis-1", use this kubeVersion check instead
 # kubeVersion: ">= 1.23.0-0"

--- a/charts/csi-isilon/templates/driver-config-params.yaml
+++ b/charts/csi-isilon/templates/driver-config-params.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   driver-config-params.yaml: |
     CSI_LOG_LEVEL: "{{ .Values.logLevel }}"
+    AZ_RECONCILE_INTERVAL: "{{ .Values.azReconcileInterval }}"
     {{ if .Values.podmon.enabled }}
     PODMON_CONTROLLER_LOG_LEVEL: "{{ .Values.logLevel }}"
     PODMON_CONTROLLER_LOG_FORMAT: "{{ .Values.logFormat }}"

--- a/charts/csi-isilon/values.yaml
+++ b/charts/csi-isilon/values.yaml
@@ -2,12 +2,12 @@
 ########################
 # version: version of this values file
 # Note: Do not change this value
-version: "v2.14.0"
+version: "v2.14.1"
 
 images:
   # "driver" defines the container image, used for the driver container.
   driver:
-    image: quay.io/dell/container-storage-modules/csi-isilon:v2.14.0
+    image: quay.io/dell/container-storage-modules/csi-isilon:v2.14.1
   # CSI sidecars
   attacher:
     image: registry.k8s.io/sig-storage/csi-attacher:v4.8.1
@@ -107,6 +107,11 @@ podmonAPIPort: 8083
 # Default value: 192
 # Examples: 192, 256
 maxPathLen: 192
+
+# azReconcileInterval: Interval to monitor and reconcile network interface labels on nodes.
+# Allowed values: Number followed by unit of time (s,m,h)
+# Default value: 1h
+azReconcileInterval: 1h
 
 # controller: configure controller pod specific parameters
 controller:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

Yes

#### What this PR does / why we need it:
AZ Network labels are reconciled on an interval

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1991
#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
- [x] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
