### PR TITLE
[charts/csm-authorization] introduce new parameter ipFamily for Auth

### DIFF
--- a/charts/csm-authorization-v2.0/values.yaml
+++ b/charts/csm-authorization-v2.0/values.yaml
@@ -7,6 +7,8 @@ openshift: false
 nginx-gateway-fabric:
   enabled: true
   nginx:
+    config:
+      # ipFamily: "ipv4"  # Optional: set to "ipv4" (IPv4-only) or "ipv6" (IPv6-only). When unset, nginx uses its default IP family behavior.
     service:
       externalTrafficPolicy: Cluster
 


### PR DESCRIPTION
#### Is this a new chart?

No

#### What this PR does / why we need it:
CSM Authorization installation fails on kubernetes clusters with IPv4-only clusters when IPv6 intentionally disabled.
NGINX Gateway Fabric fails to start with a bind error when attempting to listen on IPv6 addresses that are disabled at the kernel level.
`INFO msg="Validating NGINX configuration" correlation_id=dd-xx-xx server_type=command
time=Z level=ERROR msg="Errors found during config apply, sending error status and rolling back configuration updates" error="failed validating config NGINX config test failed exit status 1nginx: the configuration file /etc/nginx/nginx.conf syntax is ok () [::]:8081 failed (97: Address family not supported by protocol)\nnginx: configuration file /etc/nginx/nginx.conf test failed\n"`

Fix:
Add an optional ipFamily parameter under nginx-gateway-fabric.nginx.config in authorization values.yaml.
Users can set ipFamily: "ipv4" for IPv4-only clusters (e.g., RHEL 9.x with IPv6 disabled) or ipFamily: "ipv6" for IPv6-only clusters.
When unset, nginx uses its default IP family behavior.
The parameter is commented out by default to maintain backward compatibility.

#### Which issue(s) is this PR associated with:
ECS01F-963

#### Special notes for your reviewer:
Manually set the cluster to IPv4 only. Successfully deployed with PowerStore driver+Auth by setting ipFamily: "ipv4" and tested volume provisioning

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [x] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
