### PR TITLE
Fix for Authorization Bypass in csireverseproxy

### DIFF
--- a/charts/csi-powermax/charts/csireverseproxy/templates/reverseproxy.yaml
+++ b/charts/csi-powermax/charts/csireverseproxy/templates/reverseproxy.yaml
@@ -40,6 +40,10 @@ spec:
               value: /app/tls
             - name: X_CSI_REVPROXY_WATCH_NAMESPACE
               value: {{ .Release.Namespace }}
+            {{- if eq .Values.global.proxyAuthToken.enabled true }}
+            - name: X_CSI_REVPROXY_AUTH_TOKEN_FILE
+              value: /etc/proxy-auth-token/token
+            {{- end }}
           volumeMounts:
               {{- if and (hasKey .Values.global "useSecret") (.Values.global.useSecret | default false) }}
             - name: powermax-reverseproxy-secret
@@ -54,6 +58,11 @@ spec:
               mountPath: /app/tls
             - name: cert-dir
               mountPath: /app/certs
+            {{- if eq .Values.global.proxyAuthToken.enabled true }}
+            - name: proxy-auth-token
+              mountPath: /etc/proxy-auth-token
+              readOnly: true
+            {{- end }}
       volumes:
           {{- if and (hasKey .Values.global "useSecret") (.Values.global.useSecret | default false) }}
         - name: powermax-reverseproxy-secret
@@ -73,4 +82,9 @@ spec:
             secretName: {{ .Values.tlsSecret }}
         - name: cert-dir
           emptyDir:
+        {{- if eq .Values.global.proxyAuthToken.enabled true }}
+        - name: proxy-auth-token
+          secret:
+            secretName: {{ .Values.global.proxyAuthToken.secretName }}
+        {{- end }}
 {{- end }}

--- a/charts/csi-powermax/templates/controller.yaml
+++ b/charts/csi-powermax/templates/controller.yaml
@@ -564,6 +564,10 @@ spec:
               value: /app/tls
             - name: X_CSI_DYNAMIC_SG_ENABLED
               value: {{ .Values.dynamicSGEnabled | default "false" | lower | quote }}
+            {{- if and (eq .Values.global.proxyAuthToken.enabled true) (not .Values.csireverseproxy.deployAsSidecar) }}
+            - name: X_CSI_REVPROXY_AUTH_TOKEN_FILE
+              value: /etc/proxy-auth-token/token
+            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi
@@ -580,6 +584,11 @@ spec:
               {{- end }}
             - name: tls-secret
               mountPath: /app/tls
+            {{- if and (eq .Values.global.proxyAuthToken.enabled true) (not .Values.csireverseproxy.deployAsSidecar) }}
+            - name: proxy-auth-token
+              mountPath: /etc/proxy-auth-token
+              readOnly: true
+            {{- end }}
         {{- if eq .Values.csireverseproxy.deployAsSidecar true }}
         - name: reverseproxy
           image: {{ required "Must provided an image for reverseproxy container." .Values.images.csireverseproxy.image }}
@@ -600,6 +609,8 @@ spec:
               value: config.yaml
               {{- end }}
             - name: X_CSI_REVPROXY_IN_CLUSTER
+              value: "true"
+            - name: DeployAsSidecar
               value: "true"
             - name: X_CSI_REVPROXY_TLS_CERT_DIR
               value: /app/tls
@@ -649,6 +660,11 @@ spec:
         - name: powermax-config-params
           configMap:
             name: {{ .Release.Name }}-config-params
+        {{- if and (eq .Values.global.proxyAuthToken.enabled true) (not .Values.csireverseproxy.deployAsSidecar) }}
+        - name: proxy-auth-token
+          secret:
+            secretName: {{ .Values.global.proxyAuthToken.secretName }}
+        {{- end }}
         {{- if hasKey .Values "authorization" }}
         {{- if eq .Values.authorization.enabled true }}
         {{- if $authorizationConfigSecret }}

--- a/charts/csi-powermax/templates/node.yaml
+++ b/charts/csi-powermax/templates/node.yaml
@@ -354,6 +354,10 @@ spec:
               value: /app/tls
             - name: X_CSI_DYNAMIC_SG_ENABLED
               value: {{ .Values.dynamicSGEnabled | default "false" | lower | quote }}
+            {{- if and (eq .Values.global.proxyAuthToken.enabled true) (not .Values.csireverseproxy.deployAsSidecar) }}
+            - name: X_CSI_REVPROXY_AUTH_TOKEN_FILE
+              value: /etc/proxy-auth-token/token
+            {{- end }}
             {{- if hasKey .Values "fsCheck" }}
             - name: X_CSI_FS_CHECK_ENABLED
               value: "{{ .Values.fsCheck.enabled }}"
@@ -407,6 +411,11 @@ spec:
               {{- end }}
             - name: tls-secret
               mountPath: /app/tls
+            {{- if and (eq .Values.global.proxyAuthToken.enabled true) (not .Values.csireverseproxy.deployAsSidecar) }}
+            - name: proxy-auth-token
+              mountPath: /etc/proxy-auth-token
+              readOnly: true
+            {{- end }}
         - name: registrar
           image: {{ required "Must provide the CSI node registrar container image." .Values.images.registrar.image }}
           args:
@@ -594,3 +603,8 @@ spec:
         - name: tls-secret
           secret:
             secretName: {{ .Values.csireverseproxy.tlsSecret }}
+        {{- if and (eq .Values.global.proxyAuthToken.enabled true) (not .Values.csireverseproxy.deployAsSidecar) }}
+        - name: proxy-auth-token
+          secret:
+            secretName: {{ .Values.global.proxyAuthToken.secretName }}
+        {{- end }}

--- a/charts/csi-powermax/values.yaml
+++ b/charts/csi-powermax/values.yaml
@@ -51,6 +51,25 @@ global:
   # Default value: "" <empty>
   transportProtocol: ""
 
+  # proxyAuthToken: Shared authentication token between the CSI driver and the reverse proxy.
+  # When enabled, the driver sends the token in an X-Proxy-Auth-Token header, and the
+  # reverse proxy validates it. Both containers mount the same Kubernetes Secret.
+  #
+  # Note:
+  # - Sidecar deployments: Auth token is optional (trusted boundary)
+  # - Standalone deployments: Auth token is mandatory (enforced by reverse proxy startup validation)
+  proxyAuthToken:
+    # enabled: Enable/Disable shared auth token authentication
+    # Allowed values:
+    #   true: enable proxy auth token
+    #   false: disable proxy auth token
+    # Default value: false
+    enabled: false
+    # secretName: Name of the Kubernetes Secret that contains the shared auth token.
+    # The secret must have a key named "token" whose value is the shared token string.
+    # Default value: "proxy-auth-token"
+    secretName: "proxy-auth-token"
+
   # DEPRECATION NOTICE: The storageArrays parameter has been deprecated in this helm chart
   # and will be removed in a future release. It remains for backward compatibility only.
   # storageArrays have been migrated to the 'secret' format. Please refer to the official

--- a/charts/csi-powermax/values.yaml
+++ b/charts/csi-powermax/values.yaml
@@ -56,7 +56,7 @@ global:
   # reverse proxy validates it. Both containers mount the same Kubernetes Secret.
   #
   # Note:
-  # - Sidecar deployments: Auth token is optional (trusted boundary)
+  # - Sidecar deployments: Authentication is considered secure within the trusted boundary; hence, auth tokens are not implemented.
   # - Standalone deployments: The authentication token will be considered if provided; otherwise, the process will continue without the token.
   proxyAuthToken:
     # enabled: Enable/Disable shared auth token authentication

--- a/charts/csi-powermax/values.yaml
+++ b/charts/csi-powermax/values.yaml
@@ -57,7 +57,7 @@ global:
   #
   # Note:
   # - Sidecar deployments: Auth token is optional (trusted boundary)
-  # - Standalone deployments: Auth token is mandatory (enforced by reverse proxy startup validation)
+  # - Standalone deployments: The authentication token will be considered if provided; otherwise, the process will continue without the token.
   proxyAuthToken:
     # enabled: Enable/Disable shared auth token authentication
     # Allowed values:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Fix for Authorization Bypass in csireverseproxy

#### Which issue(s) is this PR associated with:

- #Issue_Number:
ECS01C-757

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable


Test:
Deployed as both standalone reverse proxy and as sidecar also and performed upgrade scenarios as well. Its working as expected. Attached logs in JIRA