### PR TITLE
Corrected the Role to publish PVC events for PowerMax

### DIFF
--- a/charts/csi-powermax/templates/node.yaml
+++ b/charts/csi-powermax/templates/node.yaml
@@ -22,7 +22,7 @@ rules:
     resources: [ "persistentvolumes" ]
     verbs: [ "create", "delete", "get", "list", "watch", "update" ]
   - apiGroups: [ "" ]
-    resources: [ "persistentvolumesclaims" ]
+    resources: [ "persistentvolumeclaims" ]
     verbs: [ "get", "list", "watch", "update" ]
   - apiGroups: [ "" ]
     resources: [ "events" ]


### PR DESCRIPTION
Manage Space Reclamation feature for PowerFlex. Providing permissions for cluster role to update the PVC events for PowerFlex.

<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Manage Space Reclamation feature for PowerFlex. Providing permissions for cluster role to update the PVC events for PowerFlex.

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] PowerMax Env Update
<img width="819" height="631" alt="image" src="https://github.com/user-attachments/assets/11df0b86-7bc3-4dd5-b59d-fc179bcd609a" />

