### PR TITLE
Updated redis config to have DNS

### DIFF
--- a/charts/csm-authorization-v2.0/charts/redis/templates/redis.yaml
+++ b/charts/csm-authorization-v2.0/charts/redis/templates/redis.yaml
@@ -81,6 +81,12 @@ spec:
             echo "masterauth $REDIS_PASSWORD" >> /etc/redis/redis.conf
             echo "requirepass $REDIS_PASSWORD" >> /etc/redis/redis.conf
 
+            # Announce this pod's stable DNS name so Sentinel tracks hostnames, not IPs
+            MY_FQDN="$(hostname).{{ .Values.name }}.{{ include "custom.namespace" . }}.svc.cluster.local"
+            echo "replica-announce-ip $MY_FQDN" >> /etc/redis/redis.conf
+            echo "replica-announce-port 6379" >> /etc/redis/redis.conf
+            echo "Announcing as $MY_FQDN"
+
             MASTER_FOUND="false"
             MAX_RETRIES=5
 
@@ -100,7 +106,7 @@ spec:
                   echo "Sentinel reports master at $MASTER_HOST:$MASTER_PORT"
 
                   # configure replicaof directive for replica pods only
-                  if [ "$(hostname -f)" != "$MASTER_HOST" ]; then
+                  if [ "$MY_FQDN" != "$MASTER_HOST" ]; then
                     echo "replicaof $MASTER_HOST $MASTER_PORT" >> /etc/redis/redis.conf
                   fi
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Fix Redis failover by configuring Redis instances to announce stable DNS names instead of ephemeral IP addresses. When a master pod restarts with a new IP, slaves can reconnect automatically because DNS resolves to the current pod IP. This prevents failover timeouts and connection loss during pod restarts.

#### Which issue(s) is this PR associated with:

- (https://jira.cec.lab.emc.com/browse/ECS01D-733)

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable

The codes changes are working fine, test report can be found for k8s here - 
[helm_redis_failover_test_report.md](https://github.com/user-attachments/files/28641384/helm_redis_failover_test_report.md) and for ocp here- 
[FINAL_REDIS_OCP_TEST_REPORT.md](https://github.com/user-attachments/files/28698207/FINAL_REDIS_OCP_TEST_REPORT.md)

