### PR TITLE
[charts/csm-authorization] Remove hardcoded Redis credentials

### DIFF
--- a/charts/csm-authorization-v2.0/charts/redis/templates/redis-secret.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/templates/redis-secret.yaml
@@ -6,6 +6,6 @@ metadata:
   namespace: {{ include "custom.namespace" . }}
 type: kubernetes.io/basic-auth
 stringData:
-  password: K@ravi123!
-  commander_user: dev
+  password: {{ required "Redis credentials are required. Either set redis.redisPassword or configure redis.redisSecretProviderClass to use a Secret Store CSI driver." .Values.redisPassword }}
+  commander_user: {{ required "Redis credentials are required. Either set redis.redisUsername or configure redis.redisSecretProviderClass to use a Secret Store CSI driver." .Values.redisUsername }}
 {{- end }}

--- a/charts/csm-authorization-v2.0/charts/redis/values.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/values.yaml
@@ -1,4 +1,6 @@
 name: redis-csm
+redisUsername:
+redisPassword:
 redisSecretProviderClass:
   secretProviderClassName:
   redisSecretName:

--- a/charts/csm-authorization-v2.0/values.yaml
+++ b/charts/csm-authorization-v2.0/values.yaml
@@ -72,10 +72,15 @@ authorization:
 
 redis:
   name: redis-csm
-  # Optional:
-  # Redis secret configuration:
-  # If using a Secret Store CSI driver, specify the SecretProviderClass details that holds the Redis secretObject.
-  # Otherwise, a default Kubernetes secret will be used for Redis credentials.
+  # Redis credentials are required and can be provided in one of two ways:
+  # 1. Directly via redisUsername/redisPassword (a Kubernetes secret will be created automatically)
+  # 2. Via a Secret Store CSI driver (specify the SecretProviderClass details below)
+  #
+  # Option 1: Provide credentials directly
+  redisUsername:
+  redisPassword:
+
+  # Option 2: Use a Secret Store CSI driver
   redisSecretProviderClass:
     # Name of the SecretProviderClass that holds the Redis secretObject.
     secretProviderClassName:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Added redisUsername and redisPassword fields to the parent chart's values.yaml and the redis subchart's values.yaml, requiring users to supply their own credentials at install time.

#### Which issue(s) is this PR associated with:

- #Issue_Number

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable


**Verifies that the chart requires explicit Redis credentials configuration.**

<details>
# helm template my-release charts/csm-authorization-v2.0
Error: execution error at (csm-authorization/charts/redis/templates/sentinel.yaml:39:28): Redis credentials are required. Either set redis.redisPassword or configure redis.redisSecretProviderClass to use a Secret Store CSI driver.

Use --debug flag to render out invalid YAML
</details>

**Verifies that the chart renders successfully when Redis credentials are provided directly.**

<details>
# helm template my-release charts/csm-authorization-v2.0   --set redis.redisUsername=testuser   --set redis.redisPassword=testpass123

# Source: csm-authorization/charts/redis/templates/redis-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: redis-csm-secret
  namespace: default
type: kubernetes.io/basic-auth
stringData:
  password: testpass123
  commander_user: testuser
</details>


**Verifies that the chart renders successfully when using a Secret Store CSI driver and does not create a hardcoded secret.**

<details>
# helm template my-release charts/csm-authorization-v2.0   --set redis.redisSecretProviderClass.secretProviderClassName=my-provider  --set redis.redisSecretProviderClass.redisSecretName=my-secret

- Template renders without errors
- No hardcoded redis-csm-secret is created
</details>
