### PR TITLE
[charts/csm-authorization] Add metrics support for proxy-server

### DIFF
--- a/charts/csm-authorization-v2.0/templates/_helpers.tpl
+++ b/charts/csm-authorization-v2.0/templates/_helpers.tpl
@@ -7,3 +7,18 @@ By default this is not set so the helm release namespace will be used
 {{- define "custom.namespace" -}}
 	{{ .Values.namespace | default .Release.Namespace }}
 {{- end -}}
+
+{{/*
+Return true if proxy-server metrics is enabled
+*/}}
+{{- define "csm-authorization.isMetricsEnabled" -}}
+{{- if hasKey .Values.authorization "metrics" -}}
+  {{- if (eq .Values.authorization.metrics.enabled true) -}}
+      {{- true -}}
+  {{- else -}}
+      {{- false -}}
+  {{- end -}}
+{{- else -}}
+  {{- false -}}
+{{- end -}}
+{{- end -}}

--- a/charts/csm-authorization-v2.0/templates/metrics-service.yaml
+++ b/charts/csm-authorization-v2.0/templates/metrics-service.yaml
@@ -1,0 +1,21 @@
+{{- if eq (include "csm-authorization.isMetricsEnabled" .) "true" }}
+---
+# Service exposing the proxy-server Prometheus metrics endpoint for scraping.
+# Created when authorization.metrics.enabled is true.
+apiVersion: v1
+kind: Service
+metadata:
+  name: proxy-server-metrics
+  namespace: {{ include "custom.namespace" . }}
+  labels:
+    app: proxy-server
+spec:
+  selector:
+    app: proxy-server
+  ports:
+    - name: metrics
+      port: {{ .Values.authorization.metrics.port | default 2112 }}
+      targetPort: {{ .Values.authorization.metrics.port | default 2112 }}
+      protocol: TCP
+  type: ClusterIP
+{{- end }}

--- a/charts/csm-authorization-v2.0/templates/proxy-server.yaml
+++ b/charts/csm-authorization-v2.0/templates/proxy-server.yaml
@@ -157,6 +157,18 @@ spec:
               secretKeyRef:
                 name: {{ $redisSecretName | default "redis-csm-secret" }}
                 key: {{ $redisSecretProviderClass.redisPasswordKey | default "password" }}
+          {{- if eq (include "csm-authorization.isMetricsEnabled" .) "true" }}
+          - name: X_CSI_METRICS_ENABLED
+            value: "true"
+          - name: X_CSI_METRICS_PORT
+            value: ":{{ .Values.authorization.metrics.port | default 2112 }}"
+          {{- if .Values.authorization.metrics.tlsCertSecret }}
+          - name: X_CSI_METRICS_TLS_CERT_FILE
+            value: "/etc/metrics-tls/tls.crt"
+          - name: X_CSI_METRICS_TLS_KEY_FILE
+            value: "/etc/metrics-tls/tls.key"
+          {{- end }}
+          {{- end }}
         args:
           - "--redis-sentinel={{ $str }}"
           - "--redis-password=$(REDIS_PASSWORD)"
@@ -165,6 +177,11 @@ spec:
           - "--storage-service=storage-service.{{ .Release.Namespace }}.svc.cluster.local:50051"
         ports:
         - containerPort: 8080
+        {{- if eq (include "csm-authorization.isMetricsEnabled" .) "true" }}
+        - name: metrics
+          containerPort: {{ .Values.authorization.metrics.port | default 2112 }}
+          protocol: TCP
+        {{- end }}
         volumeMounts:
         - name: config-volume
           mountPath: /etc/karavi-authorization/config
@@ -174,6 +191,11 @@ spec:
         {{- range $name := $allSPCNames }}
         - name: secrets-store-inline-{{ $name }}
           mountPath: /etc/csm-authorization/{{ $name }}
+          readOnly: true
+        {{- end }}
+        {{- if and (eq (include "csm-authorization.isMetricsEnabled" .) "true") .Values.authorization.metrics.tlsCertSecret }}
+        - name: metrics-tls
+          mountPath: /etc/metrics-tls
           readOnly: true
         {{- end }}
       - name: opa
@@ -208,6 +230,11 @@ spec:
           readOnly: true
           volumeAttributes:
             secretProviderClass: "{{ $name }}"
+      {{- end }}
+      {{- if and (eq (include "csm-authorization.isMetricsEnabled" .) "true") .Values.authorization.metrics.tlsCertSecret }}
+      - name: metrics-tls
+        secret:
+          secretName: {{ .Values.authorization.metrics.tlsCertSecret }}
       {{- end }}
 ---
 apiVersion: v1

--- a/charts/csm-authorization-v2.0/templates/servicemonitor.yaml
+++ b/charts/csm-authorization-v2.0/templates/servicemonitor.yaml
@@ -1,0 +1,33 @@
+{{- if eq (include "csm-authorization.isMetricsEnabled" .) "true" }}
+{{- if hasKey .Values.authorization.metrics "serviceMonitor" }}
+{{- if eq .Values.authorization.metrics.serviceMonitor.enabled true }}
+---
+# ServiceMonitor for Prometheus Operator integration with the proxy-server Deployment.
+# Created when authorization.metrics.enabled AND authorization.metrics.serviceMonitor.enabled are true.
+# Requires the Prometheus Operator CRDs to be installed in the cluster.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: proxy-server-metrics-monitor
+  namespace: {{ include "custom.namespace" . }}
+  labels:
+    app: proxy-server
+spec:
+  selector:
+    matchLabels:
+      app: proxy-server
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.authorization.metrics.serviceMonitor.interval | default "30s" }}
+      {{- if .Values.authorization.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.authorization.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      path: /metrics
+      {{- if .Values.authorization.metrics.tlsCertSecret }}
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: {{ .Values.authorization.metrics.serviceMonitor.insecureSkipVerify | default false }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/csm-authorization-v2.0/values.yaml
+++ b/charts/csm-authorization-v2.0/values.yaml
@@ -77,6 +77,46 @@ authorization:
   # storage capacity poll interval
   storageCapacityPollInterval: 30m
 
+  # metrics: configuration for proxy-server Prometheus metrics
+  metrics:
+    # enabled: Enable/Disable the Prometheus metrics HTTP server on the proxy-server.
+    # When true, the proxy-server receives X_CSI_METRICS_ENABLED=true,
+    # X_CSI_METRICS_PORT, and a metrics Service is created.
+    # Default value: false
+    enabled: false
+
+    # port: Port on which the proxy-server metrics endpoint is exposed.
+    # Passed as X_CSI_METRICS_PORT (formatted as ":port") to the proxy-server container
+    # and used as targetPort in the metrics Service.
+    # Default value: 2112
+    port: 2112
+
+    # tlsCertSecret: Name of a Kubernetes TLS Secret (tls.crt / tls.key) used to
+    # serve the metrics endpoint over HTTPS instead of plain HTTP.
+    # When set, X_CSI_METRICS_TLS_CERT_FILE and X_CSI_METRICS_TLS_KEY_FILE are
+    # injected into the proxy-server container.
+    # Leave empty (default) to use plain HTTP.
+    # Default value: "" (disabled - plain HTTP)
+    tlsCertSecret: ""
+
+    # serviceMonitor: Controls optional Prometheus Operator ServiceMonitor creation.
+    serviceMonitor:
+      # enabled: When true, a ServiceMonitor CR is created for automatic Prometheus
+      # Operator integration targeting the proxy-server pods.
+      # Requires the Prometheus Operator CRDs to be installed in the cluster.
+      # Default value: false
+      enabled: false
+      # interval: Prometheus scrape interval for the metrics endpoint.
+      # Default value: "30s"
+      interval: "30s"
+      # scrapeTimeout: Prometheus scrape timeout for the metrics endpoint.
+      # Default value: "" (unset)
+      scrapeTimeout: ""
+      # insecureSkipVerify: Controls TLS certificate verification when scraping.
+      # Only used when metrics.tlsCertSecret is set (HTTPS endpoint).
+      # Default value: false
+      insecureSkipVerify: false
+
 redis:
   name: redis-csm
   # Redis credentials are required and can be provided in one of two ways:

--- a/charts/csm-authorization-v2.0/values.yaml
+++ b/charts/csm-authorization-v2.0/values.yaml
@@ -83,7 +83,7 @@ authorization:
     # When true, the proxy-server receives X_CSI_METRICS_ENABLED=true,
     # X_CSI_METRICS_PORT, and a metrics Service is created.
     # Default value: false
-    enabled: false
+    enabled: true
 
     # port: Port on which the proxy-server metrics endpoint is exposed.
     # Passed as X_CSI_METRICS_PORT (formatted as ":port") to the proxy-server container


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:
Adds Helm chart support for exposing the CSM Authorization `proxy-server` Prometheus metrics endpoint. This is the deployment-side companion to the proxy-server metrics instrumentation: it wires the `X_CSI_METRICS_*` environment variables, creates a Kubernetes `Service`, and optionally creates a `ServiceMonitor` for Prometheus Operator integration.
#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable

#### Testing

- Authorization installed with metrics enabled and the `/metrics` endpoint on proxy-server port `:2112` was verified to emit the metrics below.
- Authorization installed metrics disabled and verified metrics server was not started.

#### Sample `/metrics` output

```text
# HELP dell_csm_auth_credential_shield_total Total credential shielding results.
# TYPE dell_csm_auth_credential_shield_total counter
dell_csm_auth_credential_shield_total{status="success",storage_type="powermax"} 3

# HELP dell_csm_auth_quota_check_total Total quota check results.
# TYPE dell_csm_auth_quota_check_total counter
dell_csm_auth_quota_check_total{result="denied",storage_type="powermax",tenant="test-auth-tenant"} 1

# HELP dell_csm_auth_request_duration_seconds Authorization request duration in seconds.
# TYPE dell_csm_auth_request_duration_seconds histogram
dell_csm_auth_request_duration_seconds_bucket{storage_type="powermax",tenant="test-auth-tenant",le="0.1"} 1
dell_csm_auth_request_duration_seconds_bucket{storage_type="powermax",tenant="test-auth-tenant",le="0.5"} 3
dell_csm_auth_request_duration_seconds_bucket{storage_type="powermax",tenant="test-auth-tenant",le="1"} 3
dell_csm_auth_request_duration_seconds_bucket{storage_type="powermax",tenant="test-auth-tenant",le="2"} 3
dell_csm_auth_request_duration_seconds_bucket{storage_type="powermax",tenant="test-auth-tenant",le="5"} 3
dell_csm_auth_request_duration_seconds_bucket{storage_type="powermax",tenant="test-auth-tenant",le="10"} 3
dell_csm_auth_request_duration_seconds_bucket{storage_type="powermax",tenant="test-auth-tenant",le="30"} 3
dell_csm_auth_request_duration_seconds_bucket{storage_type="powermax",tenant="test-auth-tenant",le="60"} 3
dell_csm_auth_request_duration_seconds_bucket{storage_type="powermax",tenant="test-auth-tenant",le="+Inf"} 3
dell_csm_auth_request_duration_seconds_sum{storage_type="powermax",tenant="test-auth-tenant"} 0.428803408
dell_csm_auth_request_duration_seconds_count{storage_type="powermax",tenant="test-auth-tenant"} 3

# HELP dell_csm_auth_request_total Total authorization requests.
# TYPE dell_csm_auth_request_total counter
dell_csm_auth_request_total{status="failure",storage_type="powermax",tenant="test-auth-tenant"} 2
dell_csm_auth_request_total{status="failure",storage_type="powermax",tenant="unknown"} 2
dell_csm_auth_request_total{status="success",storage_type="powermax",tenant="test-auth-tenant"} 1

# HELP dell_csm_auth_role_access_total Total role access decisions.
# TYPE dell_csm_auth_role_access_total counter
dell_csm_auth_role_access_total{decision="allow",role="test-auth-role",storage_type="powermax"} 1

# HELP dell_csm_auth_success_rate Rolling ratio of successful authorization requests to total requests (0.0-1.0). Target: >0.95.
# TYPE dell_csm_auth_success_rate gauge
dell_csm_auth_success_rate 0.2

# HELP dell_csm_auth_token_validation_total Total token validation outcomes.
# TYPE dell_csm_auth_token_validation_total counter
dell_csm_auth_token_validation_total{reason="invalid_header",result="failure"} 1
dell_csm_auth_token_validation_total{reason="invalid_token",result="failure"} 1
dell_csm_auth_token_validation_total{reason="ok",result="success"} 4

# HELP dell_csm_auth_up 1 if the CSM Authorization proxy is running.
# TYPE dell_csm_auth_up gauge
dell_csm_auth_up 1
```