### PR TITLE
[charts/csm-authorization-v2.0]: Add SecretProviderClass (Vault/Conjur) support for karavi config secret to CSM Authorization

### DIFF
--- a/charts/csm-authorization-v2.0/charts/redis/values.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/values.yaml
@@ -4,9 +4,9 @@ redisSecretProviderClass:
   redisSecretName:
   redisUsernameKey:
   redisPasswordKey:
-  # conjur:
-  #   passwordPath:
-  #   usernamePath:
+  conjur:
+    passwordPath:
+    usernamePath:
 sentinel: sentinel
 rediscommander: rediscommander
 replicas: 5

--- a/charts/csm-authorization-v2.0/charts/redis/values.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/values.yaml
@@ -4,9 +4,9 @@ redisSecretProviderClass:
   redisSecretName:
   redisUsernameKey:
   redisPasswordKey:
-  conjur:
-    passwordPath:
-    usernamePath:
+  # conjur:
+  #   passwordPath:
+  #   usernamePath:
 sentinel: sentinel
 rediscommander: rediscommander
 replicas: 5

--- a/charts/csm-authorization-v2.0/templates/proxy-server.yaml
+++ b/charts/csm-authorization-v2.0/templates/proxy-server.yaml
@@ -7,7 +7,7 @@
 
 # Combine SPC names from different providers
 {{- $allSPCNames := (list $redisSecretProviderClassName $jwtSecretProviderClassName) }}
-{{- $allSPCNames = without $allSPCNames "" }}
+{{- $allSPCNames = compact $allSPCNames }}
 {{- $allSPCNames = uniq $allSPCNames }}
 ---
 # Grant OPA/kube-mgmt read-only access to resources. This lets kube-mgmt
@@ -120,8 +120,8 @@ spec:
     metadata:
       labels:
         app: proxy-server
+      {{- if or (hasKey $redisSecretProviderClass "conjur") (hasKey $jwtSecretProviderClass "conjur") }}
       annotations:
-        {{- if or (hasKey $redisSecretProviderClass "conjur") (hasKey $jwtSecretProviderClass "conjur") }}
         conjur.org/secrets: |
           {{- if hasKey $redisSecretProviderClass "conjur" }}
           {{- with $redisSecretProviderClass.conjur }}
@@ -134,7 +134,7 @@ spec:
           - {{ .signingSecretPath }}: {{ .signingSecretPath | quote }}
           {{- end }}
           {{- end }}
-        {{- end }}
+      {{- end }}
     spec:
       serviceAccount: proxy-server
       containers:

--- a/charts/csm-authorization-v2.0/templates/proxy-server.yaml
+++ b/charts/csm-authorization-v2.0/templates/proxy-server.yaml
@@ -1,6 +1,14 @@
 {{- $redisSecretProviderClass := .Values.redis.redisSecretProviderClass | default dict }}
 {{- $redisSecretProviderClassName := $redisSecretProviderClass.secretProviderClassName }}
 {{- $redisSecretName := $redisSecretProviderClass.redisSecretName }}
+
+{{- $jwtSecretProviderClass := .Values.jwt.jwtSecretProviderClass | default dict }}
+{{- $jwtSecretProviderClassName := $jwtSecretProviderClass.secretProviderClassName }}
+
+# Combine SPC names from different providers
+{{- $allSPCNames := (list $redisSecretProviderClassName $jwtSecretProviderClassName) }}
+{{- $allSPCNames = without $allSPCNames "" }}
+{{- $allSPCNames = uniq $allSPCNames }}
 ---
 # Grant OPA/kube-mgmt read-only access to resources. This lets kube-mgmt
 # list configmaps to be loaded into OPA as policies.
@@ -113,12 +121,19 @@ spec:
       labels:
         app: proxy-server
       annotations:
-        {{- if hasKey $redisSecretProviderClass "conjur" }}
-        {{- with $redisSecretProviderClass.conjur }}
+        {{- if or (hasKey $redisSecretProviderClass "conjur") (hasKey $jwtSecretProviderClass "conjur") }}
         conjur.org/secrets: |
+          {{- if hasKey $redisSecretProviderClass "conjur" }}
+          {{- with $redisSecretProviderClass.conjur }}
           - {{ .usernamePath }}: {{ .usernamePath | quote }}
           - {{ .passwordPath }}: {{ .passwordPath | quote }}
-        {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- if hasKey $jwtSecretProviderClass "conjur" }}
+          {{- with $jwtSecretProviderClass.conjur }}
+          - {{ .signingSecretPath }}: {{ .signingSecretPath | quote }}
+          {{- end }}
+          {{- end }}
         {{- end }}
     spec:
       serviceAccount: proxy-server
@@ -155,9 +170,10 @@ spec:
           mountPath: /etc/karavi-authorization/config
         - name: csm-config-params
           mountPath: /etc/karavi-authorization/csm-config-params
-        {{- if and $redisSecretProviderClassName $redisSecretName }}
-        - name: secrets-store-inline-{{ $redisSecretProviderClassName }}
-          mountPath: /etc/csm-authorization/{{ $redisSecretProviderClassName }}
+        # secret provider class mounts
+        {{- range $name := $allSPCNames }}
+        - name: secrets-store-inline-{{ $name }}
+          mountPath: /etc/csm-authorization/{{ $name }}
           readOnly: true
         {{- end }}
       - name: opa
@@ -180,17 +196,18 @@ spec:
       volumes:
       - name: config-volume
         secret:
-          secretName: karavi-config-secret
+          secretName: {{ $jwtSecretProviderClass.jwtsecretName | default "karavi-config-secret" }}
       - name: csm-config-params
         configMap:
           name: csm-config-params
-      {{- if and $redisSecretProviderClassName $redisSecretName }}
-      - name: secrets-store-inline-{{ $redisSecretProviderClassName }}
+      # secret provider classes
+      {{- range $name := $allSPCNames }}
+      - name: secrets-store-inline-{{ $name }}
         csi:
           driver: secrets-store.csi.k8s.io
           readOnly: true
           volumeAttributes:
-            secretProviderClass: "{{ $redisSecretProviderClassName }}"
+            secretProviderClass: "{{ $name }}"
       {{- end }}
 ---
 apiVersion: v1

--- a/charts/csm-authorization-v2.0/templates/proxy-server.yaml
+++ b/charts/csm-authorization-v2.0/templates/proxy-server.yaml
@@ -2,11 +2,11 @@
 {{- $redisSecretProviderClassName := $redisSecretProviderClass.secretProviderClassName }}
 {{- $redisSecretName := $redisSecretProviderClass.redisSecretName }}
 
-{{- $jwtSecretProviderClass := .Values.jwt.jwtSecretProviderClass | default dict }}
-{{- $jwtSecretProviderClassName := $jwtSecretProviderClass.secretProviderClassName }}
+{{- $configSecretProviderClass := .Values.config.configSecretProviderClass | default dict }}
+{{- $configSecretProviderClassName := $configSecretProviderClass.secretProviderClassName }}
 
 # Combine SPC names from different providers
-{{- $allSPCNames := (list $redisSecretProviderClassName $jwtSecretProviderClassName) }}
+{{- $allSPCNames := (list $redisSecretProviderClassName $configSecretProviderClassName) }}
 {{- $allSPCNames = compact $allSPCNames }}
 {{- $allSPCNames = uniq $allSPCNames }}
 ---
@@ -120,7 +120,7 @@ spec:
     metadata:
       labels:
         app: proxy-server
-      {{- if or (hasKey $redisSecretProviderClass "conjur") (hasKey $jwtSecretProviderClass "conjur") }}
+      {{- if or (hasKey $redisSecretProviderClass "conjur") (hasKey $configSecretProviderClass "conjur") }}
       annotations:
         conjur.org/secrets: |
           {{- if hasKey $redisSecretProviderClass "conjur" }}
@@ -129,9 +129,9 @@ spec:
           - {{ .passwordPath }}: {{ .passwordPath | quote }}
           {{- end }}
           {{- end }}
-          {{- if hasKey $jwtSecretProviderClass "conjur" }}
-          {{- with $jwtSecretProviderClass.conjur }}
-          - {{ .signingSecretPath }}: {{ .signingSecretPath | quote }}
+          {{- if hasKey $configSecretProviderClass "conjur" }}
+          {{- with $configSecretProviderClass.conjur }}
+          - {{ .configSecretPath }}: {{ .configSecretPath | quote }}
           {{- end }}
           {{- end }}
       {{- end }}
@@ -196,7 +196,7 @@ spec:
       volumes:
       - name: config-volume
         secret:
-          secretName: {{ $jwtSecretProviderClass.jwtSecretName | default "karavi-config-secret" }}
+          secretName: {{ $configSecretProviderClass.configSecretName | default "karavi-config-secret" }}
       - name: csm-config-params
         configMap:
           name: csm-config-params

--- a/charts/csm-authorization-v2.0/templates/proxy-server.yaml
+++ b/charts/csm-authorization-v2.0/templates/proxy-server.yaml
@@ -131,7 +131,7 @@ spec:
           {{- end }}
           {{- if hasKey $configSecretProviderClass "conjur" }}
           {{- with $configSecretProviderClass.conjur }}
-          - {{ .configSecretPath }}: {{ .configSecretPath | quote }}
+          - {{ .secretPath }}: {{ .secretPath | quote }}
           {{- end }}
           {{- end }}
       {{- end }}

--- a/charts/csm-authorization-v2.0/templates/proxy-server.yaml
+++ b/charts/csm-authorization-v2.0/templates/proxy-server.yaml
@@ -196,7 +196,7 @@ spec:
       volumes:
       - name: config-volume
         secret:
-          secretName: {{ $jwtSecretProviderClass.jwtsecretName | default "karavi-config-secret" }}
+          secretName: {{ $jwtSecretProviderClass.jwtSecretName | default "karavi-config-secret" }}
       - name: csm-config-params
         configMap:
           name: csm-config-params

--- a/charts/csm-authorization-v2.0/templates/storage-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/storage-service.yaml
@@ -110,22 +110,22 @@ spec:
         {{- if or (hasKey $storageSecretProviderClasses "conjur") (hasKey $redisSecretProviderClass "conjur") (hasKey $jwtSecretProviderClass "conjur") }}
         conjur.org/secrets: |
           {{- if hasKey $storageSecretProviderClasses "conjur" }}
-            {{- range $storageSecretProviderClasses.conjur }}
-            {{- range .paths }}
-            - {{ .usernamePath }}: {{ .usernamePath | quote }}
-            - {{ .passwordPath }}: {{ .passwordPath | quote }}
-            {{- end }}
-            {{- end }}
+          {{- range $storageSecretProviderClasses.conjur }}
+          {{- range .paths }}
+          - {{ .usernamePath }}: {{ .usernamePath | quote }}
+          - {{ .passwordPath }}: {{ .passwordPath | quote }}
+          {{- end }}
+          {{- end }}
           {{- end }}
           {{- if hasKey $redisSecretProviderClass "conjur" }}
           {{- with $redisSecretProviderClass.conjur }}
-            - {{ .usernamePath }}: {{ .usernamePath | quote }}
-            - {{ .passwordPath }}: {{ .passwordPath | quote }}
+          - {{ .usernamePath }}: {{ .usernamePath | quote }}
+          - {{ .passwordPath }}: {{ .passwordPath | quote }}
           {{- end }}
           {{- end }}
           {{- if hasKey $jwtSecretProviderClass "conjur" }}
           {{- with $jwtSecretProviderClass.conjur }}
-            - {{ .signingSecretPath }}: {{ .signingSecretPath | quote }}
+          - {{ .signingSecretPath }}: {{ .signingSecretPath | quote }}
           {{- end }}
           {{- end }}
         {{- end }}
@@ -168,12 +168,10 @@ spec:
         - name: csm-config-params
           mountPath: /etc/karavi-authorization/csm-config-params
         # secret provider class mounts
-        {{- if $allSPCNames }}
         {{- range $name := $allSPCNames }}
         - name: secrets-store-inline-{{ $name }}
           mountPath: /etc/csm-authorization/{{ $name }}
           readOnly: true
-        {{- end }}
         {{- end }}
         # kubernetes secret mount
         {{- if .Values.storageSystemCredentials.secrets }}
@@ -191,7 +189,6 @@ spec:
         configMap:
           name: csm-config-params
       # secret provider classes
-      {{- if $allSPCNames }}
       {{- range $name := $allSPCNames }}
       - name: secrets-store-inline-{{ $name }}
         csi:
@@ -199,7 +196,6 @@ spec:
           readOnly: true
           volumeAttributes:
             secretProviderClass: "{{ $name }}"
-      {{- end }}
       {{- end }}
       # kubernetes secret
       {{- if .Values.storageSystemCredentials.secrets }}

--- a/charts/csm-authorization-v2.0/templates/storage-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/storage-service.yaml
@@ -125,7 +125,7 @@ spec:
           {{- end }}
           {{- if hasKey $configSecretProviderClass "conjur" }}
           {{- with $configSecretProviderClass.conjur }}
-          - {{ .configSecretPath }}: {{ .configSecretPath | quote }}
+          - {{ .secretPath }}: {{ .secretPath | quote }}
           {{- end }}
           {{- end }}
       {{- end }}

--- a/charts/csm-authorization-v2.0/templates/storage-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/storage-service.yaml
@@ -184,7 +184,7 @@ spec:
       volumes:
       - name: config-volume
         secret:
-          secretName: {{ $jwtSecretProviderClass.jwtsecretName | default "karavi-config-secret" }}
+          secretName: {{ $jwtSecretProviderClass.jwtSecretName | default "karavi-config-secret" }}
       - name: csm-config-params
         configMap:
           name: csm-config-params

--- a/charts/csm-authorization-v2.0/templates/storage-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/storage-service.yaml
@@ -19,7 +19,7 @@
 
 # Combine SPC names from different providers
 {{- $allSPCNames := concat $vaultSPCNames $conjurSPCNames (list $redisSecretProviderClassName $jwtSecretProviderClassName) }}
-{{- $allSPCNames = without $allSPCNames "" }}
+{{- $allSPCNames = compact $allSPCNames }}
 {{- $allSPCNames = uniq $allSPCNames }}
 ---
 apiVersion: v1
@@ -106,8 +106,8 @@ spec:
     metadata:
       labels:
         app: storage-service
+      {{- if or (hasKey $storageSecretProviderClasses "conjur") (hasKey $redisSecretProviderClass "conjur") (hasKey $jwtSecretProviderClass "conjur") }}
       annotations:
-        {{- if or (hasKey $storageSecretProviderClasses "conjur") (hasKey $redisSecretProviderClass "conjur") (hasKey $jwtSecretProviderClass "conjur") }}
         conjur.org/secrets: |
           {{- if hasKey $storageSecretProviderClasses "conjur" }}
           {{- range $storageSecretProviderClasses.conjur }}
@@ -128,8 +128,7 @@ spec:
           - {{ .signingSecretPath }}: {{ .signingSecretPath | quote }}
           {{- end }}
           {{- end }}
-        {{- end }}
-
+      {{- end }}
     spec:
       serviceAccountName: storage-service
       containers:

--- a/charts/csm-authorization-v2.0/templates/storage-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/storage-service.yaml
@@ -1,25 +1,26 @@
-{{- $secretProviderClasses := .Values.storageSystemCredentials.secretProviderClasses | default dict }}
+{{- $storageSecretProviderClasses := .Values.storageSystemCredentials.secretProviderClasses | default dict }}
+
 {{- $redisSecretProviderClass := .Values.redis.redisSecretProviderClass | default dict }}
 {{- $redisSecretProviderClassName := $redisSecretProviderClass.secretProviderClassName }}
 {{- $redisSecretName := $redisSecretProviderClass.redisSecretName }}
 
-# Get Vault SPC names directly from its SPC list
-{{- $vaultSPCNames := $secretProviderClasses.vault | default list }}
+{{- $jwtSecretProviderClass := .Values.jwt.jwtSecretProviderClass | default dict }}
+{{- $jwtSecretProviderClassName := $jwtSecretProviderClass.secretProviderClassName }}
 
-# Get Conjur SPC names from each SPC
-{{- $conjurSPCs := $secretProviderClasses.conjur | default list }}
+# Get Vault SPC names directly from the storageSystemCredentials SPC list
+{{- $vaultSPCNames := $storageSecretProviderClasses.vault | default list }}
+
+# Get Conjur SPC names from each storageSystemCredentials SPC
+{{- $conjurSPCs := $storageSecretProviderClasses.conjur | default list }}
 {{- $conjurSPCNames := list }}
 {{- range $conjurSPC := $conjurSPCs }}
   {{- $conjurSPCNames = append $conjurSPCNames $conjurSPC.name }}
 {{- end }}
 
 # Combine SPC names from different providers
-{{- $allSPCNames := concat $vaultSPCNames $conjurSPCNames }}
-
-# Add Redis secret provider class in the SPC names list if not already present
-{{- if not (has $redisSecretProviderClassName $allSPCNames) }}
-  {{- $allSPCNames = append $allSPCNames $redisSecretProviderClassName }}
-{{- end }}
+{{- $allSPCNames := concat $vaultSPCNames $conjurSPCNames (list $redisSecretProviderClassName $jwtSecretProviderClassName) }}
+{{- $allSPCNames = without $allSPCNames "" }}
+{{- $allSPCNames = uniq $allSPCNames }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -106,10 +107,10 @@ spec:
       labels:
         app: storage-service
       annotations:
-        {{- if or (hasKey $secretProviderClasses "conjur") (hasKey $redisSecretProviderClass "conjur") }}
+        {{- if or (hasKey $storageSecretProviderClasses "conjur") (hasKey $redisSecretProviderClass "conjur") (hasKey $jwtSecretProviderClass "conjur") }}
         conjur.org/secrets: |
-          {{- if hasKey $secretProviderClasses "conjur" }}
-            {{- range $secretProviderClasses.conjur }}
+          {{- if hasKey $storageSecretProviderClasses "conjur" }}
+            {{- range $storageSecretProviderClasses.conjur }}
             {{- range .paths }}
             - {{ .usernamePath }}: {{ .usernamePath | quote }}
             - {{ .passwordPath }}: {{ .passwordPath | quote }}
@@ -120,6 +121,11 @@ spec:
           {{- with $redisSecretProviderClass.conjur }}
             - {{ .usernamePath }}: {{ .usernamePath | quote }}
             - {{ .passwordPath }}: {{ .passwordPath | quote }}
+          {{- end }}
+          {{- end }}
+          {{- if hasKey $jwtSecretProviderClass "conjur" }}
+          {{- with $jwtSecretProviderClass.conjur }}
+            - {{ .signingSecretPath }}: {{ .signingSecretPath | quote }}
           {{- end }}
           {{- end }}
         {{- end }}
@@ -180,7 +186,7 @@ spec:
       volumes:
       - name: config-volume
         secret:
-          secretName: karavi-config-secret
+          secretName: {{ $jwtSecretProviderClass.jwtsecretName | default "karavi-config-secret" }}
       - name: csm-config-params
         configMap:
           name: csm-config-params

--- a/charts/csm-authorization-v2.0/templates/storage-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/storage-service.yaml
@@ -4,8 +4,8 @@
 {{- $redisSecretProviderClassName := $redisSecretProviderClass.secretProviderClassName }}
 {{- $redisSecretName := $redisSecretProviderClass.redisSecretName }}
 
-{{- $jwtSecretProviderClass := .Values.jwt.jwtSecretProviderClass | default dict }}
-{{- $jwtSecretProviderClassName := $jwtSecretProviderClass.secretProviderClassName }}
+{{- $configSecretProviderClass := .Values.config.configSecretProviderClass | default dict }}
+{{- $configSecretProviderClassName := $configSecretProviderClass.secretProviderClassName }}
 
 # Get Vault SPC names directly from the storageSystemCredentials SPC list
 {{- $vaultSPCNames := $storageSecretProviderClasses.vault | default list }}
@@ -18,7 +18,7 @@
 {{- end }}
 
 # Combine SPC names from different providers
-{{- $allSPCNames := concat $vaultSPCNames $conjurSPCNames (list $redisSecretProviderClassName $jwtSecretProviderClassName) }}
+{{- $allSPCNames := concat $vaultSPCNames $conjurSPCNames (list $redisSecretProviderClassName $configSecretProviderClassName) }}
 {{- $allSPCNames = compact $allSPCNames }}
 {{- $allSPCNames = uniq $allSPCNames }}
 ---
@@ -106,7 +106,7 @@ spec:
     metadata:
       labels:
         app: storage-service
-      {{- if or (hasKey $storageSecretProviderClasses "conjur") (hasKey $redisSecretProviderClass "conjur") (hasKey $jwtSecretProviderClass "conjur") }}
+      {{- if or (hasKey $storageSecretProviderClasses "conjur") (hasKey $redisSecretProviderClass "conjur") (hasKey $configSecretProviderClass "conjur") }}
       annotations:
         conjur.org/secrets: |
           {{- if hasKey $storageSecretProviderClasses "conjur" }}
@@ -123,9 +123,9 @@ spec:
           - {{ .passwordPath }}: {{ .passwordPath | quote }}
           {{- end }}
           {{- end }}
-          {{- if hasKey $jwtSecretProviderClass "conjur" }}
-          {{- with $jwtSecretProviderClass.conjur }}
-          - {{ .signingSecretPath }}: {{ .signingSecretPath | quote }}
+          {{- if hasKey $configSecretProviderClass "conjur" }}
+          {{- with $configSecretProviderClass.conjur }}
+          - {{ .configSecretPath }}: {{ .configSecretPath | quote }}
           {{- end }}
           {{- end }}
       {{- end }}
@@ -183,7 +183,7 @@ spec:
       volumes:
       - name: config-volume
         secret:
-          secretName: {{ $jwtSecretProviderClass.jwtSecretName | default "karavi-config-secret" }}
+          secretName: {{ $configSecretProviderClass.configSecretName | default "karavi-config-secret" }}
       - name: csm-config-params
         configMap:
           name: csm-config-params

--- a/charts/csm-authorization-v2.0/templates/tenant-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/tenant-service.yaml
@@ -7,7 +7,7 @@
 
 # Combine SPC names from different providers
 {{- $allSPCNames := (list $redisSecretProviderClassName $jwtSecretProviderClassName) }}
-{{- $allSPCNames = without $allSPCNames "" }}
+{{- $allSPCNames = compact $allSPCNames }}
 {{- $allSPCNames = uniq $allSPCNames }}
 ---
 apiVersion: v1
@@ -45,8 +45,8 @@ spec:
     metadata:
       labels:
         app: tenant-service
+      {{- if or (hasKey $redisSecretProviderClass "conjur") (hasKey $jwtSecretProviderClass "conjur") }}
       annotations:
-        {{- if or (hasKey $redisSecretProviderClass "conjur") (hasKey $jwtSecretProviderClass "conjur") }}
         conjur.org/secrets: |
           {{- if hasKey $redisSecretProviderClass "conjur" }}
           {{- with $redisSecretProviderClass.conjur }}
@@ -59,7 +59,7 @@ spec:
           - {{ .signingSecretPath }}: {{ .signingSecretPath | quote }}
           {{- end }}
           {{- end }}
-        {{- end }}
+      {{- end }}
     spec:
       serviceAccountName: tenant-service
       containers:

--- a/charts/csm-authorization-v2.0/templates/tenant-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/tenant-service.yaml
@@ -1,6 +1,14 @@
 {{- $redisSecretProviderClass := .Values.redis.redisSecretProviderClass | default dict }}
 {{- $redisSecretProviderClassName := $redisSecretProviderClass.secretProviderClassName }}
 {{- $redisSecretName := $redisSecretProviderClass.redisSecretName }}
+
+{{- $jwtSecretProviderClass := .Values.jwt.jwtSecretProviderClass | default dict }}
+{{- $jwtSecretProviderClassName := $jwtSecretProviderClass.secretProviderClassName }}
+
+# Combine SPC names from different providers
+{{- $allSPCNames := (list $redisSecretProviderClassName $jwtSecretProviderClassName) }}
+{{- $allSPCNames = without $allSPCNames "" }}
+{{- $allSPCNames = uniq $allSPCNames }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -38,12 +46,19 @@ spec:
       labels:
         app: tenant-service
       annotations:
-        {{- if hasKey $redisSecretProviderClass "conjur" }}
-        {{- with $redisSecretProviderClass.conjur }}
+        {{- if or (hasKey $redisSecretProviderClass "conjur") (hasKey $jwtSecretProviderClass "conjur") }}
         conjur.org/secrets: |
+          {{- if hasKey $redisSecretProviderClass "conjur" }}
+          {{- with $redisSecretProviderClass.conjur }}
           - {{ .usernamePath }}: {{ .usernamePath | quote }}
           - {{ .passwordPath }}: {{ .passwordPath | quote }}
-        {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- if hasKey $jwtSecretProviderClass "conjur" }}
+          {{- with $jwtSecretProviderClass.conjur }}
+          - {{ .signingSecretPath }}: {{ .signingSecretPath | quote }}
+          {{- end }}
+          {{- end }}
         {{- end }}
     spec:
       serviceAccountName: tenant-service
@@ -78,25 +93,27 @@ spec:
           mountPath: /etc/karavi-authorization/config
         - name: csm-config-params
           mountPath: /etc/karavi-authorization/csm-config-params
-        {{- if and $redisSecretProviderClassName $redisSecretName }}
-        - name: secrets-store-inline-{{ $redisSecretProviderClassName }}
-          mountPath: /etc/csm-authorization/{{ $redisSecretProviderClassName }}
+        # secret provider class mounts
+        {{- range $name := $allSPCNames }}
+        - name: secrets-store-inline-{{ $name }}
+          mountPath: /etc/csm-authorization/{{ $name }}
           readOnly: true
         {{- end }}
       volumes:
       - name: config-volume
         secret:
-          secretName: karavi-config-secret
+          secretName: {{ $jwtSecretProviderClass.jwtsecretName | default "karavi-config-secret" }}
       - name: csm-config-params
         configMap:
           name: csm-config-params
-      {{- if and $redisSecretProviderClassName $redisSecretName }}
-      - name: secrets-store-inline-{{ $redisSecretProviderClassName }}
+      # secret provider classes
+      {{- range $name := $allSPCNames }}
+      - name: secrets-store-inline-{{ $name }}
         csi:
           driver: secrets-store.csi.k8s.io
           readOnly: true
           volumeAttributes:
-            secretProviderClass: "{{ $redisSecretProviderClassName }}"
+            secretProviderClass: "{{ $name }}"
       {{- end }}
 ---
 apiVersion: v1

--- a/charts/csm-authorization-v2.0/templates/tenant-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/tenant-service.yaml
@@ -56,7 +56,7 @@ spec:
           {{- end }}
           {{- if hasKey $configSecretProviderClass "conjur" }}
           {{- with $configSecretProviderClass.conjur }}
-          - {{ .configSecretPath }}: {{ .configSecretPath | quote }}
+          - {{ .secretPath }}: {{ .secretPath | quote }}
           {{- end }}
           {{- end }}
       {{- end }}

--- a/charts/csm-authorization-v2.0/templates/tenant-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/tenant-service.yaml
@@ -102,7 +102,7 @@ spec:
       volumes:
       - name: config-volume
         secret:
-          secretName: {{ $jwtSecretProviderClass.jwtsecretName | default "karavi-config-secret" }}
+          secretName: {{ $jwtSecretProviderClass.jwtSecretName | default "karavi-config-secret" }}
       - name: csm-config-params
         configMap:
           name: csm-config-params

--- a/charts/csm-authorization-v2.0/templates/tenant-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/tenant-service.yaml
@@ -2,11 +2,11 @@
 {{- $redisSecretProviderClassName := $redisSecretProviderClass.secretProviderClassName }}
 {{- $redisSecretName := $redisSecretProviderClass.redisSecretName }}
 
-{{- $jwtSecretProviderClass := .Values.jwt.jwtSecretProviderClass | default dict }}
-{{- $jwtSecretProviderClassName := $jwtSecretProviderClass.secretProviderClassName }}
+{{- $configSecretProviderClass := .Values.config.configSecretProviderClass | default dict }}
+{{- $configSecretProviderClassName := $configSecretProviderClass.secretProviderClassName }}
 
 # Combine SPC names from different providers
-{{- $allSPCNames := (list $redisSecretProviderClassName $jwtSecretProviderClassName) }}
+{{- $allSPCNames := (list $redisSecretProviderClassName $configSecretProviderClassName) }}
 {{- $allSPCNames = compact $allSPCNames }}
 {{- $allSPCNames = uniq $allSPCNames }}
 ---
@@ -45,7 +45,7 @@ spec:
     metadata:
       labels:
         app: tenant-service
-      {{- if or (hasKey $redisSecretProviderClass "conjur") (hasKey $jwtSecretProviderClass "conjur") }}
+      {{- if or (hasKey $redisSecretProviderClass "conjur") (hasKey $configSecretProviderClass "conjur") }}
       annotations:
         conjur.org/secrets: |
           {{- if hasKey $redisSecretProviderClass "conjur" }}
@@ -54,9 +54,9 @@ spec:
           - {{ .passwordPath }}: {{ .passwordPath | quote }}
           {{- end }}
           {{- end }}
-          {{- if hasKey $jwtSecretProviderClass "conjur" }}
-          {{- with $jwtSecretProviderClass.conjur }}
-          - {{ .signingSecretPath }}: {{ .signingSecretPath | quote }}
+          {{- if hasKey $configSecretProviderClass "conjur" }}
+          {{- with $configSecretProviderClass.conjur }}
+          - {{ .configSecretPath }}: {{ .configSecretPath | quote }}
           {{- end }}
           {{- end }}
       {{- end }}
@@ -102,7 +102,7 @@ spec:
       volumes:
       - name: config-volume
         secret:
-          secretName: {{ $jwtSecretProviderClass.jwtSecretName | default "karavi-config-secret" }}
+          secretName: {{ $configSecretProviderClass.configSecretName | default "karavi-config-secret" }}
       - name: csm-config-params
         configMap:
           name: csm-config-params

--- a/charts/csm-authorization-v2.0/values.yaml
+++ b/charts/csm-authorization-v2.0/values.yaml
@@ -100,6 +100,23 @@ redis:
     commander:
       image: rediscommander/redis-commander:latest
 
+jwt:
+  # Optional:
+  # JWT secret configuration:
+  # If using a Secret Store CSI driver, specify the SecretProviderClass details that holds the JWT secretObject.
+  # Otherwise, you must create a Kubernetes secret called "karavi-config-secret".
+  jwtSecretProviderClass:
+    # Name of the SecretProviderClass that holds the JWT secretObject.
+    secretProviderClassName:
+    # Name of the Kubernetes secret (created by the Secret Store CSI driver) that contains the JWT secret.
+    jwtSecretName:
+    # Key in the secret that stores the JWT secret.
+    signingSecretKey:
+
+    # Paths for Conjur secret that stores the JWT secret.
+    # conjur:
+    #   signingSecretPath:
+
 # Comment and uncomment the appropriate sections below to use the desired method.
 # Storage system credentials can be provided in one of two ways:
 # 1. Using a SecretProviderClass (for dynamic secrets from external providers)
@@ -128,20 +145,3 @@ storageSystemCredentials:
   #   - secret-1
   #   - secret-2
   #   - secret-3
-
-jwt:
-# Optional:
-# JWT secret configuration:
-# If using a Secret Store CSI driver, specify the SecretProviderClass details that holds the JWT secretObject.
-# Otherwise, you must create a Kubernetes secret called "karavi-config-secret".
-jwtSecretProviderClass:
-  # Name of the SecretProviderClass that holds the JWT secretObject.
-  secretProviderClassName:
-  # Name of the Kubernetes secret (created by the Secret Store CSI driver) that contains the JWT secret.
-  jwtsecretName:
-  # Key in the secret that stores the JWT secret.
-  signingSecretKey:
-
-  # Paths for Conjur secret that stores the JWT secret.
-  conjur:
-    signingSecretPath: 

--- a/charts/csm-authorization-v2.0/values.yaml
+++ b/charts/csm-authorization-v2.0/values.yaml
@@ -100,20 +100,20 @@ redis:
     commander:
       image: rediscommander/redis-commander:latest
 
-jwt:
+config:
   # Optional:
-  # JWT secret configuration:
-  # If using a Secret Store CSI driver, specify the SecretProviderClass details that holds the JWT secretObject.
+  # Config secret configuration:
+  # If using a Secret Store CSI driver, specify the SecretProviderClass details that holds the config secretObject.
   # Otherwise, you must create a Kubernetes secret called "karavi-config-secret".
-  jwtSecretProviderClass:
-    # Name of the SecretProviderClass that holds the JWT secretObject.
+  configSecretProviderClass:
+    # Name of the SecretProviderClass that holds the config secretObject.
     secretProviderClassName:
-    # Name of the Kubernetes secret (created by the Secret Store CSI driver) that contains the JWT secret.
-    jwtSecretName:
+    # Name of the Kubernetes secret (created by the Secret Store CSI driver) that contains the config secret.
+    configSecretName:
 
-    # Paths for Conjur secret that stores the JWT secret.
+    # Paths for Conjur secret that stores the config secret.
     # conjur:
-    #   signingSecretPath:
+    #   configSecretPath: secrets/config-object
 
 # Comment and uncomment the appropriate sections below to use the desired method.
 # Storage system credentials can be provided in one of two ways:

--- a/charts/csm-authorization-v2.0/values.yaml
+++ b/charts/csm-authorization-v2.0/values.yaml
@@ -100,20 +100,21 @@ redis:
     commander:
       image: rediscommander/redis-commander:latest
 
+# Optional:
+# Config secret configuration:
+# If using a Secret Store CSI driver, specify the SecretProviderClass details that holds the config secretObject.
+# Otherwise leave the fields blank and create the "karavi-config-secret" Kubernetes secret.
 config:
-  # Optional:
-  # Config secret configuration:
-  # If using a Secret Store CSI driver, specify the SecretProviderClass details that holds the config secretObject.
-  # Otherwise, you must create a Kubernetes secret called "karavi-config-secret".
   configSecretProviderClass:
     # Name of the SecretProviderClass that holds the config secretObject.
     secretProviderClassName:
     # Name of the Kubernetes secret (created by the Secret Store CSI driver) that contains the config secret.
     configSecretName:
 
-    # Paths for Conjur secret that stores the config secret.
+    # Uncomment this section if using Conjur to store the config secret, otherwise leave commented out.
+    # Path for Conjur secret that stores the config secret.
     # conjur:
-    #   configSecretPath: secrets/config-object
+    #   secretPath: secrets/config-object
 
 # Comment and uncomment the appropriate sections below to use the desired method.
 # Storage system credentials can be provided in one of two ways:

--- a/charts/csm-authorization-v2.0/values.yaml
+++ b/charts/csm-authorization-v2.0/values.yaml
@@ -110,8 +110,6 @@ jwt:
     secretProviderClassName:
     # Name of the Kubernetes secret (created by the Secret Store CSI driver) that contains the JWT secret.
     jwtSecretName:
-    # Key in the secret that stores the JWT secret.
-    signingSecretKey:
 
     # Paths for Conjur secret that stores the JWT secret.
     # conjur:

--- a/charts/csm-authorization-v2.0/values.yaml
+++ b/charts/csm-authorization-v2.0/values.yaml
@@ -128,3 +128,20 @@ storageSystemCredentials:
   #   - secret-1
   #   - secret-2
   #   - secret-3
+
+jwt:
+# Optional:
+# JWT secret configuration:
+# If using a Secret Store CSI driver, specify the SecretProviderClass details that holds the JWT secretObject.
+# Otherwise, you must create a Kubernetes secret called "karavi-config-secret".
+jwtSecretProviderClass:
+  # Name of the SecretProviderClass that holds the JWT secretObject.
+  secretProviderClassName:
+  # Name of the Kubernetes secret (created by the Secret Store CSI driver) that contains the JWT secret.
+  jwtsecretName:
+  # Key in the secret that stores the JWT secret.
+  signingSecretKey:
+
+  # Paths for Conjur secret that stores the JWT secret.
+  conjur:
+    signingSecretPath: 


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
- Supports [karavi config secret](https://dell.github.io/csm-docs/docs/getting-started/installation/kubernetes/powerflex/helm/csm-modules/authorizationv2-0/#install-container-storage-modules-authorization) coming from a SecretProviderClass object. 
  - Both Vault and Conjur
- Ensures a SPC is only mounted a single time even if it used for multiple secrets, ex: redis and storage

#### Which issue(s) is this PR associated with:

https://github.com/dell/csm/issues/1468

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable

Tests:
Installed Authorization V2 successfully and created Auth resources including storage, role, and tenant, which became all ready and available in the follow scenarios:
- [x] storage system credentials using a k8s secret, redis using default created secret, karavi config secret in vault
- [x] storage system credentials using a k8s secret, redis using default created secret, karavi config secret in conjur
- [x] storage system credentials in vault, redis using default created secret, karavi config secret in vault
  - storage creds and config secret shared the same SPC
- [x] storage system credentials using a k8s secret, redis using conjur, karavi config secret in conjur
  - redis and config secret shared the same SPC
- [x] storage system credentials using a k8s secret, redis using conjur, karavi config secret in conjur
  - redis and config secret were in different SPCs