### PR TITLE
[charts/csi-vxflexos] Added support for PowerFlex Gateway Monitoring

### DIFF
--- a/charts/csi-vxflexos/templates/_helpers.tpl
+++ b/charts/csi-vxflexos/templates/_helpers.tpl
@@ -18,6 +18,21 @@ Return true if storage capacity tracking is enabled and is supported based on k8
 {{- end -}}
 
 {{/*
+Return true if metrics is enabled
+*/}}
+{{- define "csi-vxflexos.isMetricsEnabled" -}}
+{{- if hasKey .Values "metrics" -}}
+  {{- if (eq .Values.metrics.enabled true) -}}
+      {{- true -}}
+  {{- else -}}
+      {{- false -}}
+  {{- end -}}
+{{- else -}}
+  {{- false -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return true if volumeGroupSnapshot is enabled and properly configured
 */}}
 {{- define "csi-vxflexos.isVgsnapshotEnabled" -}}
@@ -30,4 +45,20 @@ Return true if volumeGroupSnapshot is enabled and properly configured
 {{- else -}}
   {{- false -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Return the leader election value for PowerFlex Gateway Monitoring.
+Defaults to "true" when leaderElectionEnabled is not explicitly set.
+*/}}
+{{- define "csi-vxflexos.gatewayMonitoringLeaderElect" -}}
+  {{- $leaderElect := true -}}
+  {{- if hasKey .Values "metrics" -}}
+    {{- if hasKey .Values.metrics "gatewayMonitoring" -}}
+      {{- if hasKey .Values.metrics.gatewayMonitoring "leaderElectionEnabled" -}}
+        {{- $leaderElect = .Values.metrics.gatewayMonitoring.leaderElectionEnabled -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $leaderElect | quote -}}
 {{- end -}}

--- a/charts/csi-vxflexos/templates/controller.yaml
+++ b/charts/csi-vxflexos/templates/controller.yaml
@@ -463,8 +463,7 @@ spec:
             {{- end }}
             - name: X_CSI_PODMON_API_PORT
               value: "{{ .Values.podmonAPIPort }}"
-            {{- if hasKey .Values "metrics" }}
-            {{- if eq .Values.metrics.enabled true }}
+            {{- if eq (include "csi-vxflexos.isMetricsEnabled" .) "true" }}
             - name: X_CSI_METRICS_ENABLED
               value: "true"
             - name: X_CSI_METRICS_PORT
@@ -478,15 +477,10 @@ spec:
             {{- if eq .Values.metrics.gatewayMonitoring.enabled true }}
             - name: X_CSI_GATEWAY_MONITORING_ENABLED
               value: "true"
-            {{- $leaderElect := true }}
-            {{- if hasKey .Values.metrics.gatewayMonitoring "leaderElectionEnabled" }}
-            {{- $leaderElect = .Values.metrics.gatewayMonitoring.leaderElectionEnabled }}
-            {{- end }}
             - name: X_CSI_GATEWAY_MONITORING_LEADER_ELECTION_ENABLED
-              value: {{ $leaderElect | quote }}
+              value: {{ include "csi-vxflexos.gatewayMonitoringLeaderElect" . }}
             - name: X_CSI_GATEWAY_MONITORING_POLL_INTERVAL
               value: "{{ .Values.metrics.gatewayMonitoring.pollInterval | default "30s" }}"
-            {{- end }}
             {{- end }}
             {{- end }}
           volumeMounts:
@@ -501,13 +495,11 @@ spec:
               mountPath: /certs
               readOnly: true
 {{- end}}
-{{- if hasKey .Values "metrics" }}
-{{- if eq .Values.metrics.enabled true }}
+{{- if eq (include "csi-vxflexos.isMetricsEnabled" .) "true" }}
 {{- if .Values.metrics.tlsCertSecret }}
             - name: metrics-tls
               mountPath: /etc/metrics-tls
               readOnly: true
-{{- end }}
 {{- end }}
 {{- end }}
       volumes:
@@ -543,12 +535,10 @@ spec:
                       path: cert-{{ $e }}
 {{- end }}
 {{- end }}
-{{- if hasKey .Values "metrics" }}
-{{- if eq .Values.metrics.enabled true }}
+{{- if eq (include "csi-vxflexos.isMetricsEnabled" .) "true" }}
 {{- if .Values.metrics.tlsCertSecret }}
         - name: metrics-tls
           secret:
             secretName: {{ .Values.metrics.tlsCertSecret }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/csi-vxflexos/templates/controller.yaml
+++ b/charts/csi-vxflexos/templates/controller.yaml
@@ -462,7 +462,33 @@ spec:
             {{- end }}
             {{- end }}
             - name: X_CSI_PODMON_API_PORT
-              value: "{{ .Values.podmonAPIPort }}"  
+              value: "{{ .Values.podmonAPIPort }}"
+            {{- if hasKey .Values "metrics" }}
+            {{- if eq .Values.metrics.enabled true }}
+            - name: X_CSI_METRICS_ENABLED
+              value: "true"
+            - name: X_CSI_METRICS_PORT
+              value: "{{ .Values.metrics.port | default 9090 }}"
+            {{- if .Values.metrics.tlsCertSecret }}
+            - name: X_CSI_METRICS_TLS_CERT_FILE
+              value: "/etc/metrics-tls/tls.crt"
+            - name: X_CSI_METRICS_TLS_KEY_FILE
+              value: "/etc/metrics-tls/tls.key"
+            {{- end }}
+            {{- if eq .Values.metrics.gatewayMonitoring.enabled true }}
+            - name: X_CSI_GATEWAY_MONITORING_ENABLED
+              value: "true"
+            {{- $leaderElect := true }}
+            {{- if hasKey .Values.metrics.gatewayMonitoring "leaderElectionEnabled" }}
+            {{- $leaderElect = .Values.metrics.gatewayMonitoring.leaderElectionEnabled }}
+            {{- end }}
+            - name: X_CSI_GATEWAY_MONITORING_LEADER_ELECTION_ENABLED
+              value: {{ $leaderElect | quote }}
+            - name: X_CSI_GATEWAY_MONITORING_POLL_INTERVAL
+              value: "{{ .Values.metrics.gatewayMonitoring.pollInterval | default "30s" }}"
+            {{- end }}
+            {{- end }}
+            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi
@@ -475,6 +501,15 @@ spec:
               mountPath: /certs
               readOnly: true
 {{- end}}
+{{- if hasKey .Values "metrics" }}
+{{- if eq .Values.metrics.enabled true }}
+{{- if .Values.metrics.tlsCertSecret }}
+            - name: metrics-tls
+              mountPath: /etc/metrics-tls
+              readOnly: true
+{{- end }}
+{{- end }}
+{{- end }}
       volumes:
         - name: socket-dir
           emptyDir:
@@ -506,5 +541,14 @@ spec:
                   items:
                     - key: cert-{{ $e }}
                       path: cert-{{ $e }}
+{{- end }}
+{{- end }}
+{{- if hasKey .Values "metrics" }}
+{{- if eq .Values.metrics.enabled true }}
+{{- if .Values.metrics.tlsCertSecret }}
+        - name: metrics-tls
+          secret:
+            secretName: {{ .Values.metrics.tlsCertSecret }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/csi-vxflexos/templates/metrics-service.yaml
+++ b/charts/csi-vxflexos/templates/metrics-service.yaml
@@ -1,5 +1,4 @@
-{{- if hasKey .Values "metrics" }}
-{{- if eq .Values.metrics.enabled true }}
+{{- if eq (include "csi-vxflexos.isMetricsEnabled" .) "true" }}
 ---
 # Service exposing the shared driver metrics endpoint for Prometheus scraping.
 # Created when metrics.enabled is true.
@@ -19,5 +18,4 @@ spec:
       targetPort: {{ .Values.metrics.port | default 9090 }}
       protocol: TCP
   type: ClusterIP
-{{- end }}
 {{- end }}

--- a/charts/csi-vxflexos/templates/metrics-service.yaml
+++ b/charts/csi-vxflexos/templates/metrics-service.yaml
@@ -1,0 +1,23 @@
+{{- if hasKey .Values "metrics" }}
+{{- if eq .Values.metrics.enabled true }}
+---
+# Service exposing the shared driver metrics endpoint for Prometheus scraping.
+# Created when metrics.enabled is true.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  selector:
+    name: {{ .Release.Name }}-controller
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.port | default 9090 }}
+      targetPort: {{ .Values.metrics.port | default 9090 }}
+      protocol: TCP
+  type: ClusterIP
+{{- end }}
+{{- end }}

--- a/charts/csi-vxflexos/templates/servicemonitor.yaml
+++ b/charts/csi-vxflexos/templates/servicemonitor.yaml
@@ -1,5 +1,4 @@
-{{- if hasKey .Values "metrics" }}
-{{- if eq .Values.metrics.enabled true }}
+{{- if eq (include "csi-vxflexos.isMetricsEnabled" .) "true" }}
 {{- if hasKey .Values.metrics "serviceMonitor" }}
 {{- if eq .Values.metrics.serviceMonitor.enabled true }}
 ---
@@ -29,7 +28,6 @@ spec:
         # alternatively configure ca, cert, and keySecret for full verification.
         insecureSkipVerify: {{ .Values.metrics.serviceMonitor.insecureSkipVerify | default false }}
       {{- end }}
-{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/csi-vxflexos/templates/servicemonitor.yaml
+++ b/charts/csi-vxflexos/templates/servicemonitor.yaml
@@ -1,0 +1,35 @@
+{{- if hasKey .Values "metrics" }}
+{{- if eq .Values.metrics.enabled true }}
+{{- if hasKey .Values.metrics "serviceMonitor" }}
+{{- if eq .Values.metrics.serviceMonitor.enabled true }}
+---
+# ServiceMonitor for Prometheus Operator integration.
+# Created when metrics.enabled AND metrics.serviceMonitor.enabled are true.
+# Requires the Prometheus Operator CRDs to be installed in the cluster.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-gateway-monitoring
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-controller
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval | default "30s" }}
+      path: /metrics
+      {{- if .Values.metrics.tlsCertSecret }}
+      scheme: https
+      tlsConfig:
+        # The metrics endpoint uses a self-provided TLS certificate.
+        # Set insecureSkipVerify to true if the certificate is self-signed;
+        # alternatively configure ca, cert, and keySecret for full verification.
+        insecureSkipVerify: {{ .Values.metrics.serviceMonitor.insecureSkipVerify | default false }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/csi-vxflexos/values.yaml
+++ b/charts/csi-vxflexos/values.yaml
@@ -421,6 +421,80 @@ authorization:
   # Default value: "true"
   skipCertificateValidation: true
 
+# metrics: configuration for driver metrics and monitoring
+metrics:
+  # enabled: Enable/Disable the shared Prometheus metrics HTTP server.
+  # This is the master switch for the metrics endpoint.  Gateway monitoring
+  # (metrics.gatewayMonitoring.enabled) only takes effect when this is true; setting
+  # metrics.gatewayMonitoring.enabled=true without metrics.enabled=true has no effect.
+  # Type: bool
+  # Default: false
+  # Effect: When true, the controller Deployment receives X_CSI_METRICS_ENABLED=true,
+  #         X_CSI_METRICS_PORT, and a metrics Service is created.
+  enabled: false
+
+  # port: Port on which the shared driver metrics endpoint is exposed.
+  # This port serves gateway monitoring metrics and any other driver-supplied metrics.
+  # Type: integer
+  # Default: 9090
+  # Effect: Passed as X_CSI_METRICS_PORT to the driver container; used as targetPort in the Service.
+  port: 9090
+
+  # tlsCertSecret: Name of a Kubernetes TLS Secret whose "tls.crt" and "tls.key" entries
+  # are used to serve the metrics endpoint over HTTPS instead of plain HTTP.
+  # Leave empty (the default) to use plain HTTP.
+  # The Secret must exist in the same namespace as the driver and contain the keys
+  # "tls.crt" (PEM-encoded certificate) and "tls.key" (PEM-encoded private key).
+  # Type: string
+  # Default: "" (disabled — plain HTTP)
+  # Example: tlsCertSecret: "powerflex-metrics-tls"
+  tlsCertSecret: ""
+
+  # gatewayMonitoring: configuration for PowerFlex Gateway health monitoring
+  # When enabled, the CSI controller pod exposes a Prometheus-scrapable /metrics
+  # endpoint that reports the availability of each configured PowerFlex Gateway.
+  gatewayMonitoring:
+    # enabled: Enable/Disable gateway monitoring feature.
+    # Requires metrics.enabled=true — if metrics.enabled is false this has no effect.
+    # Type: bool
+    # Default: false
+    # Effect: When true (and metrics.enabled is true), the controller Deployment receives
+    #         X_CSI_GATEWAY_MONITORING_ENABLED=true, and (optionally) a ServiceMonitor is created.
+    enabled: false
+
+    # leaderElectionEnabled: Enable/Disable gateway monitoring leader election.
+    # Type: bool
+    # Default: true
+    # Effect: When true, the controller Deployment receives X_CSI_GATEWAY_MONITORING_LEADER_ELECTION_ENABLED=true,
+    #         and only one controller will monitor the gateway.
+    leaderElectionEnabled: true
+
+    # pollInterval: How frequently the leader controller probes each gateway endpoint.
+    # Type: string (Go duration, e.g. "30s", "1m")
+    # Default: "30s"
+    # Effect: Passed as X_CSI_GATEWAY_MONITORING_POLL_INTERVAL to the driver container.
+    pollInterval: "30s"
+
+  # serviceMonitor: Controls optional Prometheus Operator ServiceMonitor creation.
+  serviceMonitor:
+    # enabled: When true, a ServiceMonitor CR is created for automatic Prometheus Operator integration.
+    # Type: bool
+    # Default: false
+    # Effect: Requires the Prometheus Operator CRDs to be installed in the cluster.
+    enabled: false
+
+    # interval: Prometheus scrape interval for the metrics endpoint.
+    # Type: string (Prometheus duration, e.g. "30s", "1m")
+    # Default: "30s"
+    interval: "30s"
+
+    # insecureSkipVerify: Controls TLS certificate verification when scraping metrics.
+    # Only used when metrics.tlsCertSecret is set (HTTPS endpoint).
+    # Type: bool
+    # Default: false
+    # Effect: When true, Prometheus will skip TLS certificate verification.
+    insecureSkipVerify: false
+
 interfaceNames:
   # worker1: interface1
   # worker2: interface2


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

Provides support for PowerFlex gateway monitoring, including configurable parameters to enable the metrics port and gateway monitoring, as well as a new Service and ServiceMonitor to allow Prometheus to scrape metrics.

#### Which issue(s) is this PR associated with:

- #Issue_Number

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
