### PR TITLE
PowerFlex: Adding changes to make drv_cfg path configurable

### DIFF
--- a/charts/csi-vxflexos/templates/node.yaml
+++ b/charts/csi-vxflexos/templates/node.yaml
@@ -449,7 +449,7 @@ spec:
                   name: {{ .Release.Name }}-config
                   key: MDM
             - name: HOST_DRV_CFG_PATH
-              value: /opt/emc/scaleio/sdc/bin
+              value: {{ default "/opt/emc/scaleio/sdc/bin" .Values.node.sdc.sdcHostDrvCfgPath }}
           volumeMounts:
             - name: dev
               mountPath: /dev
@@ -526,7 +526,7 @@ spec:
             type: DirectoryOrCreate
         - name: scaleio-path-opt
           hostPath:
-            path: /opt/emc/scaleio/sdc/bin
+            path: {{ default "/opt/emc/scaleio/sdc/bin" .Values.node.sdc.sdcHostDrvCfgPath }}
             type: DirectoryOrCreate
         {{- if eq .Values.node.sdc.sdcSFTPRepo.enabled true }}
         - name: sftp-keys
@@ -553,7 +553,7 @@ spec:
         - name: host-opt-emc-path
           hostPath:
             path: /opt/emc
-            type: Directory
+            type: DirectoryOrCreate
         - name: vxflexos-config
           secret:
             secretName: {{ .Release.Name }}-config

--- a/charts/csi-vxflexos/templates/node.yaml
+++ b/charts/csi-vxflexos/templates/node.yaml
@@ -449,7 +449,7 @@ spec:
                   name: {{ .Release.Name }}-config
                   key: MDM
             - name: HOST_DRV_CFG_PATH
-              value: {{ default "/opt/emc/scaleio/sdc/bin" .Values.node.sdc.sdcHostDrvCfgPath }}
+              value: {{ .Values.node.sdc.sdcHostDrvCfgPath }}
           volumeMounts:
             - name: dev
               mountPath: /dev
@@ -526,7 +526,7 @@ spec:
             type: DirectoryOrCreate
         - name: scaleio-path-opt
           hostPath:
-            path: {{ default "/opt/emc/scaleio/sdc/bin" .Values.node.sdc.sdcHostDrvCfgPath }}
+            path: {{ .Values.node.sdc.sdcHostDrvCfgPath }}
             type: DirectoryOrCreate
         {{- if eq .Values.node.sdc.sdcSFTPRepo.enabled true }}
         - name: sftp-keys

--- a/charts/csi-vxflexos/values.yaml
+++ b/charts/csi-vxflexos/values.yaml
@@ -319,7 +319,7 @@ node:
     enabled: true
     # sdcHostDrvCfgPath: Host path to the SDC drv_cfg utility
     # Default value: /opt/emc/scaleio/sdc/bin
-    sdcHostDrvCfgPath: ""
+    sdcHostDrvCfgPath: "/opt/emc/scaleio/sdc/bin"
     # sdcSFTPRepo: Enable/Disable SFTP/private repository details
     sdcSFTPRepo:
       enabled: false

--- a/charts/csi-vxflexos/values.yaml
+++ b/charts/csi-vxflexos/values.yaml
@@ -317,7 +317,10 @@ node:
   sdc:
     # enabled: Enable/Disable SDC
     enabled: true
-      # sdcSFTPRepo: Enable/Disable SFTP/private repository details
+    # sdcHostDrvCfgPath: Host path to the SDC drv_cfg utility
+    # Default value: /opt/emc/scaleio/sdc/bin
+    sdcHostDrvCfgPath: ""
+    # sdcSFTPRepo: Enable/Disable SFTP/private repository details
     sdcSFTPRepo:
       enabled: false
       # sdcSFTPRepoAddress specifies the address of the SFTP/private repository to look up for SDC kernel files

--- a/charts/csi-vxflexos/values.yaml
+++ b/charts/csi-vxflexos/values.yaml
@@ -317,8 +317,8 @@ node:
   sdc:
     # enabled: Enable/Disable SDC
     enabled: true
-    # sdcHostDrvCfgPath: Host path to the SDC drv_cfg utility
-    # Default value: /opt/emc/scaleio/sdc/bin
+    # sdcHostDrvCfgPath: Specifies the host path where the SDC drv_cfg utility is installed on the node.
+    # Defaults to "/opt/emc/scaleio/sdc/bin". Override this if host uses a different installation path.
     sdcHostDrvCfgPath: "/opt/emc/scaleio/sdc/bin"
     # sdcSFTPRepo: Enable/Disable SFTP/private repository details
     sdcSFTPRepo:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Currently, the path for the drv_cfg binary is hardcoded within the implementation. To address this limitation, we need to make the drv_cfg path configurable. This PR introduces the necessary changes to externalize the path configuration (e.g., via values.yaml), allowing users to specify a custom installation location.

#### Which issue(s) is this PR associated with:

- ECS02A-998 (K8S and OCP results are captured here)
- SUSE test results are captured in ECS02A-979

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable


**K8S Testing**
<img width="1527" height="275" alt="image" src="https://github.com/user-attachments/assets/12c43fd0-abed-43c1-9652-46788216941d" />
<img width="935" height="303" alt="image" src="https://github.com/user-attachments/assets/8ecfbd15-ee95-4f89-bc8b-17cd4e6aa8a4" />
<img width="652" height="212" alt="image" src="https://github.com/user-attachments/assets/7ba2423a-94e9-487b-bd2b-04415f110316" />
<img width="652" height="215" alt="image" src="https://github.com/user-attachments/assets/93dda069-01ea-4b8d-adca-3969711585d9" />

**OCP Testing**
Screenshots are attached in JIRA

