### PR TITLE
[charts/csm-authorization-v2.0]: Add Conjur support for Redis secret to CSM Authorization

### DIFF
--- a/charts/csm-authorization-v2.0/charts/redis/templates/redis.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/templates/redis.yaml
@@ -1,7 +1,7 @@
 {{- $redisSecretProviderClass := .Values.redisSecretProviderClass | default dict }}
-{{- $redisSecretProviderClassName := .Values.redisSecretProviderClass.secretProviderClassName }}
-{{- $redisSecretName := .Values.redisSecretProviderClass.redisSecretName }}
-{{- $redisPasswordKey := .Values.redisSecretProviderClass.redisPasswordKey }}
+{{- $redisSecretProviderClassName := $redisSecretProviderClass.secretProviderClassName }}
+{{- $redisSecretName := $redisSecretProviderClass.redisSecretName }}
+{{- $redisPasswordKey := $redisSecretProviderClass.redisPasswordKey }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -230,7 +230,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: {{ $redisSecretName | default "redis-csm-secret" }}
-              key: {{ .Values.redisSecretProviderClass.redisUsernameKey | default "commander_user" }}
+              key: {{ $redisSecretProviderClass.redisUsernameKey | default "commander_user" }}
         ports:
         - name: {{ .Values.rediscommander }}
           containerPort: 8081

--- a/charts/csm-authorization-v2.0/charts/redis/templates/redis.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/templates/redis.yaml
@@ -1,4 +1,4 @@
-{{- $redisSecretProviderClass := .Values.redis.redisSecretProviderClass | default dict }}
+{{- $redisSecretProviderClass := .Values.redisSecretProviderClass | default dict }}
 {{- $redisSecretProviderClassName := .Values.redisSecretProviderClass.secretProviderClassName }}
 {{- $redisSecretName := .Values.redisSecretProviderClass.redisSecretName }}
 {{- $redisPasswordKey := .Values.redisSecretProviderClass.redisPasswordKey }}
@@ -56,13 +56,11 @@ spec:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/redis-secret.yaml") . | sha256sum }}
         {{- if hasKey $redisSecretProviderClass "conjur" }}
+        {{- with $redisSecretProviderClass.conjur }}
         conjur.org/secrets: |
-          {{- range $redisSecretProviderClass.conjur }}
-          {{- range .paths }}
           - {{ .usernamePath }}: {{ .usernamePath | quote }}
           - {{ .passwordPath }}: {{ .passwordPath | quote }}
-          {{- end }}
-          {{- end }}
+        {{- end }}
         {{- end }}
     spec:
       serviceAccountName: redis
@@ -186,13 +184,11 @@ spec:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/redis-secret.yaml") . | sha256sum }}
         {{- if hasKey $redisSecretProviderClass "conjur" }}
+        {{- with $redisSecretProviderClass.conjur }}
         conjur.org/secrets: |
-          {{- range $redisSecretProviderClass.conjur }}
-          {{- range .paths }}
           - {{ .usernamePath }}: {{ .usernamePath | quote }}
           - {{ .passwordPath }}: {{ .passwordPath | quote }}
-          {{- end }}
-          {{- end }}
+        {{- end }}
         {{- end }}
     spec:
       serviceAccountName: redis

--- a/charts/csm-authorization-v2.0/charts/redis/templates/redis.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/templates/redis.yaml
@@ -1,3 +1,4 @@
+{{- $redisSecretProviderClass := .Values.redis.redisSecretProviderClass | default dict }}
 {{- $redisSecretProviderClassName := .Values.redisSecretProviderClass.secretProviderClassName }}
 {{- $redisSecretName := .Values.redisSecretProviderClass.redisSecretName }}
 {{- $redisPasswordKey := .Values.redisSecretProviderClass.redisPasswordKey }}
@@ -54,6 +55,15 @@ spec:
         app: {{ .Values.name }}
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/redis-secret.yaml") . | sha256sum }}
+        {{- if hasKey $redisSecretProviderClass "conjur" }}
+        conjur.org/secrets: |
+          {{- range $redisSecretProviderClass.conjur }}
+          {{- range .paths }}
+          - {{ .usernamePath }}: {{ .usernamePath | quote }}
+          - {{ .passwordPath }}: {{ .passwordPath | quote }}
+          {{- end }}
+          {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: redis
       initContainers:
@@ -175,6 +185,15 @@ spec:
         tier: backend
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/redis-secret.yaml") . | sha256sum }}
+        {{- if hasKey $redisSecretProviderClass "conjur" }}
+        conjur.org/secrets: |
+          {{- range $redisSecretProviderClass.conjur }}
+          {{- range .paths }}
+          - {{ .usernamePath }}: {{ .usernamePath | quote }}
+          - {{ .passwordPath }}: {{ .passwordPath | quote }}
+          {{- end }}
+          {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: redis
       containers:

--- a/charts/csm-authorization-v2.0/charts/redis/templates/sentinel.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/templates/sentinel.yaml
@@ -1,4 +1,4 @@
-{{- $redisSecretProviderClass := .Values.redis.redisSecretProviderClass | default dict }}
+{{- $redisSecretProviderClass := .Values.redisSecretProviderClass | default dict }}
 {{- $redisSecretProviderClassName := .Values.redisSecretProviderClass.secretProviderClassName }}
 {{- $redisSecretName := .Values.redisSecretProviderClass.redisSecretName }}
 ---
@@ -38,13 +38,11 @@ spec:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/redis-secret.yaml") . | sha256sum }}
         {{- if hasKey $redisSecretProviderClass "conjur" }}
+        {{- with $redisSecretProviderClass.conjur }}
         conjur.org/secrets: |
-          {{- range $redisSecretProviderClass.conjur }}
-          {{- range .paths }}
           - {{ .usernamePath }}: {{ .usernamePath | quote }}
           - {{ .passwordPath }}: {{ .passwordPath | quote }}
-          {{- end }}
-          {{- end }}
+        {{- end }}
         {{- end }}
     spec:
       serviceAccountName: sentinel

--- a/charts/csm-authorization-v2.0/charts/redis/templates/sentinel.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/templates/sentinel.yaml
@@ -1,3 +1,4 @@
+{{- $redisSecretProviderClass := .Values.redis.redisSecretProviderClass | default dict }}
 {{- $redisSecretProviderClassName := .Values.redisSecretProviderClass.secretProviderClassName }}
 {{- $redisSecretName := .Values.redisSecretProviderClass.redisSecretName }}
 ---
@@ -36,6 +37,15 @@ spec:
         app: {{ .Values.sentinel }}
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/redis-secret.yaml") . | sha256sum }}
+        {{- if hasKey $redisSecretProviderClass "conjur" }}
+        conjur.org/secrets: |
+          {{- range $redisSecretProviderClass.conjur }}
+          {{- range .paths }}
+          - {{ .usernamePath }}: {{ .usernamePath | quote }}
+          - {{ .passwordPath }}: {{ .passwordPath | quote }}
+          {{- end }}
+          {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: sentinel
       initContainers:

--- a/charts/csm-authorization-v2.0/charts/redis/templates/sentinel.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/templates/sentinel.yaml
@@ -1,6 +1,6 @@
 {{- $redisSecretProviderClass := .Values.redisSecretProviderClass | default dict }}
-{{- $redisSecretProviderClassName := .Values.redisSecretProviderClass.secretProviderClassName }}
-{{- $redisSecretName := .Values.redisSecretProviderClass.redisSecretName }}
+{{- $redisSecretProviderClassName := $redisSecretProviderClass.secretProviderClassName }}
+{{- $redisSecretName := $redisSecretProviderClass.redisSecretName }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -55,7 +55,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ $redisSecretName | default "redis-csm-secret" }}
-                key: {{ .Values.redisSecretProviderClass.redisPasswordKey | default "password" }}
+                key: {{ $redisSecretProviderClass.redisPasswordKey | default "password" }}
         args:
           - |
             MASTER_FOUND="false"

--- a/charts/csm-authorization-v2.0/charts/redis/values.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/values.yaml
@@ -4,6 +4,9 @@ redisSecretProviderClass:
   redisSecretName:
   redisUsernameKey:
   redisPasswordKey:
+  conjur:
+    passwordPath: secrets/redis-password
+    usernamePath: secrets/redis-username
 sentinel: sentinel
 rediscommander: rediscommander
 replicas: 5

--- a/charts/csm-authorization-v2.0/charts/redis/values.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/values.yaml
@@ -5,8 +5,8 @@ redisSecretProviderClass:
   redisUsernameKey:
   redisPasswordKey:
   conjur:
-    passwordPath: secrets/redis-password
-    usernamePath: secrets/redis-username
+    passwordPath:
+    usernamePath:
 sentinel: sentinel
 rediscommander: rediscommander
 replicas: 5

--- a/charts/csm-authorization-v2.0/templates/proxy-server.yaml
+++ b/charts/csm-authorization-v2.0/templates/proxy-server.yaml
@@ -1,3 +1,4 @@
+{{- $redisSecretProviderClass := .Values.redis.redisSecretProviderClass | default dict }}
 {{- $redisSecretProviderClassName := .Values.redis.redisSecretProviderClass.secretProviderClassName }}
 {{- $redisSecretName := .Values.redis.redisSecretProviderClass.redisSecretName }}
 ---
@@ -111,6 +112,16 @@ spec:
     metadata:
       labels:
         app: proxy-server
+      annotations:
+        {{- if hasKey $redisSecretProviderClass "conjur" }}
+        conjur.org/secrets: |
+          {{- range $redisSecretProviderClass.conjur }}
+          {{- range .paths }}
+          - {{ .usernamePath }}: {{ .usernamePath | quote }}
+          - {{ .passwordPath }}: {{ .passwordPath | quote }}
+          {{- end }}
+          {{- end }}
+        {{- end }}
     spec:
       serviceAccount: proxy-server
       containers:

--- a/charts/csm-authorization-v2.0/templates/proxy-server.yaml
+++ b/charts/csm-authorization-v2.0/templates/proxy-server.yaml
@@ -114,13 +114,11 @@ spec:
         app: proxy-server
       annotations:
         {{- if hasKey $redisSecretProviderClass "conjur" }}
+        {{- with $redisSecretProviderClass.conjur }}
         conjur.org/secrets: |
-          {{- range $redisSecretProviderClass.conjur }}
-          {{- range .paths }}
           - {{ .usernamePath }}: {{ .usernamePath | quote }}
           - {{ .passwordPath }}: {{ .passwordPath | quote }}
-          {{- end }}
-          {{- end }}
+        {{- end }}
         {{- end }}
     spec:
       serviceAccount: proxy-server

--- a/charts/csm-authorization-v2.0/templates/proxy-server.yaml
+++ b/charts/csm-authorization-v2.0/templates/proxy-server.yaml
@@ -1,6 +1,6 @@
 {{- $redisSecretProviderClass := .Values.redis.redisSecretProviderClass | default dict }}
-{{- $redisSecretProviderClassName := .Values.redis.redisSecretProviderClass.secretProviderClassName }}
-{{- $redisSecretName := .Values.redis.redisSecretProviderClass.redisSecretName }}
+{{- $redisSecretProviderClassName := $redisSecretProviderClass.secretProviderClassName }}
+{{- $redisSecretName := $redisSecretProviderClass.redisSecretName }}
 ---
 # Grant OPA/kube-mgmt read-only access to resources. This lets kube-mgmt
 # list configmaps to be loaded into OPA as policies.
@@ -141,7 +141,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ $redisSecretName | default "redis-csm-secret" }}
-                key: {{ .Values.redis.redisSecretProviderClass.redisPasswordKey | default "password" }}
+                key: {{ $redisSecretProviderClass.redisPasswordKey | default "password" }}
         args:
           - "--redis-sentinel={{ $str }}"
           - "--redis-password=$(REDIS_PASSWORD)"

--- a/charts/csm-authorization-v2.0/templates/storage-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/storage-service.yaml
@@ -1,16 +1,25 @@
 {{- $secretProviderClasses := .Values.storageSystemCredentials.secretProviderClasses | default dict }}
-{{- $vaultSPCs := $secretProviderClasses.vault | default list }}
-
 {{- $redisSecretProviderClass := .Values.redis.redisSecretProviderClass | default dict }}
 {{- $redisSecretProviderClassName := .Values.redis.redisSecretProviderClass.secretProviderClassName }}
 {{- $redisSecretName := .Values.redis.redisSecretProviderClass.redisSecretName }}
 
-# Add Redis secret provider class in the vault list if not already present
-{{- if not (has $redisSecretProviderClassName $vaultSPCs) }}
-  {{- $vaultSPCs = append $vaultSPCs $redisSecretProviderClassName }}
+# Get Vault SPC names directly from its SPC list
+{{- $vaultSPCNames := $secretProviderClasses.vault | default list }}
+
+# Get Conjur SPC names from each SPC
+{{- $conjurSPCs := $secretProviderClasses.conjur | default list }}
+{{- $conjurSPCNames := list }}
+{{- range $conjurSPC := $conjurSPCs }}
+  {{- $conjurSPCNames = append $conjurSPCNames $conjurSPC.name }}
 {{- end }}
 
-{{- $_ := set $secretProviderClasses "vault" $vaultSPCs }}
+# Combine SPC names from different providers
+{{- $allSPCNames := concat $vaultSPCNames $conjurSPCNames }}
+
+# Add Redis secret provider class in the SPC names list if not already present
+{{- if not (has $redisSecretProviderClassName $allSPCNames) }}
+  {{- $allSPCNames = append $allSPCNames $redisSecretProviderClassName }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -97,12 +106,20 @@ spec:
       labels:
         app: storage-service
       annotations:
-        {{- if or hasKey $secretProviderClasses "conjur" }}
+        {{- if or (hasKey $secretProviderClasses "conjur") (hasKey $redisSecretProviderClass "conjur") }}
         conjur.org/secrets: |
-          {{- range $secretProviderClasses.conjur }}
-          {{- range .paths }}
-          - {{ .usernamePath }}: {{ .usernamePath | quote }}
-          - {{ .passwordPath }}: {{ .passwordPath | quote }}
+          {{- if hasKey $secretProviderClasses "conjur" }}
+            {{- range $secretProviderClasses.conjur }}
+            {{- range .paths }}
+            - {{ .usernamePath }}: {{ .usernamePath | quote }}
+            - {{ .passwordPath }}: {{ .passwordPath | quote }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- if hasKey $redisSecretProviderClass "conjur" }}
+          {{- with $redisSecretProviderClass.conjur }}
+            - {{ .usernamePath }}: {{ .usernamePath | quote }}
+            - {{ .passwordPath }}: {{ .passwordPath | quote }}
           {{- end }}
           {{- end }}
         {{- end }}
@@ -145,17 +162,10 @@ spec:
         - name: csm-config-params
           mountPath: /etc/karavi-authorization/csm-config-params
         # secret provider class mounts
-        {{- if hasKey $secretProviderClasses "vault" }}
-        {{- range $secretproviderclass := $secretProviderClasses.vault }}
-        - name: secrets-store-inline-{{ $secretproviderclass }}
-          mountPath: /etc/csm-authorization/{{ $secretproviderclass }}
-          readOnly: true
-        {{- end }}
-        {{- end }}
-        {{- if hasKey $secretProviderClasses "conjur" }}
-        {{- range $secretproviderclass := $secretProviderClasses.conjur }}
-        - name: secrets-store-inline-{{ $secretproviderclass.name }}
-          mountPath: /etc/csm-authorization/{{ $secretproviderclass.name }}
+        {{- if $allSPCNames }}
+        {{- range $name := $allSPCNames }}
+        - name: secrets-store-inline-{{ $name }}
+          mountPath: /etc/csm-authorization/{{ $name }}
           readOnly: true
         {{- end }}
         {{- end }}
@@ -175,24 +185,14 @@ spec:
         configMap:
           name: csm-config-params
       # secret provider classes
-      {{- if and hasKey $secretProviderClasses "vault" }}
-      {{- range $secretproviderclass := $secretProviderClasses.vault }}
-      - name: secrets-store-inline-{{ $secretproviderclass }}
+      {{- if $allSPCNames }}
+      {{- range $name := $allSPCNames }}
+      - name: secrets-store-inline-{{ $name }}
         csi:
           driver: secrets-store.csi.k8s.io
           readOnly: true
           volumeAttributes:
-            secretProviderClass: "{{ $secretproviderclass }}"
-      {{- end }}
-      {{- end }}
-      {{- if hasKey $secretProviderClasses "conjur" }}
-      {{- range $secretproviderclass := $secretProviderClasses.conjur }}
-      - name: secrets-store-inline-{{ $secretproviderclass.name }}
-        csi:
-          driver: secrets-store.csi.k8s.io
-          readOnly: true
-          volumeAttributes:
-            secretProviderClass: "{{ $secretproviderclass.name }}"
+            secretProviderClass: "{{ $name }}"
       {{- end }}
       {{- end }}
       # kubernetes secret

--- a/charts/csm-authorization-v2.0/templates/storage-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/storage-service.yaml
@@ -1,6 +1,7 @@
 {{- $secretProviderClasses := .Values.storageSystemCredentials.secretProviderClasses | default dict }}
 {{- $vaultSPCs := $secretProviderClasses.vault | default list }}
 
+{{- $redisSecretProviderClass := .Values.redis.redisSecretProviderClass | default dict }}
 {{- $redisSecretProviderClassName := .Values.redis.redisSecretProviderClass.secretProviderClassName }}
 {{- $redisSecretName := .Values.redis.redisSecretProviderClass.redisSecretName }}
 
@@ -96,15 +97,26 @@ spec:
       labels:
         app: storage-service
       annotations:
-      {{- if and $secretProviderClasses (hasKey $secretProviderClasses "conjur") }}
+        {{- if or (hasKey $storageSecretProviderClasses "conjur") (hasKey $redisSecretProviderClass "conjur") }}
         conjur.org/secrets: |
-          {{- range $secretProviderClasses.conjur }}
-          {{- range .paths}}
-          - {{ .usernamePath }}: {{ .usernamePath | quote }}
-          - {{ .passwordPath }}: {{ .passwordPath | quote }}
+          {{- if hasKey $storageSecretProviderClasses "conjur" }}
+            {{- range $storageSecretProviderClasses.conjur }}
+            {{- range .paths }}
+            - {{ .usernamePath }}: {{ .usernamePath | quote }}
+            - {{ .passwordPath }}: {{ .passwordPath | quote }}
+            {{- end }}
+            {{- end }}
           {{- end }}
+          {{- if hasKey $redisSecretProviderClass "conjur" }}
+            {{- range $redisSecretProviderClass.conjur }}
+            {{- range .paths }}
+            - {{ .usernamePath }}: {{ .usernamePath | quote }}
+            - {{ .passwordPath }}: {{ .passwordPath | quote }}
+            {{- end }}
+            {{- end }}
           {{- end }}
-      {{- end }}
+        {{- end }}
+
     spec:
       serviceAccountName: storage-service
       containers:
@@ -142,16 +154,15 @@ spec:
           mountPath: /etc/karavi-authorization/config
         - name: csm-config-params
           mountPath: /etc/karavi-authorization/csm-config-params
-        # secret provider class mounts
-        {{- if and $secretProviderClasses (hasKey $secretProviderClasses "vault") }}
-        {{- range $secretproviderclass := $secretProviderClasses.vault }}
+        {{- if hasKey $storageSecretProviderClasses "vault" }}
+        {{- range $secretproviderclass := $storageSecretProviderClasses.vault }}
         - name: secrets-store-inline-{{ $secretproviderclass }}
           mountPath: /etc/csm-authorization/{{ $secretproviderclass }}
           readOnly: true
         {{- end }}
         {{- end }}
-        {{- if and $secretProviderClasses (hasKey $secretProviderClasses "conjur") }}
-        {{- range $secretproviderclass := $secretProviderClasses.conjur }}
+        {{- if hasKey $storageSecretProviderClasses "conjur" }}
+        {{- range $secretproviderclass := $storageSecretProviderClasses.conjur }}
         - name: secrets-store-inline-{{ $secretproviderclass.name }}
           mountPath: /etc/csm-authorization/{{ $secretproviderclass.name }}
           readOnly: true
@@ -172,9 +183,8 @@ spec:
       - name: csm-config-params
         configMap:
           name: csm-config-params
-      # secret provider classes
-      {{- if and $secretProviderClasses (hasKey $secretProviderClasses "vault") }}
-      {{- range $secretproviderclass := $secretProviderClasses.vault }}
+      {{- if hasKey $storageSecretProviderClasses "vault" }}
+      {{- range $secretproviderclass := $storageSecretProviderClasses.vault }}
       - name: secrets-store-inline-{{ $secretproviderclass }}
         csi:
           driver: secrets-store.csi.k8s.io
@@ -183,8 +193,8 @@ spec:
             secretProviderClass: "{{ $secretproviderclass }}"
       {{- end }}
       {{- end }}
-      {{- if and $secretProviderClasses (hasKey $secretProviderClasses "conjur") }}
-      {{- range $secretproviderclass := $secretProviderClasses.conjur }}
+      {{- if hasKey $storageSecretProviderClasses "conjur" }}
+      {{- range $secretproviderclass := $storageSecretProviderClasses.conjur }}
       - name: secrets-store-inline-{{ $secretproviderclass.name }}
         csi:
           driver: secrets-store.csi.k8s.io

--- a/charts/csm-authorization-v2.0/templates/storage-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/storage-service.yaml
@@ -1,7 +1,7 @@
 {{- $secretProviderClasses := .Values.storageSystemCredentials.secretProviderClasses | default dict }}
 {{- $redisSecretProviderClass := .Values.redis.redisSecretProviderClass | default dict }}
-{{- $redisSecretProviderClassName := .Values.redis.redisSecretProviderClass.secretProviderClassName }}
-{{- $redisSecretName := .Values.redis.redisSecretProviderClass.redisSecretName }}
+{{- $redisSecretProviderClassName := $redisSecretProviderClass.secretProviderClassName }}
+{{- $redisSecretName := $redisSecretProviderClass.redisSecretName }}
 
 # Get Vault SPC names directly from its SPC list
 {{- $vaultSPCNames := $secretProviderClasses.vault | default list }}
@@ -145,7 +145,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ $redisSecretName | default "redis-csm-secret" }}
-                key: {{ .Values.redis.redisSecretProviderClass.redisPasswordKey | default "password" }}
+                key: {{ $redisSecretProviderClass.redisPasswordKey | default "password" }}
         args:
           - "--redis-sentinel={{ $str }}"
           - "--redis-password=$(REDIS_PASSWORD)"

--- a/charts/csm-authorization-v2.0/templates/storage-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/storage-service.yaml
@@ -97,23 +97,13 @@ spec:
       labels:
         app: storage-service
       annotations:
-        {{- if or (hasKey $storageSecretProviderClasses "conjur") (hasKey $redisSecretProviderClass "conjur") }}
+        {{- if or hasKey $secretProviderClasses "conjur" }}
         conjur.org/secrets: |
-          {{- if hasKey $storageSecretProviderClasses "conjur" }}
-            {{- range $storageSecretProviderClasses.conjur }}
-            {{- range .paths }}
-            - {{ .usernamePath }}: {{ .usernamePath | quote }}
-            - {{ .passwordPath }}: {{ .passwordPath | quote }}
-            {{- end }}
-            {{- end }}
+          {{- range $secretProviderClasses.conjur }}
+          {{- range .paths }}
+          - {{ .usernamePath }}: {{ .usernamePath | quote }}
+          - {{ .passwordPath }}: {{ .passwordPath | quote }}
           {{- end }}
-          {{- if hasKey $redisSecretProviderClass "conjur" }}
-            {{- range $redisSecretProviderClass.conjur }}
-            {{- range .paths }}
-            - {{ .usernamePath }}: {{ .usernamePath | quote }}
-            - {{ .passwordPath }}: {{ .passwordPath | quote }}
-            {{- end }}
-            {{- end }}
           {{- end }}
         {{- end }}
 
@@ -154,15 +144,16 @@ spec:
           mountPath: /etc/karavi-authorization/config
         - name: csm-config-params
           mountPath: /etc/karavi-authorization/csm-config-params
-        {{- if hasKey $storageSecretProviderClasses "vault" }}
-        {{- range $secretproviderclass := $storageSecretProviderClasses.vault }}
+        # secret provider class mounts
+        {{- if hasKey $secretProviderClasses "vault" }}
+        {{- range $secretproviderclass := $secretProviderClasses.vault }}
         - name: secrets-store-inline-{{ $secretproviderclass }}
           mountPath: /etc/csm-authorization/{{ $secretproviderclass }}
           readOnly: true
         {{- end }}
         {{- end }}
-        {{- if hasKey $storageSecretProviderClasses "conjur" }}
-        {{- range $secretproviderclass := $storageSecretProviderClasses.conjur }}
+        {{- if hasKey $secretProviderClasses "conjur" }}
+        {{- range $secretproviderclass := $secretProviderClasses.conjur }}
         - name: secrets-store-inline-{{ $secretproviderclass.name }}
           mountPath: /etc/csm-authorization/{{ $secretproviderclass.name }}
           readOnly: true
@@ -183,8 +174,9 @@ spec:
       - name: csm-config-params
         configMap:
           name: csm-config-params
-      {{- if hasKey $storageSecretProviderClasses "vault" }}
-      {{- range $secretproviderclass := $storageSecretProviderClasses.vault }}
+      # secret provider classes
+      {{- if and hasKey $secretProviderClasses "vault" }}
+      {{- range $secretproviderclass := $secretProviderClasses.vault }}
       - name: secrets-store-inline-{{ $secretproviderclass }}
         csi:
           driver: secrets-store.csi.k8s.io
@@ -193,8 +185,8 @@ spec:
             secretProviderClass: "{{ $secretproviderclass }}"
       {{- end }}
       {{- end }}
-      {{- if hasKey $storageSecretProviderClasses "conjur" }}
-      {{- range $secretproviderclass := $storageSecretProviderClasses.conjur }}
+      {{- if hasKey $secretProviderClasses "conjur" }}
+      {{- range $secretproviderclass := $secretProviderClasses.conjur }}
       - name: secrets-store-inline-{{ $secretproviderclass.name }}
         csi:
           driver: secrets-store.csi.k8s.io

--- a/charts/csm-authorization-v2.0/templates/tenant-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/tenant-service.yaml
@@ -1,3 +1,4 @@
+{{- $redisSecretProviderClass := .Values.redis.redisSecretProviderClass | default dict }}
 {{- $redisSecretProviderClassName := .Values.redis.redisSecretProviderClass.secretProviderClassName }}
 {{- $redisSecretName := .Values.redis.redisSecretProviderClass.redisSecretName }}
 ---
@@ -36,6 +37,16 @@ spec:
     metadata:
       labels:
         app: tenant-service
+      annotations:
+        {{- if hasKey $redisSecretProviderClass "conjur" }}
+        conjur.org/secrets: |
+          {{- range $redisSecretProviderClass.conjur }}
+          {{- range .paths }}
+          - {{ .usernamePath }}: {{ .usernamePath | quote }}
+          - {{ .passwordPath }}: {{ .passwordPath | quote }}
+          {{- end }}
+          {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: tenant-service
       containers:

--- a/charts/csm-authorization-v2.0/templates/tenant-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/tenant-service.yaml
@@ -1,6 +1,6 @@
 {{- $redisSecretProviderClass := .Values.redis.redisSecretProviderClass | default dict }}
-{{- $redisSecretProviderClassName := .Values.redis.redisSecretProviderClass.secretProviderClassName }}
-{{- $redisSecretName := .Values.redis.redisSecretProviderClass.redisSecretName }}
+{{- $redisSecretProviderClassName := $redisSecretProviderClass.secretProviderClassName }}
+{{- $redisSecretName := $redisSecretProviderClass.redisSecretName }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -66,7 +66,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ $redisSecretName | default "redis-csm-secret" }}
-                key: {{ .Values.redis.redisSecretProviderClass.redisPasswordKey | default "password" }}
+                key: {{ $redisSecretProviderClass.redisPasswordKey | default "password" }}
         args:
           - "--redis-sentinel={{ $str }}"
           - "--redis-password=$(REDIS_PASSWORD)"

--- a/charts/csm-authorization-v2.0/templates/tenant-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/tenant-service.yaml
@@ -39,13 +39,11 @@ spec:
         app: tenant-service
       annotations:
         {{- if hasKey $redisSecretProviderClass "conjur" }}
+        {{- with $redisSecretProviderClass.conjur }}
         conjur.org/secrets: |
-          {{- range $redisSecretProviderClass.conjur }}
-          {{- range .paths }}
           - {{ .usernamePath }}: {{ .usernamePath | quote }}
           - {{ .passwordPath }}: {{ .passwordPath | quote }}
-          {{- end }}
-          {{- end }}
+        {{- end }}
         {{- end }}
     spec:
       serviceAccountName: tenant-service

--- a/charts/csm-authorization-v2.0/values.yaml
+++ b/charts/csm-authorization-v2.0/values.yaml
@@ -87,9 +87,9 @@ redis:
     redisPasswordKey:
 
     # Paths for Conjur secrets that store the Redis username and password.
-    conjur:
-      passwordPath: secrets/redis-password
-      usernamePath: secrets/redis-username
+    # conjur:
+    #   passwordPath: secrets/redis-password
+    #   usernamePath: secrets/redis-username
 
   sentinel: sentinel
   rediscommander: rediscommander

--- a/charts/csm-authorization-v2.0/values.yaml
+++ b/charts/csm-authorization-v2.0/values.yaml
@@ -85,6 +85,12 @@ redis:
     redisUsernameKey:
     # Key in the secret that stores the Redis password.
     redisPasswordKey:
+
+    # Paths for Conjur secrets that store the Redis username and password.
+    conjur:
+      passwordPath: secrets/redis-password
+      usernamePath: secrets/redis-username
+
   sentinel: sentinel
   rediscommander: rediscommander
   replicas: 5
@@ -107,16 +113,16 @@ storageSystemCredentials:
       # - secretProviderClassName3
 
     # conjur:
-        # - name: secretProviderClassName1
-          # paths:
-            # - passwordPath: secrets/password1
-            #   usernamePath: secrets/username1
-            # - passwordPath: secrets/password2
-            #   usernamePath: secrets/username2
-        # - name: secretProviderClassName2
-          # paths:
-            # - passwordPath: secrets/password3
-            #   usernamePath: secrets/username3
+    #   - name: secretProviderClassName1
+    #     paths:
+    #       - passwordPath: secrets/password1
+    #         usernamePath: secrets/username1
+    #       - passwordPath: secrets/password2
+    #         usernamePath: secrets/username2
+    #   - name: secretProviderClassName2
+    #     paths:
+    #       - passwordPath: secrets/password3
+    #         usernamePath: secrets/username3
 
   # secrets:
   #   - secret-1


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

#### Which issue(s) is this PR associated with:

https://github.com/dell/csm/issues/1468

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable

#### Tests:
Installed Authorization V2 successfully and created Auth resources including storage, role, and tenant, which became all ready and available in the follow scenarios:
- [x] Redis secret and storage system credentials are in the same secret provider class using Conjur
- [x] Only use Redis secret using Conjur and use standard k8s secret as storage system credentials