### PR TITLE
csi-isilon: Change default isiAuthType to session-based Authentication

### DIFF
--- a/charts/csi-isilon/Chart.yaml
+++ b/charts/csi-isilon/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: csi-isilon
-version: 2.17.0
-appVersion: "2.17.0"
+version: 2.17.1
+appVersion: "2.17.1"
 kubeVersion: ">= 1.25.0"
 # If you are using a complex K8s version like "v1.24.0-mirantis-1", use this kubeVersion check instead
 # kubeVersion: ">= 1.24.0-0"

--- a/charts/csi-isilon/values.yaml
+++ b/charts/csi-isilon/values.yaml
@@ -2,12 +2,12 @@
 ########################
 # version: version of this values file
 # Note: Do not change this value
-version: "v2.17.0"
+version: "v2.17.1"
 
 images:
   # "driver" defines the container image, used for the driver container.
   driver:
-    image: quay.io/dell/container-storage-modules/csi-isilon:v2.17.0
+    image: quay.io/dell/container-storage-modules/csi-isilon:v2.17.1
   # CSI sidecars
   attacher:
     image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
@@ -326,8 +326,8 @@ skipCertificateValidation: true
 # Allowed values:
 #   0: enables basic Authentication
 #   1: enables session-based Authentication
-# Default value: 0
-isiAuthType: 0
+# Default value: 1
+isiAuthType: 1
 
 # isiAccessZone: The name of the access zone a volume can be created in.
 # If storageclass is missing with AccessZone parameter, then value of isiAccessZone is used for the same.

--- a/container-storage-modules/container-storage-modules/Chart.yaml
+++ b/container-storage-modules/container-storage-modules/Chart.yaml
@@ -50,7 +50,7 @@ dependencies:
     condition: csi-powermax.enabled
 
   - name: csi-isilon
-    version: 2.17.0
+    version: 2.17.1
     repository: https://dell.github.io/helm-charts
     condition: csi-isilon.enabled
 

--- a/container-storage-modules/container-storage-modules/values.yaml
+++ b/container-storage-modules/container-storage-modules/values.yaml
@@ -218,11 +218,11 @@ csi-powermax:
 ########################
 csi-isilon:
   enabled: false
-  version: "v2.17.0"
+  version: "v2.17.1"
   images:
     # "driver" defines the container image, used for the driver container.
     driver:
-      image: quay.io/dell/container-storage-modules/csi-isilon:v2.17.0
+      image: quay.io/dell/container-storage-modules/csi-isilon:v2.17.1
     # CSI sidecars
     attacher:
       image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
This PR will change the default isiAuthType from basic to session based

#### Which issue(s) is this PR associated with:

- #ECS01D-737

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Chart Version bumped
- [x] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
