### PR TITLE
[charts/csi-powerstore] CSI Addons replication support for CSI PowerStore

### DIFF
--- a/charts/csi-powermax/templates/controller.yaml
+++ b/charts/csi-powermax/templates/controller.yaml
@@ -118,8 +118,9 @@ rules:
     resources: ["volumegroupsnapshotcontents/status"]
     verbs: ["update", "patch"]
   {{- end }}
+  {{- if hasKey .Values.controller "csiAddonsReplication" }}
+  {{- if eq .Values.controller.csiAddonsReplication.enabled true}}
   # below for csi-addons replication
-  {{- if eq .Values.csiAddonsReplication.enabled true}}
   - apiGroups: ["replication.storage.openshift.io"]
     resources: ["volumegroupreplications", "volumegroupreplications/status"]
     verbs: ["get", "list", "watch", "update", "patch"]
@@ -132,6 +133,7 @@ rules:
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]
     verbs: ["create"]
+  {{- end}}
   {{- end}}
   # Permissions for Storage Capacity
   {{- if eq (include "csi-powermax.isStorageCapacitySupported" .) "true" }}
@@ -334,7 +336,8 @@ spec:
               mountPath: /var/run/csi
         {{- end }}
         {{- end }}
-        {{- if eq .Values.csiAddonsReplication.enabled true}}
+        {{- if hasKey .Values.controller "csiAddonsReplication" }}
+        {{- if eq .Values.controller.csiAddonsReplication.enabled true}}
         - name: csi-addons
           image: {{ required "Must provide the CSI Addons sidecar container image." .Values.images.csiAddons.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -369,6 +372,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi
+        {{- end }}
         {{- end }}
         {{- if eq .Values.replication.enabled true}}
         - name: dell-csi-replicator
@@ -619,8 +623,10 @@ spec:
               value: /app/tls
             - name: X_CSI_DYNAMIC_SG_ENABLED
               value: {{ .Values.dynamicSGEnabled | default "false" | lower | quote }}
+            {{- if hasKey .Values.controller "csiAddonsReplication" }}
             - name: X_CSI_CSIADDONS_REPLICATION_ENABLED
-              value: "{{ .Values.csiAddonsReplication.enabled }}"
+              value: "{{ .Values.controller.csiAddonsReplication.enabled }}"
+            {{- end }}
             - name: X_CSI_DRIVER_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/csi-powermax/values.yaml
+++ b/charts/csi-powermax/values.yaml
@@ -326,6 +326,18 @@ controller:
     # Default value: 60s
     interval: 60s
 
+  # csiAddonsReplication: allows to configure CSI Addons replication
+  # CSI Addons provides additional capabilities like volume group replication
+  # CSI Addons CRDs (VolumeGroupReplication, VolumeReplicationClass) must be installed
+  # before enabling this feature.
+  csiAddonsReplication:
+    # enabled: Enable/Disable CSI Addons replication feature
+    # Allowed values:
+    #   true: enable CSI Addons replication feature (install csi-addons sidecar)
+    #   false: disable CSI Addons replication feature (do not install csi-addons sidecar)
+    # Default value: false
+    enabled: false
+
 # node: configure node specific parameters
 node:
   # nodeSelector: Define node selection constraints for node pods.
@@ -482,17 +494,6 @@ modifyHostName: "false"
 # is being done on a Red Hat OpenShift cluster in the Helm Chart
 # Don't modify this value as this value is overridden by the install script
 openshift: false
-
-# CSI Addons replication support
-# Set this to true to enable CSI Addons VolumeGroupReplication via the csi-addons sidecar.
-# CSI Addons CRDs (VolumeGroupReplication, VolumeReplicationClass) must be installed
-# before enabling this feature.
-# Allowed values:
-#   "true" - CSI Addons replication is enabled
-#   "false" - CSI Addons replication is disabled
-# Default value: "false"
-csiAddonsReplication:
-  enabled: false
 
 # CSM module attributes
 # Set this to true to enable replication

--- a/charts/csi-powerstore/templates/controller.yaml
+++ b/charts/csi-powerstore/templates/controller.yaml
@@ -120,6 +120,23 @@ rules:
     verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]
   {{- end}}
   {{- end}}
+  # below for csi-addons replication
+  {{- if hasKey .Values.controller "csiAddonsReplication" }}
+  {{- if eq .Values.controller.csiAddonsReplication.enabled true}}
+  - apiGroups: ["replication.storage.openshift.io"]
+    resources: ["volumegroupreplications", "volumegroupreplications/status"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["replication.storage.openshift.io"]
+    resources: ["volumegroupreplicationcontents", "volumegroupreplicationcontents/status"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["csiaddons.openshift.io"]
+    resources: ["csiaddonsnodes"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+  {{- end}}
+  {{- end}}
   # Permissions for CSIStorageCapacity
   {{- if eq (include "csi-powerstore.isStorageCapacitySupported" .) "true" }}
   - apiGroups: [ "storage.k8s.io" ]
@@ -397,6 +414,44 @@ spec:
               mountPath: /var/run/csi
         {{- end }}
         {{- end }}
+        {{- if hasKey .Values.controller "csiAddonsReplication" }}
+        {{- if eq .Values.controller.csiAddonsReplication.enabled true}}
+        - name: csi-addons
+          image: {{ required "Must provide the CSI Addons sidecar container image." .Values.images.csiAddons.image }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          args:
+            - "--node-id=$(KUBE_NODE_NAME)"
+            - "--v=5"
+            - "--csi-addons-address=$(CSI_ADDONS_ENDPOINT)"
+            - "--controller-port=9809"
+            - "--pod=$(POD_NAME)"
+            - "--namespace=$(POD_NAMESPACE)"
+            - "--pod-uid=$(POD_UID)"
+          env:
+            - name: CSI_ADDONS_ENDPOINT
+              value: /var/run/csi/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+        {{- end }}
+        {{- end }}
         - name: csi-metadata-retriever
           image: {{ required "Must provide the CSI Metadata retriever container image." .Values.images.metadataretriever.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -503,14 +558,14 @@ spec:
               value: "{{ .Values.controller.healthMonitor.enabled }}"
             {{- end }}
             {{- end }}
+            {{- if hasKey .Values.controller "csiAddonsReplication" }}
+            - name: X_CSI_CSIADDONS_REPLICATION_ENABLED
+              value: "{{ .Values.controller.csiAddonsReplication.enabled }}"
+            {{- end }}
             - name: GOPOWERSTORE_DEBUG
               value: "true"
             - name: CSI_AUTO_ROUND_OFF_FILESYSTEM_SIZE
               value: "{{ .Values.allowAutoRoundOffFilesystemSize | default true }}"
-            - name: X_CSI_DRIVER_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/charts/csi-powerstore/templates/controller.yaml
+++ b/charts/csi-powerstore/templates/controller.yaml
@@ -566,6 +566,10 @@ spec:
               value: "true"
             - name: CSI_AUTO_ROUND_OFF_FILESYSTEM_SIZE
               value: "{{ .Values.allowAutoRoundOffFilesystemSize | default true }}"
+            - name: X_CSI_DRIVER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/charts/csi-powerstore/templates/controller.yaml
+++ b/charts/csi-powerstore/templates/controller.yaml
@@ -123,9 +123,9 @@ rules:
     verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]
   {{- end}}
   {{- end}}
-  # below for csi-addons replication
   {{- if hasKey .Values.controller "csiAddonsReplication" }}
   {{- if eq .Values.controller.csiAddonsReplication.enabled true}}
+  # below for csi-addons replication
   - apiGroups: ["replication.storage.openshift.io"]
     resources: ["volumegroupreplications", "volumegroupreplications/status"]
     verbs: ["get", "list", "watch", "update", "patch"]

--- a/charts/csi-powerstore/values.yaml
+++ b/charts/csi-powerstore/values.yaml
@@ -45,6 +45,10 @@ images:
   healthmonitor:
     image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.18.0
 
+  # CSI Addons sidecar
+  csiAddons:
+    image: quay.io/csiaddons/k8s-sidecar:v0.14.0
+
   # CSM sidecars
   replication:
     image: quay.io/dell/container-storage-modules/dell-csi-replicator:v1.16.0
@@ -250,6 +254,16 @@ controller:
     # Allowed values: string
     # Default value: replication.storage.dell.com
     replicationPrefix: "replication.storage.dell.com"
+
+  # csiAddonsReplication: allows to configure CSI Addons replication
+  # CSI Addons provides additional capabilities like volume group replication
+  csiAddonsReplication:
+    # enabled: Enable/Disable CSI Addons replication feature
+    # Allowed values:
+    #   true: enable CSI Addons replication feature (install csi-addons sidecar)
+    #   false: disable CSI Addons replication feature (do not install csi-addons sidecar)
+    # Default value: false
+    enabled: false
 
   # nodeSelector: Define node selection constraints for controller pods.
   # For the pod to be eligible to run on a node, the node must have each

--- a/charts/csi-powerstore/values.yaml
+++ b/charts/csi-powerstore/values.yaml
@@ -257,6 +257,8 @@ controller:
 
   # csiAddonsReplication: allows to configure CSI Addons replication
   # CSI Addons provides additional capabilities like volume group replication
+  # CSI Addons CRDs (VolumeGroupReplication, VolumeReplicationClass) must be installed
+  # before enabling this feature.
   csiAddonsReplication:
     # enabled: Enable/Disable CSI Addons replication feature
     # Allowed values:

--- a/container-storage-modules/container-storage-modules/values.yaml
+++ b/container-storage-modules/container-storage-modules/values.yaml
@@ -20,7 +20,7 @@
 ########################
 csi-powerstore:
   enabled: false
-  version: "v2.17.0"
+  version: "v2.18.0"
   images:
     # "driver" defines the container image, used for the driver container.
     driver:
@@ -38,6 +38,8 @@ csi-powerstore:
       image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
     healthmonitor:
       image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.18.0
+    csiAddons:
+      image: quay.io/csiaddons/k8s-sidecar:v0.14.0
 
     # CSM sidecars
     replication:
@@ -64,6 +66,8 @@ csi-powerstore:
       enabled: true
     resizer:
       enabled: true
+    csiAddonsReplication:
+      enabled: false
   ## Node ATTRIBUTES
   node:
     healthMonitor:
@@ -147,7 +151,7 @@ csi-powermax:
       - endpoint: https://backup-1.unisphe.re:8443
   #    - endpoint: https://primary-2.unisphe.re:8443
   #    - endpoint: https://backup-2.unisphe.re:8443
-  version: "v2.17.0"
+  version: "v2.18.0"
   images:
     # "driver" defines the container image, used for the driver container.
     driver:
@@ -167,6 +171,8 @@ csi-powermax:
       image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
     healthmonitor:
       image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.18.0
+    csiAddons:
+      image: quay.io/csiaddons/k8s-sidecar:v0.14.0
     # CSM sidecars
     replication:
       image: quay.io/dell/container-storage-modules/dell-csi-replicator:v1.16.0
@@ -190,6 +196,8 @@ csi-powermax:
     healthMonitor:
       enabled: false
     nodeSelector:
+    csiAddonsReplication:
+      enabled: false
   node:
     healthMonitor:
       enabled: false
@@ -218,7 +226,7 @@ csi-powermax:
 ########################
 csi-isilon:
   enabled: false
-  version: "v2.17.0"
+  version: "v2.18.0"
   images:
     # "driver" defines the container image, used for the driver container.
     driver:
@@ -317,7 +325,7 @@ csi-isilon:
 ########################
 csi-vxflexos:
   enabled: false
-  version: v2.17.0
+  version: v2.18.0
   images:
     # "driver" defines the container image, used for the driver container.
     driver:
@@ -437,7 +445,7 @@ csi-vxflexos:
 ########################
 csi-unity:
   enabled: false
-  version: "v2.17.0"
+  version: "v2.18.0"
   images:
     # "driver" defines the container image, used for the driver container.
     driver:


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
This PR supports installing CSI Addons replication for the PowerStore driver via Helm chart

#### Which issue(s) is this PR associated with:

- #Issue_Number

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
