### PR TITLE
[charts/csm-authorization] Remove hardcoded Redis credentials

### DIFF
--- a/charts/csm-authorization-v2.0/charts/redis/Chart.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: redis-csm
+name: redis
 description: Helm Chart for Redis with Sentinels
 type: application
 version: 0.1.0

--- a/charts/csm-authorization-v2.0/charts/redis/templates/redis-secret.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/templates/redis-secret.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: {{ include "custom.namespace" . }}
 type: kubernetes.io/basic-auth
 stringData:
-  password: K@ravi123!
-  commander_user: dev
+  password: {{ required "Redis credentials are required. Set redis.redisPassword." .Values.redisPassword }}
+  commander_user: {{ required "Redis credentials are required. Set redis.redisUsername." .Values.redisUsername }}

--- a/charts/csm-authorization-v2.0/charts/redis/templates/redis.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/templates/redis.yaml
@@ -1,40 +1,40 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.redis.name }}
+  name: {{ .Values.name }}
   namespace: {{ include "custom.namespace" . }}
 spec:
   type:
   clusterIP: None
   selector:
-    app: {{ .Values.redis.name }}
+    app: {{ .Values.name }}
   ports:
   - protocol: TCP
     port: 6379
     targetPort: 6379
-    name: {{ .Values.redis.name }}
+    name: {{ .Values.name }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Values.redis.name }}
+  name: {{ .Values.name }}
   namespace: {{ include "custom.namespace" . }}
 spec:
-  serviceName: {{ .Values.redis.name }}
-  replicas: {{ .Values.redis.replicas }}
+  serviceName: {{ .Values.name }}
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app: {{ .Values.redis.name }}
+      app: {{ .Values.name }}
   template:
     metadata:
       labels:
-        app: {{ .Values.redis.name }}
+        app: {{ .Values.name }}
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/redis-secret.yaml") . | sha256sum }}
     spec:
       initContainers:
       - name: config
-        image: {{ .Values.redis.images.redis }}
+        image: {{ .Values.images.redis }}
         env:
           - name: REDIS_PASSWORD
             valueFrom:
@@ -50,11 +50,11 @@ spec:
             echo "requirepass $REDIS_PASSWORD" >> /etc/redis/redis.conf
             
             echo "Finding master..."
-            MASTER_FDQN=`hostname  -f | sed -e 's/{{ .Values.redis.name }}-[0-9]\./{{ .Values.redis.name }}-0./'`
+            MASTER_FDQN=`hostname  -f | sed -e 's/{{ .Values.name }}-[0-9]\./{{ .Values.name }}-0./'`
             echo "Master at " $MASTER_FQDN
             if [ "$(redis-cli -h sentinel -p 5000 ping)" != "PONG" ]; then
               echo "No sentinel found..."
-              if [ "$(hostname)" = "{{ .Values.redis.name }}-0" ]; then
+              if [ "$(hostname)" = "{{ .Values.name }}-0" ]; then
                 echo "This is Redis master, not updating redis.conf..."
               else
                 echo "This is Redis replica, updating redis.conf..."               
@@ -73,13 +73,13 @@ spec:
         - name: config
           mountPath: /etc/redis/
       containers:
-      - name: {{ .Values.redis.name }}
-        image: {{ .Values.redis.images.redis }}
+      - name: {{ .Values.name }}
+        image: {{ .Values.images.redis }}
         command: ["redis-server"]
         args: ["/etc/redis/redis.conf"]
         ports:
         - containerPort: 6379
-          name: {{ .Values.redis.name }}
+          name: {{ .Values.name }}
         volumeMounts:
         - name: redis-primary-volume
           mountPath: /data
@@ -99,30 +99,30 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.redis.rediscommander }}
+  name: {{ .Values.rediscommander }}
   namespace: {{ include "custom.namespace" . }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Values.redis.rediscommander }}
+      app: {{ .Values.rediscommander }}
   template:
     metadata:
       labels:
-        app: {{ .Values.redis.rediscommander }}
+        app: {{ .Values.rediscommander }}
         tier: backend
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/redis-secret.yaml") . | sha256sum }}
     spec:
       containers:
-      - name: {{ .Values.redis.rediscommander }}
-        image: {{ .Values.redis.images.commander }}
+      - name: {{ .Values.rediscommander }}
+        image: {{ .Values.images.commander }}
         imagePullPolicy: IfNotPresent
         env:
           {{- $str := "" -}}
           {{- $ns := include "custom.namespace" . -}} 
-          {{- $replicas := .Values.redis.replicas | int }}
-          {{- $sentinel := .Values.redis.sentinel }}
+          {{- $replicas := .Values.replicas | int }}
+          {{- $sentinel := .Values.sentinel }}
           {{- range $i, $e := until $replicas }} 
           {{- if $i }}         
           {{- $str = print $str "," -}}
@@ -154,7 +154,7 @@ spec:
               name: redis-csm-secret
               key: commander_user         
         ports:
-        - name: {{ .Values.redis.rediscommander }}
+        - name: {{ .Values.rediscommander }}
           containerPort: 8081
         livenessProbe:
           httpGet:
@@ -177,11 +177,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.redis.rediscommander }}
+  name: {{ .Values.rediscommander }}
   namespace: {{ include "custom.namespace" . }}
 spec:
   selector:
-    app: {{ .Values.redis.rediscommander }}
+    app: {{ .Values.rediscommander }}
   ports:
   - protocol: TCP
     port: 8081

--- a/charts/csm-authorization-v2.0/charts/redis/templates/sentinel.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/templates/sentinel.yaml
@@ -1,23 +1,23 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Values.redis.sentinel }}
+  name: {{ .Values.sentinel }}
 spec:
-  serviceName: {{ .Values.redis.sentinel }}
-  replicas: {{ .Values.redis.replicas }}
+  serviceName: {{ .Values.sentinel }}
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app: {{ .Values.redis.sentinel }}
+      app: {{ .Values.sentinel }}
   template:
     metadata:
       labels:
-        app: {{ .Values.redis.sentinel }}
+        app: {{ .Values.sentinel }}
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/redis-secret.yaml") . | sha256sum }}
     spec:
       initContainers:
       - name: config
-        image: {{ .Values.redis.images.redis }}
+        image: {{ .Values.images.redis }}
         command: [ "sh", "-c" ]
         env:
           - name: REDIS_PASSWORD
@@ -27,10 +27,10 @@ spec:
                 key: password
         args:         
           - |         
-            replicas=$( expr {{ .Values.redis.replicas | int }} - 1)          
+            replicas=$( expr {{ .Values.replicas | int }} - 1)          
             for i in $(seq 0 $replicas)
             do               
-                node=$( echo "{{ .Values.redis.name }}-$i.{{ .Values.redis.name }}" )
+                node=$( echo "{{ .Values.name }}-$i.{{ .Values.name }}" )
                 nodes=$( echo "$nodes*$node" )
             done            
             loop=$(echo $nodes | sed -e "s/"*"/\n/g")
@@ -66,12 +66,12 @@ spec:
           mountPath: /etc/redis/
       containers:
       - name: sentinel
-        image: {{ .Values.redis.images.redis }}
+        image: {{ .Values.images.redis }}
         command: ["redis-sentinel"]
         args: ["/etc/redis/sentinel.conf"]
         ports:
         - containerPort: 5000
-          name: {{ .Values.redis.sentinel }}
+          name: {{ .Values.sentinel }}
         volumeMounts:
         - name: redis-config
           mountPath: /etc/redis/
@@ -86,7 +86,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.redis.sentinel }}
+  name: {{ .Values.sentinel }}
 spec:
   clusterIP: None
   ports:
@@ -99,13 +99,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
- name: {{ .Values.redis.sentinel }}-svc
+ name: {{ .Values.sentinel }}-svc
 spec: 
  type: NodePort
  ports:
  - port: 5000
    targetPort: 5000
    nodePort: 32003
-   name: {{ .Values.redis.sentinel }}-svc
+   name: {{ .Values.sentinel }}-svc
  selector:
-   app: {{ .Values.redis.sentinel }}
+   app: {{ .Values.sentinel }}

--- a/charts/csm-authorization-v2.0/charts/redis/values.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/values.yaml
@@ -1,8 +1,9 @@
-redis:
-  name: redis-csm
-  sentinel: sentinel
-  rediscommander: rediscommander
-  replicas: 5
-  images:
-    redis: redis:7.2.4-alpine
-    commander: rediscommander/redis-commander:latest
+name: redis-csm
+redisUsername:
+redisPassword:
+sentinel: sentinel
+rediscommander: rediscommander
+replicas: 5
+images:
+  redis: redis:7.2.4-alpine
+  commander: rediscommander/redis-commander:latest

--- a/charts/csm-authorization-v2.0/values.yaml
+++ b/charts/csm-authorization-v2.0/values.yaml
@@ -62,6 +62,8 @@ authorization:
 
 redis:
   name: redis-csm
+  redisUsername:
+  redisPassword:
   sentinel: sentinel
   rediscommander: rediscommander
   replicas: 5


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Added redisUsername and redisPassword fields to the parent chart's values.yaml and the redis subchart's values.yaml, requiring users to supply their own credentials at install time.

#### Which issue(s) is this PR associated with:

- #Issue_Number

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable


**Verifies that the chart requires explicit Redis credentials configuration.**

<details>
# helm template my-release charts/csm-authorization-v2.0
Error: execution error at (csm-authorization/charts/redis/templates/sentinel.yaml:16:28): Redis credentials are required. Set redis.redisPassword.

Use --debug flag to render out invalid YAML
</details>

**Verifies that the chart renders successfully when Redis credentials are provided directly.**

<details>
# helm template my-release charts/csm-authorization-v2.0   --set redis.redisUsername=testuser   --set redis.redisPassword=testpass123

# Source: csm-authorization/charts/redis/templates/redis-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: redis-csm-secret
  namespace: default
type: kubernetes.io/basic-auth
stringData:
  password: testpass123
  commander_user: testuser
</details>
