### PR TITLE
[charts/csm-authorization] Remove hardcoded Redis credentials

### DIFF
--- a/charts/csm-authorization-v2.0/charts/redis/templates/redis-secret.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/templates/redis-secret.yaml
@@ -6,6 +6,6 @@ metadata:
   namespace: {{ include "custom.namespace" . }}
 type: kubernetes.io/basic-auth
 stringData:
-  password: K@ravi123!
-  commander_user: dev
+  password: {{ .Values.redisPassword }}
+  commander_user: {{ .Values.redisUsername }}
 {{- end }}

--- a/charts/csm-authorization-v2.0/charts/redis/templates/redis-secret.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/templates/redis-secret.yaml
@@ -6,6 +6,6 @@ metadata:
   namespace: {{ include "custom.namespace" . }}
 type: kubernetes.io/basic-auth
 stringData:
-  password: {{ .Values.redisPassword }}
-  commander_user: {{ .Values.redisUsername }}
+  password: {{ required "Redis credentials are required. Either set redis.redisPassword or configure redis.redisSecretProviderClass to use a Secret Store CSI driver." .Values.redisPassword }}
+  commander_user: {{ required "Redis credentials are required. Either set redis.redisUsername or configure redis.redisSecretProviderClass to use a Secret Store CSI driver." .Values.redisUsername }}
 {{- end }}

--- a/charts/csm-authorization-v2.0/charts/redis/values.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/values.yaml
@@ -1,4 +1,6 @@
 name: redis-csm
+redisPassword:
+redisUsername:
 redisSecretProviderClass:
   secretProviderClassName:
   redisSecretName:

--- a/charts/csm-authorization-v2.0/charts/redis/values.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/values.yaml
@@ -1,6 +1,6 @@
 name: redis-csm
-redisPassword:
 redisUsername:
+redisPassword:
 redisSecretProviderClass:
   secretProviderClassName:
   redisSecretName:

--- a/charts/csm-authorization-v2.0/values.yaml
+++ b/charts/csm-authorization-v2.0/values.yaml
@@ -74,10 +74,15 @@ authorization:
 
 redis:
   name: redis-csm
-  # Optional:
-  # Redis secret configuration:
-  # If using a Secret Store CSI driver, specify the SecretProviderClass details that holds the Redis secretObject.
-  # Otherwise, a default Kubernetes secret will be used for Redis credentials.
+  # Redis credentials are required and can be provided in one of two ways:
+  # 1. Directly via redisUsername/redisPassword (a Kubernetes secret will be created automatically)
+  # 2. Via a Secret Store CSI driver (specify the SecretProviderClass details below)
+  #
+  # Option 1: Provide credentials directly
+  redisUsername:
+  redisPassword:
+
+  # Option 2: Use a Secret Store CSI driver
   redisSecretProviderClass:
     # Name of the SecretProviderClass that holds the Redis secretObject.
     secretProviderClassName:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

Added redisUsername and redisPassword fields to the parent chart's values.yaml and the redis subchart's values.yaml, requiring users to supply their own credentials at install time.

#### Which issue(s) is this PR associated with:


#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable

Tests ran:

- Installed the chart with redisUsername/redisPassword set directly and verified the redis-csm-secret Kubernetes secret is created with the provided values.
```
# helm -n authorization install authorization -f /root/csm/helm-charts/charts/csm-authorization-v2.0/values.yaml charts/csm-authorization-v2.0
NAME: authorization
LAST DEPLOYED: Fri Apr 10 16:11:46 2026
NAMESPACE: authorization
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
The CSM Authorization deployment has been successfully installed.

Execute the following commands in your shell to print the URL of the CSM Authorization NodePort LoadBalancer:

export NODE_PORT=$(kubectl get --namespace authorization -o jsonpath="{.spec.ports[0].nodePort}" service authorization-gateway-nginx)
export NODE_IP=$(kubectl get nodes --namespace authorization -o jsonpath="{.items[0].status.addresses[0].address}")
echo https://$NODE_IP:$NODE_PORT

LoadBalancer host rules for proxy-server:
- csm-authorization.com
- authorization-gateway-nginx.authorization.svc.cluster.local

authorization.proxyHost value for a CSI Driver examples:
- authorization-gateway-nginx.authorization.svc.cluster.local:443 (CSI Driver in the same cluster as CSM Authorization)
```
- Verified that omitting credentials produces a clear failure rather than silently using hardcoded defaults
```
# helm -n authorization install authorization -f /root/csm/helm-charts/charts/csm-authorization-v2.0/values.yaml charts/csm-authorization-v2.0
Error: INSTALLATION FAILED: execution error at (csm-authorization/charts/redis/templates/sentinel.yaml:39:28): Redis credentials are required. Either set redis.redisPassword or configure redis.redisSecretProviderClass to use a Secret Store CSI driver.
```