### PR TITLE
CIDR network string

### DIFF
--- a/charts/csi-isilon/values.yaml
+++ b/charts/csi-isilon/values.yaml
@@ -45,10 +45,11 @@ certSecretCount: 1
 
 # allowedNetworks: Custom networks for PowerScale export
 #   Specify list of networks which can be used for NFS I/O traffic; CIDR format should be used.
-# Allowed values: list of one or more networks
+#   The driver will select the first node IP that falls within any of the specified CIDR ranges.
+# Allowed values: a quoted, bracketed, comma-separated string of one or more networks in CIDR notation
 # Default value: None
-# Examples: [192.168.1.0/24, 192.168.100.0/22]
-allowedNetworks: []
+# Examples: "[192.168.1.0/24, 192.168.100.0/22]"
+allowedNetworks: ""
 
 # maxIsilonVolumesPerNode: Specify default value for maximum number of volumes that controller can publish to the node.
 # If value is zero CO SHALL decide how many volumes of this type can be published by the controller to the node.


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Updates the allowedNetworks parameter in charts/csi-isilon/values.yaml from a YAML list ([]) to a quoted string (""). This aligns the Helm chart value format with how the CSI PowerScale driver actually parses the allowed networks configuration — as a single comma-separated string rather than a native YAML list. The comment and example are updated to reflect the expected format: a quoted, bracketed, comma-separated string of CIDR ranges (e.g., "[192.168.1.0/24, 192.168.100.0/22]"). Also clarifies that the driver selects the first node IP falling within any of the specified CIDR ranges.

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable

