### PR TITLE
Changes for Helmv4 SSA Conflict for Authorization

### DIFF
--- a/charts/csm-authorization-v2.0/templates/cert-manager-readiness-check.yaml
+++ b/charts/csm-authorization-v2.0/templates/cert-manager-readiness-check.yaml
@@ -1,0 +1,86 @@
+{{- if or (not .Values.authorization.certificate) (not .Values.authorization.privateKey) }}
+{{- if index .Values "cert-manager" "enabled" }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cert-manager-readiness-check
+  namespace: {{ include "custom.namespace" . }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: readiness-check
+        image: bitnami/kubectl:latest
+        command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Waiting for cert-manager webhook pod to be ready..."
+          max_attempts=60
+          attempt=0
+          
+          while [ $attempt -lt $max_attempts ]; do
+            # Check if webhook pod is running
+            if kubectl get pods -n {{ include "custom.namespace" . }} -l app.kubernetes.io/name=webhook --field-selector=status.phase=Running 2>/dev/null | grep -q "{{ .Release.Name }}-cert-manager-webhook"; then
+              echo "cert-manager webhook pod is running!"
+              exit 0
+            fi
+            
+            echo "Attempt $((attempt + 1))/$max_attempts: Webhook pod not ready yet, waiting 5 seconds..."
+            sleep 5
+            attempt=$((attempt + 1))
+          done
+          
+          echo "Error: Timeout waiting for cert-manager webhook pod to be ready"
+          exit 1
+      serviceAccountName: cert-manager-readiness-check
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-manager-readiness-check
+  namespace: {{ include "custom.namespace" . }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cert-manager-readiness-check
+  namespace: {{ include "custom.namespace" . }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cert-manager-readiness-check
+  namespace: {{ include "custom.namespace" . }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+subjects:
+- kind: ServiceAccount
+  name: cert-manager-readiness-check
+  namespace: {{ include "custom.namespace" . }}
+roleRef:
+  kind: Role
+  name: cert-manager-readiness-check
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}

--- a/charts/csm-authorization-v2.0/templates/cert-manager-readiness-check.yaml
+++ b/charts/csm-authorization-v2.0/templates/cert-manager-readiness-check.yaml
@@ -1,4 +1,3 @@
-{{- if or (not .Values.authorization.certificate) (not .Values.authorization.privateKey) }}
 {{- if index .Values "cert-manager" "enabled" }}
 ---
 apiVersion: batch/v1
@@ -82,5 +81,4 @@ roleRef:
   kind: Role
   name: cert-manager-readiness-check
   apiGroup: rbac.authorization.k8s.io
-{{- end }}
 {{- end }}

--- a/charts/csm-authorization-v2.0/templates/certificate.yaml
+++ b/charts/csm-authorization-v2.0/templates/certificate.yaml
@@ -23,6 +23,9 @@ kind: Issuer
 metadata:
   name: selfsigned
   namespace: {{ include "custom.namespace" . }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
 spec:
   selfSigned: {}
 
@@ -33,6 +36,9 @@ kind: Certificate
 metadata:
   name: karavi-auth
   namespace: {{ include "custom.namespace" . }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "11"
 spec:
   secretName: karavi-selfsigned-tls
   duration: 2160h # 90d

--- a/charts/csm-authorization-v2.0/templates/pre-delete-cert-manager-hook.yaml
+++ b/charts/csm-authorization-v2.0/templates/pre-delete-cert-manager-hook.yaml
@@ -1,4 +1,3 @@
-{{- if index .Values "cert-manager" "enabled" }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -67,4 +66,3 @@ spec:
           kubectl delete certificate karavi-auth -n {{ include "custom.namespace" . }} --ignore-not-found=true
           kubectl delete issuer selfsigned -n {{ include "custom.namespace" . }} --ignore-not-found=true
           echo "Cleanup completed"
-{{- end }}

--- a/charts/csm-authorization-v2.0/templates/pre-delete-cert-manager-hook.yaml
+++ b/charts/csm-authorization-v2.0/templates/pre-delete-cert-manager-hook.yaml
@@ -1,0 +1,70 @@
+{{- if index .Values "cert-manager" "enabled" }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-manager-cleanup
+  namespace: {{ include "custom.namespace" . }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cert-manager-cleanup
+  namespace: {{ include "custom.namespace" . }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+rules:
+- apiGroups: ["cert-manager.io"]
+  resources: ["certificates", "issuers"]
+  verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cert-manager-cleanup
+  namespace: {{ include "custom.namespace" . }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+subjects:
+- kind: ServiceAccount
+  name: cert-manager-cleanup
+  namespace: {{ include "custom.namespace" . }}
+roleRef:
+  kind: Role
+  name: cert-manager-cleanup
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cert-manager-cleanup
+  namespace: {{ include "custom.namespace" . }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccountName: cert-manager-cleanup
+      containers:
+      - name: cleanup
+        image: bitnami/kubectl:latest
+        command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Deleting Certificate and Issuer resources..."
+          kubectl delete certificate karavi-auth -n {{ include "custom.namespace" . }} --ignore-not-found=true
+          kubectl delete issuer selfsigned -n {{ include "custom.namespace" . }} --ignore-not-found=true
+          echo "Cleanup completed"
+{{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Helm v4 uses SSA (Server-Side Apply) which applies all resources simultaneously while Helm v3 uses the sequential 3-way merge. So, when using Helm v4 for installing the Authorization module, the cert-manager webhook isn't ready when Certificate and Issuer resources are being applied, which gives error when using Helm v4 when installing the Authorization Proxy Server

As part of this PR, we have added the YAML for readiness check in the Authorization charts which waits for cert-manger webhook pod in running state and then creates the Issuer and Certificate as post install hooks when installing the Authorization Proxy Server via Helm v4. 

Now, that the Certificate and Issuer remain as post-install,post-upgrade hooks (for ordering during install), a separate pre-delete Job is added that explicitly deletes them during uninstall. 


#### Which issue(s) is this PR associated with:

- [https://jira.cec.lab.emc.com/browse/ECS01D-757]()

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable

#### Testing 

- **Current Scenario** - When the Authorization Proxy Server installation is failing with Helm V4 due to SSA Conflicts
```
[root@master-1-Y2S5NM9VANqis helm-charts]# helm -n authorization install authorization -f charts/csm-authorization-v2.0/values.yaml charts/csm-authorization-v2.0
Error: INSTALLATION FAILED: server-side apply failed for object authorization/karavi-auth cert-manager.io/v1, Kind=Certificate: Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://authorization-cert-manager-webhook.authorization.svc:443/mutate?timeout=10s": dial tcp 10.111.79.33:443: connect: connection refused
server-side apply failed for object authorization/selfsigned cert-manager.io/v1, Kind=Issuer: Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://authorization-cert-manager-webhook.authorization.svc:443/mutate?timeout=10s": dial tcp 10.111.79.33:443: connect: connection refused
[root@master-1-Y2S5NM9VANqis helm-charts]# 
[root@master-1-Y2S5NM9VANqis helm-charts]# helm version
version.BuildInfo{Version:"v4.2.1", GitCommit:"d591a19b953bd9cfdf7d9ddd83c2f4ffdaeafb29", GitTreeState:"clean", GoVersion:"go1.26.4", KubeClientVersion:"v1.36"}
```
- **With the fix applied** 
```
[root@master-1-Y2S5NM9VANqis helm-charts]# helm -n authorization install authorization -f charts/csm-authorization-v2.0/values.yaml charts/csm-authorization-v2.0
NAME: authorization
LAST DEPLOYED: Thu Jun 18 05:37:44 2026
NAMESPACE: authorization
STATUS: deployed
REVISION: 1
DESCRIPTION: Install complete
TEST SUITE: None
NOTES:
The CSM Authorization deployment has been successfully installed.

Execute the following commands in your shell to print the URL of the CSM Authorization NodePort LoadBalancer:

export NODE_PORT=$(kubectl get --namespace authorization -o jsonpath="{.spec.ports[0].nodePort}" service authorization-gateway-nginx)
export NODE_IP=$(kubectl get nodes --namespace authorization -o jsonpath="{.items[0].status.addresses[0].address}")
echo https://$NODE_IP:$NODE_PORT

LoadBalancer host rules for proxy-server:
- csm-authorization.com
- authorization-gateway-nginx.authorization.svc.cluster.local

authorization.proxyHost value for a CSI Driver examples:
- authorization-gateway-nginx.authorization.svc.cluster.local:443 (CSI Driver in the same cluster as CSM Authorization)
[root@master-1-Y2S5NM9VANqis helm-charts]# 
[root@master-1-Y2S5NM9VANqis helm-charts]# helm version
version.BuildInfo{Version:"v4.2.1", GitCommit:"d591a19b953bd9cfdf7d9ddd83c2f4ffdaeafb29", GitTreeState:"clean", GoVersion:"go1.26.4", KubeClientVersion:"v1.36"}
```
The readiness pod checks for the cert-manager webhook pod and gets deleted after the pod is ready 
```
[root@master-1-Y2S5NM9VANqis ~]# kubectl logs cert-manager-readiness-check-jkqz7 -n authorization 
Waiting for cert-manager webhook pod to be ready...
cert-manager webhook pod is running!
[root@master-1-Y2S5NM9VANqis ~]# kubectl get pod cert-manager-readiness-check-jkqz7 -n authorization
NAME                                 READY   STATUS      RESTARTS   AGE
cert-manager-readiness-check-jkqz7   0/1     Completed   0          78s
[root@master-1-Y2S5NM9VANqis ~]# kubectl get pod cert-manager-readiness-check-jkqz7 -n authorization
Error from server (NotFound): pods "cert-manager-readiness-check-jkqz7" not found
```

- Upgrade scenario is also tested with the changes 
[Authorization_UpgradeTesting_v3-v4.txt](https://github.com/user-attachments/files/29126186/Authorization_UpgradeTesting_v3-v4.txt)
