### PR TITLE
Simplify Auth v2 deployment by removing karavi-authorization-config Secret requirement

### DIFF
--- a/charts/csi-isilon/templates/controller.yaml
+++ b/charts/csi-isilon/templates/controller.yaml
@@ -513,8 +513,8 @@ spec:
                   name: proxy-authz-tokens
                   key: refresh
           volumeMounts:
-            - name: karavi-authorization-config
-              mountPath: /etc/karavi-authorization/config
+            - name: isilon-configs
+              mountPath: /isilon-configs
             - name: proxy-server-root-certificate
               mountPath: /etc/karavi-authorization/root-certificates
             - name: csi-isilon-config-params
@@ -542,9 +542,6 @@ spec:
              name: {{ .Release.Name }}-config-params
         {{- if hasKey .Values "authorization" }}
         {{- if eq .Values.authorization.enabled true }}
-        - name: karavi-authorization-config
-          secret:
-            secretName: karavi-authorization-config
         - name: proxy-server-root-certificate
           secret:
             secretName: proxy-server-root-certificate

--- a/charts/csi-isilon/templates/controller.yaml
+++ b/charts/csi-isilon/templates/controller.yaml
@@ -1,3 +1,5 @@
+{{- $authorizationConfigSecret := lookup "v1" "Secret" .Release.Namespace "karavi-authorization-config" }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -513,8 +515,13 @@ spec:
                   name: proxy-authz-tokens
                   key: refresh
           volumeMounts:
+            {{- if $authorizationConfigSecret }}
+            - name: karavi-authorization-config
+              mountPath: /etc/karavi-authorization/config
+            {{- else }}
             - name: isilon-configs
               mountPath: /isilon-configs
+            {{- end }}
             - name: proxy-server-root-certificate
               mountPath: /etc/karavi-authorization/root-certificates
             - name: csi-isilon-config-params
@@ -542,6 +549,11 @@ spec:
              name: {{ .Release.Name }}-config-params
         {{- if hasKey .Values "authorization" }}
         {{- if eq .Values.authorization.enabled true }}
+        {{- if $authorizationConfigSecret }}
+        - name: karavi-authorization-config
+          secret:
+            secretName: karavi-authorization-config
+        {{- end }}
         - name: proxy-server-root-certificate
           secret:
             secretName: proxy-server-root-certificate

--- a/charts/csi-isilon/templates/node.yaml
+++ b/charts/csi-isilon/templates/node.yaml
@@ -1,3 +1,5 @@
+{{- $authorizationConfigSecret := lookup "v1" "Secret" .Release.Namespace "karavi-authorization-config" }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -298,8 +300,13 @@ spec:
                   name: proxy-authz-tokens
                   key: refresh
           volumeMounts:
+            {{- if $authorizationConfigSecret }}
+            - name: karavi-authorization-config
+              mountPath: /etc/karavi-authorization/config
+            {{- else }}
             - name: isilon-configs
               mountPath: /isilon-configs
+            {{- end }}
             - name: proxy-server-root-certificate
               mountPath: /etc/karavi-authorization/root-certificates
             - name: csi-isilon-config-params
@@ -345,6 +352,11 @@ spec:
              name: {{ .Release.Name }}-config-params
         {{- if hasKey .Values "authorization" }}
         {{- if eq .Values.authorization.enabled true }}
+        {{- if $authorizationConfigSecret }}
+        - name: karavi-authorization-config
+          secret:
+            secretName: karavi-authorization-config
+        {{- end }}
         - name: proxy-server-root-certificate
           secret:
             secretName: proxy-server-root-certificate

--- a/charts/csi-isilon/templates/node.yaml
+++ b/charts/csi-isilon/templates/node.yaml
@@ -76,9 +76,9 @@ metadata:
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]  
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 {{ end }}
-{{ end }}    
+{{ end }}
 ---
 
 kind: DaemonSet
@@ -298,8 +298,8 @@ spec:
                   name: proxy-authz-tokens
                   key: refresh
           volumeMounts:
-            - name: karavi-authorization-config
-              mountPath: /etc/karavi-authorization/config
+            - name: isilon-configs
+              mountPath: /isilon-configs
             - name: proxy-server-root-certificate
               mountPath: /etc/karavi-authorization/root-certificates
             - name: csi-isilon-config-params
@@ -345,9 +345,6 @@ spec:
              name: {{ .Release.Name }}-config-params
         {{- if hasKey .Values "authorization" }}
         {{- if eq .Values.authorization.enabled true }}
-        - name: karavi-authorization-config
-          secret:
-            secretName: karavi-authorization-config
         - name: proxy-server-root-certificate
           secret:
             secretName: proxy-server-root-certificate

--- a/charts/csi-isilon/values.yaml
+++ b/charts/csi-isilon/values.yaml
@@ -308,7 +308,7 @@ node:
 # endpointPort: Specify the HTTPs port number of the PowerScale OneFS API server
 # Formerly this attribute was named as "isiPort"
 # This value acts as a default value for endpointPort, if not specified for a cluster config in secret
-# If authorization is enabled, endpointPort must match the port specified in the endpoint parameter of the karavi-authorization-config secret
+# If authorization is enabled, endpointPort must match the port specified in the endpointPort parameter of the isilon-creds secret
 # Allowed value: valid port number
 # Default value: 8080
 endpointPort: 8080

--- a/charts/csi-powermax/templates/controller.yaml
+++ b/charts/csi-powermax/templates/controller.yaml
@@ -1,3 +1,5 @@
+{{- $authorizationConfigSecret := lookup "v1" "Secret" .Release.Namespace "karavi-authorization-config" }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -391,8 +393,13 @@ spec:
                   name: proxy-authz-tokens
                   key: refresh
           volumeMounts:
+            {{- if $authorizationConfigSecret }}
             - name: karavi-authorization-config
               mountPath: /etc/karavi-authorization/config
+            {{- else }}
+            - name: powermax-reverseproxy-secret
+              mountPath: /powermax-reverseproxy-secret
+            {{- end }}
             - name: proxy-server-root-certificate
               mountPath: /etc/karavi-authorization/root-certificates
             - name: powermax-config-params

--- a/charts/csi-powermax/templates/node.yaml
+++ b/charts/csi-powermax/templates/node.yaml
@@ -1,3 +1,4 @@
+{{- $authorizationConfigSecret := lookup "v1" "Secret" .Release.Namespace "karavi-authorization-config" }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -476,8 +477,13 @@ spec:
                   name: proxy-authz-tokens
                   key: refresh
           volumeMounts:
+            {{- if $authorizationConfigSecret }}
             - name: karavi-authorization-config
               mountPath: /etc/karavi-authorization/config
+            {{- else }}
+            - name: powermax-reverseproxy-secret
+              mountPath: /powermax-reverseproxy-secret
+            {{- end }}
             - name: proxy-server-root-certificate
               mountPath: /etc/karavi-authorization/root-certificates
             - name: powermax-config-params

--- a/charts/csi-powerstore/templates/controller.yaml
+++ b/charts/csi-powerstore/templates/controller.yaml
@@ -14,6 +14,8 @@
 #
 #
 
+{{- $authorizationConfigSecret := lookup "v1" "Secret" .Release.Namespace "karavi-authorization-config" }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -84,10 +86,10 @@ rules:
   {{- end }}
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments/status"]
-    verbs: ["patch"]          
+    verbs: ["patch"]
   - apiGroups: [ "" ]
     resources: [ "pods" ]
-  {{- if hasKey .Values "podmon" }}    
+  {{- if hasKey .Values "podmon" }}
   {{- if .Values.podmon.enabled }}
     verbs: [ "get", "list", "watch", "delete" ]
   {{- else }}
@@ -529,8 +531,13 @@ spec:
                   name: proxy-authz-tokens
                   key: refresh
           volumeMounts:
+            {{- if $authorizationConfigSecret }}
             - name: karavi-authorization-config
               mountPath: /etc/karavi-authorization/config
+            {{- else }}
+            - name: powerstore-config
+              mountPath: /powerstore-config
+            {{- end }}
             - name: proxy-server-root-certificate
               mountPath: /etc/karavi-authorization/root-certificates
             - name: powerstore-config-params
@@ -541,9 +548,11 @@ spec:
         # for authorization
         {{- if hasKey .Values "authorization" }}
         {{- if eq .Values.authorization.enabled true }}
+        {{- if $authorizationConfigSecret }}
         - name: karavi-authorization-config
           secret:
             secretName: karavi-authorization-config
+        {{- end }}
         - name: proxy-server-root-certificate
           secret:
             secretName: proxy-server-root-certificate

--- a/charts/csi-powerstore/templates/node.yaml
+++ b/charts/csi-powerstore/templates/node.yaml
@@ -14,6 +14,8 @@
 #
 #
 
+{{- $authorizationConfigSecret := lookup "v1" "Secret" .Release.Namespace "karavi-authorization-config" }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -59,7 +61,7 @@ rules:
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
   {{ end }}
-  {{ end }}    
+  {{ end }}
 ---
 # ClusterRoleBinding for Cluster-specific
 kind: ClusterRoleBinding
@@ -102,9 +104,9 @@ metadata:
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]  
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 {{ end }}
-{{ end }}    
+{{ end }}
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -161,8 +163,13 @@ spec:
                   name: proxy-authz-tokens
                   key: refresh
           volumeMounts:
+            {{- if $authorizationConfigSecret }}
             - name: karavi-authorization-config
               mountPath: /etc/karavi-authorization/config
+            {{- else }}
+            - name: powerstore-config
+              mountPath: /powerstore-config
+            {{- end }}
             - name: proxy-server-root-certificate
               mountPath: /etc/karavi-authorization/root-certificates
             - name: powerstore-config-params
@@ -271,7 +278,7 @@ spec:
             - name: X_CSI_DRIVER_NAME
               value: {{ .Values.driverName }}
             - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
-              value: {{ .Values.nodeFCPortsFilterFile }}    
+              value: {{ .Values.nodeFCPortsFilterFile }}
             - name: X_CSI_NFS_EXPORT_DIRECTORY
               value: {{ .Values.nfsExportDirectory | default "/var/lib/dell/nfs" }}
             - name: X_CSI_NFS_CLIENT_PORT
@@ -375,9 +382,11 @@ spec:
         # for authorization
         {{- if hasKey .Values "authorization" }}
         {{- if eq .Values.authorization.enabled true }}
+        {{- if $authorizationConfigSecret }}
         - name: karavi-authorization-config
           secret:
             secretName: karavi-authorization-config
+        {{- end }}
         - name: proxy-server-root-certificate
           secret:
             secretName: proxy-server-root-certificate

--- a/charts/csi-vxflexos/templates/controller.yaml
+++ b/charts/csi-vxflexos/templates/controller.yaml
@@ -1,3 +1,5 @@
+{{- $authorizationConfigSecret := lookup "v1" "Secret" .Release.Namespace "karavi-authorization-config" }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -407,8 +409,13 @@ spec:
                   name: proxy-authz-tokens
                   key: refresh
           volumeMounts:
+            {{- if $authorizationConfigSecret }}
+            - name: karavi-authorization-config
+              mountPath: /etc/karavi-authorization/config
+            {{- else }}
             - name: vxflexos-config
               mountPath: /vxflexos-config
+            {{- end }}
             - name: proxy-server-root-certificate
               mountPath: /etc/karavi-authorization/root-certificates
             - name: vxflexos-config-params
@@ -480,6 +487,11 @@ spec:
             name: {{ .Release.Name }}-config-params
         {{- if hasKey .Values "authorization" }}
         {{- if eq .Values.authorization.enabled true }}
+        {{- if $authorizationConfigSecret }}
+        - name: karavi-authorization-config
+          secret:
+            secretName: karavi-authorization-config
+        {{- end }}
         - name: proxy-server-root-certificate
           secret:
             secretName: proxy-server-root-certificate

--- a/charts/csi-vxflexos/templates/controller.yaml
+++ b/charts/csi-vxflexos/templates/controller.yaml
@@ -407,8 +407,8 @@ spec:
                   name: proxy-authz-tokens
                   key: refresh
           volumeMounts:
-            - name: karavi-authorization-config
-              mountPath: /etc/karavi-authorization/config
+            - name: vxflexos-config
+              mountPath: /vxflexos-config
             - name: proxy-server-root-certificate
               mountPath: /etc/karavi-authorization/root-certificates
             - name: vxflexos-config-params
@@ -480,9 +480,6 @@ spec:
             name: {{ .Release.Name }}-config-params
         {{- if hasKey .Values "authorization" }}
         {{- if eq .Values.authorization.enabled true }}
-        - name: karavi-authorization-config
-          secret:
-            secretName: karavi-authorization-config
         - name: proxy-server-root-certificate
           secret:
             secretName: proxy-server-root-certificate

--- a/charts/csi-vxflexos/templates/node.yaml
+++ b/charts/csi-vxflexos/templates/node.yaml
@@ -1,5 +1,6 @@
 {{- $is_openshift := .Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints" -}}
-
+{{- $authorizationConfigSecret := lookup "v1" "Secret" .Release.Namespace "karavi-authorization-config" }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -203,8 +204,13 @@ spec:
                   name: proxy-authz-tokens
                   key: refresh
           volumeMounts:
+            {{- if $authorizationConfigSecret }}
+            - name: karavi-authorization-config
+              mountPath: /etc/karavi-authorization/config
+            {{- else }}
             - name: vxflexos-config
               mountPath: /vxflexos-config
+            {{- end }}
             - name: proxy-server-root-certificate
               mountPath: /etc/karavi-authorization/root-certificates
             - name: vxflexos-config-params
@@ -473,6 +479,11 @@ spec:
 {{- end }}
 {{- if hasKey .Values "authorization" }}
 {{- if eq .Values.authorization.enabled true }}
+        {{- if $authorizationConfigSecret }}
+        - name: karavi-authorization-config
+          secret:
+            secretName: karavi-authorization-config
+        {{- end }}
         - name: proxy-server-root-certificate
           secret:
             secretName: proxy-server-root-certificate

--- a/charts/csi-vxflexos/templates/node.yaml
+++ b/charts/csi-vxflexos/templates/node.yaml
@@ -203,8 +203,8 @@ spec:
                   name: proxy-authz-tokens
                   key: refresh
           volumeMounts:
-            - name: karavi-authorization-config
-              mountPath: /etc/karavi-authorization/config
+            - name: vxflexos-config
+              mountPath: /vxflexos-config
             - name: proxy-server-root-certificate
               mountPath: /etc/karavi-authorization/root-certificates
             - name: vxflexos-config-params
@@ -473,9 +473,6 @@ spec:
 {{- end }}
 {{- if hasKey .Values "authorization" }}
 {{- if eq .Values.authorization.enabled true }}
-        - name: karavi-authorization-config
-          secret:
-            secretName: karavi-authorization-config
         - name: proxy-server-root-certificate
           secret:
             secretName: proxy-server-root-certificate

--- a/charts/csm-authorization-v2.0/charts/redis/templates/sentinel.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/templates/sentinel.yaml
@@ -68,6 +68,7 @@ spec:
               SENTINEL="{{ .Values.sentinel }}-$i.{{ .Values.sentinel }}.{{ include "custom.namespace" . }}.svc.cluster.local"
               SENTINELS="$SENTINELS $SENTINEL"
             done
+            loop=$(echo $nodes | sed -e "s/"*"/\n/g")
 
             echo "Sentinel nodes: $SENTINELS"
 
@@ -114,7 +115,7 @@ spec:
             echo "port 5000
             sentinel resolve-hostnames yes
             sentinel announce-hostnames yes
-            sentinel monitor mymaster $MASTER 6379 2
+            $(cat /tmp/master)
             sentinel down-after-milliseconds mymaster 5000
             sentinel failover-timeout mymaster 60000
             sentinel parallel-syncs mymaster 2

--- a/charts/csm-authorization-v2.0/charts/redis/templates/sentinel.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/templates/sentinel.yaml
@@ -68,7 +68,6 @@ spec:
               SENTINEL="{{ .Values.sentinel }}-$i.{{ .Values.sentinel }}.{{ include "custom.namespace" . }}.svc.cluster.local"
               SENTINELS="$SENTINELS $SENTINEL"
             done
-            loop=$(echo $nodes | sed -e "s/"*"/\n/g")
 
             echo "Sentinel nodes: $SENTINELS"
 
@@ -115,7 +114,7 @@ spec:
             echo "port 5000
             sentinel resolve-hostnames yes
             sentinel announce-hostnames yes
-            $(cat /tmp/master)
+            sentinel monitor mymaster $MASTER 6379 2
             sentinel down-after-milliseconds mymaster 5000
             sentinel failover-timeout mymaster 60000
             sentinel parallel-syncs mymaster 2


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

This PR removes the dependency on the _karavi-authorization-config_ secret for deploying Auth v2 with PowerStore, PowerFlex, PowerScale, and PowerMax. With this change, new deployments only require the driver secret, simplifying the configuration process.

The existing deployments using the _karavi-authorization-config_ secret will continue to function as expected, ensuring seamless upgrades.

#### Which issue(s) is this PR associated with:

- https://github.com/dell/csm/issues/1583

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable

Testing:
Logs are attached to the internal stories.

- Greenfield - Auth e2e: 
     - using _karavi-authorization-config_ secret
     - using driver secret
- Upgrade - Auth e2e: 
     - continue to use _karavi-authorization-config_ secret
     - switch over to driver secret. i.e delete _karavi-authorization-config_ secret
- K8s e2e test for driver deployment without Auth