### PR TITLE
[‎charts/karavi-observability] Fix cert-manager issuer naming collision for PowerMax observability

### DIFF
--- a/charts/karavi-observability/templates/cert-manager.yaml
+++ b/charts/karavi-observability/templates/cert-manager.yaml
@@ -65,7 +65,11 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
+  {{- if .Values.karaviMetricsPowermax.enabled }}
+  name: {{ .Chart.Name }}-selfsigned-issuer
+  {{- else }}
   name: selfsigned-issuer
+  {{- end }}
   namespace: {{ include "custom.namespace" . }}
 spec:
   selfSigned: {}
@@ -100,6 +104,8 @@ spec:
   issuerRef:
   {{- if and (.Values.otelCollector.certificateFile) (.Values.otelCollector.privateKeyFile) }}
     name: otel-collector-issuer
+  {{- else if .Values.karaviMetricsPowermax.enabled }}
+    name: {{ .Chart.Name }}-selfsigned-issuer
   {{- else }}
     name: selfsigned-issuer
   {{- end }}
@@ -135,6 +141,8 @@ spec:
   issuerRef:
   {{- if and (.Values.karaviMetricsPowerstore.certificateFile) (.Values.karaviMetricsPowerstore.privateKeyFile) }}
     name: karavi-metrics-powerstore-issuer
+  {{- else if .Values.karaviMetricsPowermax.enabled }}
+    name: {{ .Chart.Name }}-selfsigned-issuer
   {{- else }}
     name: selfsigned-issuer
   {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

Fixes cert-manager issuer naming collision when installing PowerMax driver with observability via the umbrella chart. Both the PowerMax reverse proxy and observability module attempted to create an Issuer named `selfsigned-issuer`, causing installation failure.

The fix conditionally prefixes the observability issuer name with the chart name (`karavi-observability-selfsigned-issuer`) only when PowerMax metrics are enabled. For other drivers (PowerStore, PowerScale, PowerFlex), the issuer name remains `selfsigned-issuer` to maintain backward compatibility.

See detailed investigation and testing in [OBSERVABILITY_ISSUE_FIX_LOG_CLEAN.md](https://github.com/user-attachments/files/27414826/OBSERVABILITY_ISSUE_FIX_LOG_CLEAN.md).


#### Which issue(s) is this PR associated with:

N/A

#### Special notes for your reviewer:

The condition uses `.Values.karaviMetricsPowermax.enabled` which is reliably set by dellctl based on the driver type being installed. This ensures the prefix only applies to PowerMax observability deployments.

#### Checklist:

- [x] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable