### PR TITLE
 [charts/csm-authorization] Added externalTrafficPolicy to cluster for nginx-gateway-fabric

### DIFF
--- a/charts/csm-authorization-v2.0/values.yaml
+++ b/charts/csm-authorization-v2.0/values.yaml
@@ -6,6 +6,9 @@ openshift: false
 # if enabled, NGINX Gateway Fabric controller will be deployed
 nginx-gateway-fabric:
   enabled: true
+  nginx:
+    service:
+      externalTrafficPolicy: Cluster
 
 # if enabled, cert-manager will be deployed
 # if cert-manager is already deployed, keep this false


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Sets `externalTrafficPolicy: Cluster` on the NGINX Gateway Fabric data plane service to restore the behavior from the previous ingress-nginx setup.

In `v2.4.0`, the `ingress-nginx` subchart defaulted externalTrafficPolicy to Cluster, which allowed NodePort access from any cluster node. When the chart was migrated to `nginx-gateway-fabric` in `v2.5.0`,
this setting was lost because the `nginx-gateway-fabric` subchart defaults `externalTrafficPolicy` to Local. With Local, the NodePort only works on the node running the gateway pod, which breaks multi-node access.

This fix overrides the subchart default by passing nginx.service.externalTrafficPolicy: Cluster in values.yaml.

#### Which issue(s) is this PR associated with:

- #Issue_Number

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
- [x] Tested by deploying authorization via helm
<img width="521" height="105" alt="image" src="https://github.com/user-attachments/assets/f3b57f2d-19cc-4705-ba66-d0866cd2f802" />
 
