### PR TITLE
sdc driver container mount path configurable

### DIFF
--- a/charts/csi-vxflexos/templates/node.yaml
+++ b/charts/csi-vxflexos/templates/node.yaml
@@ -334,7 +334,7 @@ spec:
               mountPath: {{ .Values.kubeletConfigDir }}/plugins/kubernetes.io/csi
               mountPropagation: "Bidirectional"
             - name: scaleio-path-opt
-              mountPath: /opt/emc/scaleio/sdc/bin/
+              mountPath: {{ .Values.node.sdc.sdcHostDrvCfgPath }}
               readOnly: true
             - name: vxflexos-config
               mountPath: /vxflexos-config


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
This PR updates the mount path scaleio-path-opt in the driver container to align with the Operator configuration.

#### Which issue(s) is this PR associated with:

- #Issue_Number

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable


Testing:

<img width="1451" height="791" alt="image" src="https://github.com/user-attachments/assets/3cc23f53-b40f-47b6-923b-bde9cd750ea8" />

