### PR TITLE
Metrics flag added to observability

### DIFF
--- a/charts/karavi-observability/templates/karavi-metrics-powerscale.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerscale.yaml
@@ -15,6 +15,11 @@ spec:
   - name: karavi-metrics-powerscale
     port: 8080
     targetPort: 8080
+  {{- if .Values.karaviMetricsPowerscale.metrics.enabled }}
+  - name: obs-metrics
+    port: {{ .Values.karaviMetricsPowerscale.metrics.port }}
+    targetPort: {{ .Values.karaviMetricsPowerscale.metrics.port }}
+  {{- end }}
   selector:
     app.kubernetes.io/name: karavi-metrics-powerscale
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -53,6 +58,12 @@ spec:
       - name: karavi-metrics-powerscale
         image: {{ .Values.karaviMetricsPowerscale.image }}
         resources: {}
+        ports:
+        {{- if .Values.karaviMetricsPowerscale.metrics.enabled }}
+        - name: obs-metrics
+          containerPort: {{ .Values.karaviMetricsPowerscale.metrics.port }}
+          protocol: TCP
+        {{- end }}
         env:
         - name: POWERSCALE_METRICS_ENDPOINT
           value: "{{ .Values.karaviMetricsPowerscale.endpoint }}"
@@ -62,6 +73,12 @@ spec:
               fieldPath: metadata.namespace
         - name: TLS_ENABLED
           value: "true"
+        {{- if and .Values.karaviMetricsPowerscale.metrics.enabled .Values.karaviMetricsPowerscale.metrics.tlsCertSecret }}
+        - name: X_CSI_METRICS_TLS_CERT_FILE
+          value: /etc/metrics-tls/tls.crt
+        - name: X_CSI_METRICS_TLS_KEY_FILE
+          value: /etc/metrics-tls/tls.key
+        {{- end }}
         volumeMounts:
         - name: isilon-creds
           mountPath: /isilon-creds
@@ -70,6 +87,11 @@ spec:
           readOnly: true
         - name: karavi-metrics-powerscale-configmap
           mountPath: /etc/config
+        {{- if and .Values.karaviMetricsPowerscale.metrics.enabled .Values.karaviMetricsPowerscale.metrics.tlsCertSecret }}
+        - name: metrics-tls
+          mountPath: /etc/metrics-tls
+          readOnly: true
+        {{- end }}
       {{- if hasKey .Values.karaviMetricsPowerscale "authorization" }}
       {{- if eq .Values.karaviMetricsPowerscale.authorization.enabled true }}
       - name: karavi-authorization-proxy
@@ -119,6 +141,11 @@ spec:
       - name: karavi-metrics-powerscale-configmap
         configMap:
           name: karavi-metrics-powerscale-configmap
+      {{- if and .Values.karaviMetricsPowerscale.metrics.enabled .Values.karaviMetricsPowerscale.metrics.tlsCertSecret }}
+      - name: metrics-tls
+        secret:
+          secretName: {{ .Values.karaviMetricsPowerscale.metrics.tlsCertSecret }}
+      {{- end }}
       {{- if hasKey .Values.karaviMetricsPowerscale "authorization" }}
       {{- if eq .Values.karaviMetricsPowerscale.authorization.enabled true }}
       {{- if $authorizationConfigSecret }}
@@ -136,5 +163,40 @@ spec:
       {{ end }}
       restartPolicy: Always
 status: {}
+
+---
+{{- if and .Values.karaviMetricsPowerscale.metrics.enabled .Values.karaviMetricsPowerscale.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: karavi-metrics-powerscale-obs-monitor
+  namespace: {{ include "custom.namespace" . }}
+  labels:
+    app.kubernetes.io/name: karavi-metrics-powerscale
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- with .Values.karaviMetricsPowerscale.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: karavi-metrics-powerscale
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "custom.namespace" . }}
+  endpoints:
+  - port: obs-metrics
+    interval: {{ .Values.karaviMetricsPowerscale.metrics.serviceMonitor.interval }}
+    {{- if .Values.karaviMetricsPowerscale.metrics.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.karaviMetricsPowerscale.metrics.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    path: /metrics
+    {{- if and .Values.karaviMetricsPowerscale.metrics.enabled .Values.karaviMetricsPowerscale.metrics.tlsCertSecret }}
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: {{ .Values.karaviMetricsPowerscale.metrics.serviceMonitor.insecureSkipVerify }}
+    {{- end }}
+{{- end }}
 
 {{ end }}

--- a/charts/karavi-observability/templates/karavi-metrics-powerstore.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerstore.yaml
@@ -59,12 +59,10 @@ spec:
           protocol: TCP
         {{- end }}
         env:
-        - name: X_CSI_OBS_METRICS_ENABLED
+        - name: X_CSI_METRICS_ENABLED
           value: {{ .Values.karaviMetricsPowerstore.metrics.enabled | quote }}
-        - name: X_CSI_OBS_METRICS_PORT
+        - name: X_CSI_METRICS_PORT
           value: {{ .Values.karaviMetricsPowerstore.metrics.port | quote }}
-        - name: X_CSI_OBS_METRICS_SCHEME
-          value: {{ if .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}https{{ else }}http{{ end }}
         - name: POWERSTORE_METRICS_ENDPOINT
           value: "{{ .Values.karaviMetricsPowerstore.endpoint }}"
         - name: POWERSTORE_METRICS_NAMESPACE
@@ -73,12 +71,12 @@ spec:
               fieldPath: metadata.namespace
         - name: TLS_ENABLED
           value: "true"
-        {{- if .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
-        - name: X_CSI_OBS_METRICS_TLS_CERT
-          value: /certs/obs-tls.crt
-        - name: X_CSI_OBS_METRICS_TLS_KEY
-          value: /certs/obs-tls.key
-{{- end }}
+        {{- if and .Values.karaviMetricsPowerstore.metrics.enabled .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
+        - name: X_CSI_METRICS_TLS_CERT_FILE
+          value: /etc/metrics-tls/tls.crt
+        - name: X_CSI_METRICS_TLS_KEY_FILE
+          value: /etc/metrics-tls/tls.key
+        {{- end }}
         - name: X_CSI_POWERSTORE_API_TIMEOUT
           value: "{{ .Values.karaviMetricsPowerstore.apiTimeout }}"
         volumeMounts:
@@ -86,10 +84,11 @@ spec:
           mountPath: "/certs"
         - name: powerstore-config
           mountPath: /powerstore-config
-{{- if .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
-        - name: obs-metrics-tls-secret
-          mountPath: "/certs"
-{{- end }}
+        {{- if and .Values.karaviMetricsPowerstore.metrics.enabled .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
+        - name: metrics-tls
+          mountPath: /etc/metrics-tls
+          readOnly: true
+        {{- end }}
         - name: tls-secret
           mountPath: /etc/ssl/certs
           readOnly: true
@@ -152,11 +151,11 @@ spec:
       - name: karavi-metrics-powerstore-configmap
         configMap:
           name: karavi-metrics-powerstore-configmap
-{{- if .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
-      - name: obs-metrics-tls-secret
+      {{- if and .Values.karaviMetricsPowerstore.metrics.enabled .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
+      - name: metrics-tls
         secret:
           secretName: {{ .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
-{{- end }}
+      {{- end }}
       {{- if hasKey .Values.karaviMetricsPowerstore "authorization" }}
       {{- if eq .Values.karaviMetricsPowerstore.authorization.enabled true }}
       {{- if $authorizationConfigSecret }}

--- a/charts/karavi-observability/templates/karavi-metrics-powerstore.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerstore.yaml
@@ -59,11 +59,11 @@ spec:
           protocol: TCP
         {{- end }}
         env:
-        - name: OBS_METRICS_ENABLED
+        - name: X_CSI_OBS_METRICS_ENABLED
           value: {{ .Values.karaviMetricsPowerstore.metrics.enabled | quote }}
-        - name: OBS_METRICS_PORT
+        - name: X_CSI_OBS_METRICS_PORT
           value: {{ .Values.karaviMetricsPowerstore.metrics.port | quote }}
-        - name: OBS_METRICS_SCHEME
+        - name: X_CSI_OBS_METRICS_SCHEME
           value: {{ if .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}https{{ else }}http{{ end }}
         - name: POWERSTORE_METRICS_ENDPOINT
           value: "{{ .Values.karaviMetricsPowerstore.endpoint }}"
@@ -73,14 +73,14 @@ spec:
               fieldPath: metadata.namespace
         - name: TLS_ENABLED
           value: "true"
-        - name: X_CSI_POWERSTORE_API_TIMEOUT
-          value: "{{ .Values.karaviMetricsPowerstore.apiTimeout }}"
-{{- if .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
-        - name: OBS_METRICS_TLS_CERT
+        {{- if .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
+        - name: X_CSI_OBS_METRICS_TLS_CERT
           value: /certs/obs-tls.crt
-        - name: OBS_METRICS_TLS_KEY
+        - name: X_CSI_OBS_METRICS_TLS_KEY
           value: /certs/obs-tls.key
 {{- end }}
+        - name: X_CSI_POWERSTORE_API_TIMEOUT
+          value: "{{ .Values.karaviMetricsPowerstore.apiTimeout }}"
         volumeMounts:
         - name: karavi-metrics-powerstore-secret-volume
           mountPath: "/certs"
@@ -140,11 +140,6 @@ spec:
               path: localhost.crt
             - key: tls.key
               path: localhost.key
-{{- if .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
-      - name: obs-metrics-tls-secret
-        secret:
-          secretName: {{ .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
-{{- end }}
       - name: powerstore-config
         secret:
           secretName: powerstore-config
@@ -157,6 +152,11 @@ spec:
       - name: karavi-metrics-powerstore-configmap
         configMap:
           name: karavi-metrics-powerstore-configmap
+{{- if .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
+      - name: obs-metrics-tls-secret
+        secret:
+          secretName: {{ .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
+{{- end }}
       {{- if hasKey .Values.karaviMetricsPowerstore "authorization" }}
       {{- if eq .Values.karaviMetricsPowerstore.authorization.enabled true }}
       {{- if $authorizationConfigSecret }}

--- a/charts/karavi-observability/templates/karavi-metrics-powerstore.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerstore.yaml
@@ -59,10 +59,6 @@ spec:
           protocol: TCP
         {{- end }}
         env:
-        - name: X_CSI_METRICS_ENABLED
-          value: {{ .Values.karaviMetricsPowerstore.metrics.enabled | quote }}
-        - name: X_CSI_METRICS_PORT
-          value: {{ .Values.karaviMetricsPowerstore.metrics.port | quote }}
         - name: POWERSTORE_METRICS_ENDPOINT
           value: "{{ .Values.karaviMetricsPowerstore.endpoint }}"
         - name: POWERSTORE_METRICS_NAMESPACE
@@ -215,4 +211,4 @@ spec:
     {{- end }}
 {{- end }}
 
-{{ end }}
+{{- end }}

--- a/charts/karavi-observability/templates/karavi-metrics-powerstore.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerstore.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.karaviMetricsPowerstore.enabled }}
+{{- if .Values.karaviMetricsPowerstore.enabled }}
 {{- $authorizationConfigSecret := lookup "v1" "Secret" .Release.Namespace "karavi-authorization-config" }}
 
 apiVersion: v1
@@ -15,6 +15,11 @@ spec:
   - name: karavi-metrics-powerstore
     port: 9090
     targetPort: 9090
+  {{- if .Values.karaviMetricsPowerstore.metrics.enabled }}
+  - name: obs-metrics
+    port: {{ .Values.karaviMetricsPowerstore.metrics.port }}
+    targetPort: {{ .Values.karaviMetricsPowerstore.metrics.port }}
+  {{- end }}
   selector:
     app.kubernetes.io/name: karavi-metrics-powerstore
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -47,7 +52,19 @@ spec:
       - name: karavi-metrics-powerstore
         image: {{ .Values.karaviMetricsPowerstore.image }}
         resources: {}
+        ports:
+        {{- if .Values.karaviMetricsPowerstore.metrics.enabled }}
+        - name: obs-metrics
+          containerPort: {{ .Values.karaviMetricsPowerstore.metrics.port }}
+          protocol: TCP
+        {{- end }}
         env:
+        - name: OBS_METRICS_ENABLED
+          value: {{ .Values.karaviMetricsPowerstore.metrics.enabled | quote }}
+        - name: OBS_METRICS_PORT
+          value: {{ .Values.karaviMetricsPowerstore.metrics.port | quote }}
+        - name: OBS_METRICS_SCHEME
+          value: {{ if .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}https{{ else }}http{{ end }}
         - name: POWERSTORE_METRICS_ENDPOINT
           value: "{{ .Values.karaviMetricsPowerstore.endpoint }}"
         - name: POWERSTORE_METRICS_NAMESPACE
@@ -58,11 +75,21 @@ spec:
           value: "true"
         - name: X_CSI_POWERSTORE_API_TIMEOUT
           value: "{{ .Values.karaviMetricsPowerstore.apiTimeout }}"
+{{- if .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
+        - name: OBS_METRICS_TLS_CERT
+          value: /certs/obs-tls.crt
+        - name: OBS_METRICS_TLS_KEY
+          value: /certs/obs-tls.key
+{{- end }}
         volumeMounts:
         - name: karavi-metrics-powerstore-secret-volume
           mountPath: "/certs"
         - name: powerstore-config
           mountPath: /powerstore-config
+{{- if .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
+        - name: obs-metrics-tls-secret
+          mountPath: "/certs"
+{{- end }}
         - name: tls-secret
           mountPath: /etc/ssl/certs
           readOnly: true
@@ -113,6 +140,11 @@ spec:
               path: localhost.crt
             - key: tls.key
               path: localhost.key
+{{- if .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
+      - name: obs-metrics-tls-secret
+        secret:
+          secretName: {{ .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
+{{- end }}
       - name: powerstore-config
         secret:
           secretName: powerstore-config
@@ -142,5 +174,46 @@ spec:
       {{ end }}
       restartPolicy: Always
 status: {}
+
+---
+{{- if and .Values.karaviMetricsPowerstore.metrics.enabled .Values.karaviMetricsPowerstore.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: karavi-metrics-powerstore-obs
+  namespace: {{ include "custom.namespace" . }}
+  labels:
+    app.kubernetes.io/name: karavi-metrics-powerstore
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- with .Values.karaviMetricsPowerstore.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: karavi-metrics-powerstore
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "custom.namespace" . }}
+  endpoints:
+  - port: obs-metrics
+    interval: {{ .Values.karaviMetricsPowerstore.metrics.serviceMonitor.interval }}
+    {{- if .Values.karaviMetricsPowerstore.metrics.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.karaviMetricsPowerstore.metrics.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    scheme: {{ if .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}https{{ else }}http{{ end }}
+    {{- if .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
+    tlsConfig:
+      insecureSkipVerify: {{ .Values.karaviMetricsPowerstore.metrics.serviceMonitor.insecureSkipVerify }}
+      cert:
+        secret:
+          name: {{ .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
+          key: obs-tls.crt
+      keySecret:
+        name: {{ .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
+          key: obs-tls.key
+    {{- end }}
+{{- end }}
 
 {{ end }}

--- a/charts/karavi-observability/templates/karavi-observability-configmap.yaml
+++ b/charts/karavi-observability/templates/karavi-observability-configmap.yaml
@@ -50,7 +50,8 @@ data:
     ZIPKIN_URI: "{{ .Values.karaviMetricsPowerstore.zipkin.uri }}"
     ZIPKIN_SERVICE_NAME: "{{ .Values.karaviMetricsPowerstore.zipkin.serviceName }}"
     ZIPKIN_PROBABILITY: "{{ .Values.karaviMetricsPowerstore.zipkin.probability }}"
-    X_CSI_OBS_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerstore.metrics.enabled }}"
+    X_CSI_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerstore.metrics.enabled }}"
+    X_CSI_METRICS_PORT: "{{ .Values.karaviMetricsPowerstore.metrics.port }}"
 
 {{ end }}
 

--- a/charts/karavi-observability/templates/karavi-observability-configmap.yaml
+++ b/charts/karavi-observability/templates/karavi-observability-configmap.yaml
@@ -50,8 +50,7 @@ data:
     ZIPKIN_URI: "{{ .Values.karaviMetricsPowerstore.zipkin.uri }}"
     ZIPKIN_SERVICE_NAME: "{{ .Values.karaviMetricsPowerstore.zipkin.serviceName }}"
     ZIPKIN_PROBABILITY: "{{ .Values.karaviMetricsPowerstore.zipkin.probability }}"
-    OBS_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerstore.obsMetricsEnabled }}"
-
+    OBS_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerstore.metrics.enabled }}"
 
 {{ end }}
 

--- a/charts/karavi-observability/templates/karavi-observability-configmap.yaml
+++ b/charts/karavi-observability/templates/karavi-observability-configmap.yaml
@@ -50,6 +50,8 @@ data:
     ZIPKIN_URI: "{{ .Values.karaviMetricsPowerstore.zipkin.uri }}"
     ZIPKIN_SERVICE_NAME: "{{ .Values.karaviMetricsPowerstore.zipkin.serviceName }}"
     ZIPKIN_PROBABILITY: "{{ .Values.karaviMetricsPowerstore.zipkin.probability }}"
+    OBS_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerstore.obsMetricsEnabled }}"
+
 
 {{ end }}
 

--- a/charts/karavi-observability/templates/karavi-observability-configmap.yaml
+++ b/charts/karavi-observability/templates/karavi-observability-configmap.yaml
@@ -78,6 +78,8 @@ data:
     POWERSCALE_ISICLIENT_INSECURE: "{{ .Values.karaviMetricsPowerscale.isiClientOptions.isiSkipCertificateValidation }}"
     POWERSCALE_ISICLIENT_AUTH_TYPE: "{{ .Values.karaviMetricsPowerscale.isiClientOptions.isiAuthType }}"
     POWERSCALE_ISICLIENT_VERBOSE: "{{ .Values.karaviMetricsPowerscale.isiClientOptions.isiLogVerbose }}"
+    X_CSI_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerscale.metrics.enabled }}"
+    X_CSI_METRICS_PORT: "{{ .Values.karaviMetricsPowerscale.metrics.port }}"
     LOG_LEVEL: "{{ .Values.karaviMetricsPowerscale.logLevel }}"
     LOG_FORMAT: "{{ .Values.karaviMetricsPowerscale.logFormat }}"
 

--- a/charts/karavi-observability/templates/karavi-observability-configmap.yaml
+++ b/charts/karavi-observability/templates/karavi-observability-configmap.yaml
@@ -50,7 +50,7 @@ data:
     ZIPKIN_URI: "{{ .Values.karaviMetricsPowerstore.zipkin.uri }}"
     ZIPKIN_SERVICE_NAME: "{{ .Values.karaviMetricsPowerstore.zipkin.serviceName }}"
     ZIPKIN_PROBABILITY: "{{ .Values.karaviMetricsPowerstore.zipkin.probability }}"
-    OBS_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerstore.metrics.enabled }}"
+    X_CSI_OBS_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerstore.metrics.enabled }}"
 
 {{ end }}
 

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -153,6 +153,38 @@ karaviMetricsPowerscale:
     type: ClusterIP
   logLevel: INFO
   logFormat: text
+  # metrics: configuration for observability self-metrics (dell_csm_obs_* on port /metrics)
+  metrics:
+    # enabled: Enable/Disable observability self-metrics endpoint
+    # Allowed values: true, false
+    # Default value: false
+    enabled: false
+    # port: Port used by observability self-metrics endpoint
+    # Allowed values: 1-65535
+    # Default value: 8443
+    port: 8443
+    # tlsCertSecret: Name of secret containing TLS certificate and key for observability self-metrics
+    # Allowed values: Kubernetes secret name, empty string
+    # Default value: ""
+    tlsCertSecret: ""
+    # serviceMonitor: Configure ServiceMonitor for observability self-metrics
+    serviceMonitor:
+      # enabled: Enable/Disable ServiceMonitor creation for observability self-metrics
+      # Allowed values: true, false
+      # Default value: false
+      enabled: false
+      # interval: Prometheus scrape interval for observability self-metrics
+      # Allowed values: duration string (for example: 15s, 30s, 1m)
+      # Default value: "30s"
+      interval: "30s"
+      # scrapeTimeout: Prometheus scrape timeout for observability self-metrics
+      # Allowed values: duration string, empty string
+      # Default value: ""
+      scrapeTimeout: ""
+      # insecureSkipVerify: Skip TLS certificate verification while scraping observability self-metrics
+      # Allowed values: true, false
+      # Default value: false
+      insecureSkipVerify: false
   # isiClientOptions to access Powerscale OneFS API server
   isiClientOptions:
     # set isiSkipCertificateValidation to true/false to skip/verify OneFS API server's certificates

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -1,6 +1,6 @@
 karaviMetricsPowerflex:
   image: quay.io/dell/container-storage-modules/csm-metrics-powerflex:v1.16.0
-  enabled: true
+  enabled: false
   collectorAddr: otel-collector:55680
   # comma separated list of provisioner names (ex: csi-vxflexos.dellemc.com)
   provisionerNames: csi-vxflexos.dellemc.com
@@ -44,7 +44,7 @@ karaviMetricsPowerflex:
     skipCertificateValidation: true
 
 karaviMetricsPowerstore:
-  image: quay.io/dell/container-storage-modules/csm-metrics-powerstore:v1.16.0
+  image: csm.artifactory.cec.lab.emc.com/csm-users/harish_h2/csm-metrics-powerstore:version6
   enabled: true
   collectorAddr: otel-collector:55680
   # comma separated list of provisioner names (ex: csi-powerstore.dellemc.com)
@@ -73,10 +73,38 @@ karaviMetricsPowerstore:
     type: ClusterIP
   logLevel: INFO
   logFormat: text
-  # obsMetricsEnabled: enable/disable observability self-metrics (dell_csm_obs_* on port 8080/metrics)
-  # Requires metrics.enabled in the csi-powerstore chart to also be true.
-  # Default value: false
-  obsMetricsEnabled: false
+  # metrics: configuration for observability self-metrics (dell_csm_obs_* on port /metrics)
+  metrics:
+    # enabled: Enable/Disable observability self-metrics endpoint
+    # Allowed values: true, false
+    # Default value: false
+    enabled: false
+    # port: Port used by observability self-metrics endpoint
+    # Allowed values: 1-65535
+    # Default value: 8080
+    port: 8080
+    # tlsCertSecret: Name of secret containing TLS certificate and key for observability self-metrics
+    # Allowed values: Kubernetes secret name, empty string
+    # Default value: ""
+    tlsCertSecret: ""
+    # serviceMonitor: Configure ServiceMonitor for observability self-metrics
+    serviceMonitor:
+      # enabled: Enable/Disable ServiceMonitor creation for observability self-metrics
+      # Allowed values: true, false
+      # Default value: false
+      enabled: false
+      # interval: Prometheus scrape interval for observability self-metrics
+      # Allowed values: duration string (for example: 15s, 30s, 1m)
+      # Default value: "30s"
+      interval: "30s"
+      # scrapeTimeout: Prometheus scrape timeout for observability self-metrics
+      # Allowed values: duration string, empty string
+      # Default value: ""
+      scrapeTimeout: ""
+      # insecureSkipVerify: Skip TLS certificate verification while scraping observability self-metrics
+      # Allowed values: true, false
+      # Default value: false
+      insecureSkipVerify: false
   zipkin:
     uri: ""
     serviceName: metrics-powerstore
@@ -99,7 +127,7 @@ karaviMetricsPowerstore:
 
 karaviMetricsPowerscale:
   image: quay.io/dell/container-storage-modules/csm-metrics-powerscale:v1.13.0
-  enabled: true
+  enabled: false
   collectorAddr: otel-collector:55680
   # comma separated list of provisioner names (ex: csi-isilon.dellemc.com)
   provisionerNames: csi-isilon.dellemc.com
@@ -154,7 +182,7 @@ karaviMetricsPowerscale:
 
 karaviMetricsPowermax:
   image: quay.io/dell/container-storage-modules/csm-metrics-powermax:v1.11.0
-  enabled: true
+  enabled: false
   collectorAddr: otel-collector:55680
   # comma separated list of provisioner names (ex: csi-powermax.dellemc.com)
   provisionerNames: csi-powermax.dellemc.com

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -73,6 +73,10 @@ karaviMetricsPowerstore:
     type: ClusterIP
   logLevel: INFO
   logFormat: text
+  # obsMetricsEnabled: enable/disable observability self-metrics (dell_csm_obs_* on port 8080/metrics)
+  # Requires metrics.enabled in the csi-powerstore chart to also be true.
+  # Default value: false
+  obsMetricsEnabled: false
   zipkin:
     uri: ""
     serviceName: metrics-powerstore

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -1,6 +1,6 @@
 karaviMetricsPowerflex:
   image: quay.io/dell/container-storage-modules/csm-metrics-powerflex:v1.16.0
-  enabled: false
+  enabled: true
   collectorAddr: otel-collector:55680
   # comma separated list of provisioner names (ex: csi-vxflexos.dellemc.com)
   provisionerNames: csi-vxflexos.dellemc.com
@@ -44,7 +44,7 @@ karaviMetricsPowerflex:
     skipCertificateValidation: true
 
 karaviMetricsPowerstore:
-  image: csm.artifactory.cec.lab.emc.com/csm-users/harish_h2/csm-metrics-powerstore:version6
+  image: quay.io/dell/container-storage-modules/csm-metrics-powerstore:v1.16.0
   enabled: true
   collectorAddr: otel-collector:55680
   # comma separated list of provisioner names (ex: csi-powerstore.dellemc.com)
@@ -127,7 +127,7 @@ karaviMetricsPowerstore:
 
 karaviMetricsPowerscale:
   image: quay.io/dell/container-storage-modules/csm-metrics-powerscale:v1.13.0
-  enabled: false
+  enabled: true
   collectorAddr: otel-collector:55680
   # comma separated list of provisioner names (ex: csi-isilon.dellemc.com)
   provisionerNames: csi-isilon.dellemc.com
@@ -182,7 +182,7 @@ karaviMetricsPowerscale:
 
 karaviMetricsPowermax:
   image: quay.io/dell/container-storage-modules/csm-metrics-powermax:v1.11.0
-  enabled: false
+  enabled: true
   collectorAddr: otel-collector:55680
   # comma separated list of provisioner names (ex: csi-powermax.dellemc.com)
   provisionerNames: csi-powermax.dellemc.com

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -81,8 +81,8 @@ karaviMetricsPowerstore:
     enabled: false
     # port: Port used by observability self-metrics endpoint
     # Allowed values: 1-65535
-    # Default value: 8080
-    port: 8080
+    # Default value: 8443
+    port: 8443
     # tlsCertSecret: Name of secret containing TLS certificate and key for observability self-metrics
     # Allowed values: Kubernetes secret name, empty string
     # Default value: ""


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No 

#### What this PR does / why we need it:

Implement CSM metrics powerstore and powerscale  instrumentation

#### Which issue(s) is this PR associated with:

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable

 - [x] Tested with the flag both enabled and disabled; it is working as expected for PowerStore & PowerScale
