### PR TITLE
Metric flag added for powermax

### DIFF
--- a/charts/karavi-observability/templates/karavi-metrics-powermax.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powermax.yaml
@@ -15,6 +15,11 @@ spec:
   - name: karavi-metrics-powermax
     port: 8081
     targetPort: 8081
+  {{- if .Values.karaviMetricsPowermax.metrics.enabled }}
+  - name: obs-metrics
+    port: {{ .Values.karaviMetricsPowermax.metrics.port }}
+    targetPort: {{ .Values.karaviMetricsPowermax.metrics.port }}
+  {{- end }}
   selector:
     app.kubernetes.io/name: karavi-metrics-powermax
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -53,6 +58,12 @@ spec:
       - name: karavi-metrics-powermax
         image: {{ .Values.karaviMetricsPowermax.image }}
         resources: {}
+        {{- if .Values.karaviMetricsPowermax.metrics.enabled }}
+        ports:
+        - name: obs-metrics
+          containerPort: {{ .Values.karaviMetricsPowermax.metrics.port }}
+          protocol: TCP
+        {{- end }}
         env:
         {{- $useRevProxySecret := and (hasKey .Values.karaviMetricsPowermax "useSecret") (.Values.karaviMetricsPowermax.useSecret | default false) }}
         - name: X_CSI_REVPROXY_USE_SECRET
@@ -69,6 +80,12 @@ spec:
           value: "true"
         - name: SSL_CERT_DIR
           value: /certs
+        {{- if and .Values.karaviMetricsPowermax.metrics.enabled .Values.karaviMetricsPowermax.metrics.tlsCertSecret }}
+        - name: X_CSI_METRICS_TLS_CERT_FILE
+          value: /etc/metrics-tls/tls.crt
+        - name: X_CSI_METRICS_TLS_KEY_FILE
+          value: /etc/metrics-tls/tls.key
+        {{- end }}
         volumeMounts:
             {{- if and (hasKey .Values.karaviMetricsPowermax "useSecret") (.Values.karaviMetricsPowermax.useSecret | default false) }}
         - name: powermax-reverseproxy-secret
@@ -84,6 +101,11 @@ spec:
           mountPath: /etc/config
         - name: certs
           mountPath: /certs
+        {{- if and .Values.karaviMetricsPowermax.metrics.enabled .Values.karaviMetricsPowermax.metrics.tlsCertSecret }}
+        - name: metrics-tls
+          mountPath: /etc/metrics-tls
+          readOnly: true
+        {{- end }}
       {{- if hasKey .Values.karaviMetricsPowermax "authorization" }}
       {{- if eq .Values.karaviMetricsPowermax.authorization.enabled true }}
       - name: karavi-authorization-proxy
@@ -141,6 +163,11 @@ spec:
       - name: karavi-metrics-powermax-configmap
         configMap:
           name: karavi-metrics-powermax-configmap
+      {{- if and .Values.karaviMetricsPowermax.metrics.enabled .Values.karaviMetricsPowermax.metrics.tlsCertSecret }}
+      - name: metrics-tls
+        secret:
+          secretName: {{ .Values.karaviMetricsPowermax.metrics.tlsCertSecret }}
+      {{- end }}
      {{- if hasKey .Values.karaviMetricsPowermax "authorization" }}
      {{- if eq .Values.karaviMetricsPowermax.authorization.enabled true }}
       {{- if $authorizationConfigSecret }}
@@ -160,3 +187,45 @@ spec:
 status: {}
 
 {{ end }}
+
+---
+{{- if and .Values.karaviMetricsPowermax.metrics.enabled .Values.karaviMetricsPowermax.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: karavi-metrics-powermax-obs-monitor
+  namespace: {{ include "custom.namespace" . }}
+  labels:
+    app.kubernetes.io/name: karavi-metrics-powermax
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- with .Values.karaviMetricsPowermax.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: karavi-metrics-powermax
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "custom.namespace" . }}
+  endpoints:
+  - port: obs-metrics
+    interval: {{ .Values.karaviMetricsPowermax.metrics.serviceMonitor.interval }}
+    {{- if .Values.karaviMetricsPowermax.metrics.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.karaviMetricsPowermax.metrics.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    path: /metrics
+    scheme: {{ if .Values.karaviMetricsPowermax.metrics.tlsCertSecret }}https{{ else }}http{{ end }}
+    {{- if .Values.karaviMetricsPowermax.metrics.tlsCertSecret }}
+    tlsConfig:
+      insecureSkipVerify: {{ .Values.karaviMetricsPowermax.metrics.serviceMonitor.insecureSkipVerify }}
+      cert:
+        secret:
+          name: {{ .Values.karaviMetricsPowermax.metrics.tlsCertSecret }}
+          key: obs-tls.crt
+      keySecret:
+        name: {{ .Values.karaviMetricsPowermax.metrics.tlsCertSecret }}
+        key: obs-tls.key
+    {{- end }}
+{{- end }}

--- a/charts/karavi-observability/templates/karavi-observability-configmap.yaml
+++ b/charts/karavi-observability/templates/karavi-observability-configmap.yaml
@@ -106,6 +106,8 @@ data:
     POWERMAX_PERFORMANCE_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowermax.performancePollFrequencySeconds }}"
     POWERMAX_TOPOLOGY_METRICS_ENABLED: "{{ .Values.karaviMetricsPowermax.topologyMetricsEnabled }}"
     POWERMAX_TOPOLOGY_METRICS_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowermax.topologyMetricsPollFrequencySeconds }}"
+    X_CSI_METRICS_ENABLED: "{{ .Values.karaviMetricsPowermax.metrics.enabled }}"
+    X_CSI_METRICS_PORT: "{{ .Values.karaviMetricsPowermax.metrics.port }}"
     LOG_LEVEL: "{{ .Values.karaviMetricsPowermax.logLevel }}"
     LOG_FORMAT: "{{ .Values.karaviMetricsPowermax.logFormat }}"
 

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -252,6 +252,38 @@ karaviMetricsPowermax:
     type: ClusterIP
   logLevel: INFO
   logFormat: text
+  # metrics: configuration for observability self-metrics (dell_csm_obs_* on port /metrics)
+  metrics:
+    # enabled: Enable/Disable observability self-metrics endpoint
+    # Allowed values: true, false
+    # Default value: false
+    enabled: false
+    # port: Port used by observability self-metrics endpoint
+    # Allowed values: 1-65535
+    # Default value: 8443
+    port: 8443
+    # tlsCertSecret: Name of secret containing TLS certificate and key for observability self-metrics
+    # Allowed values: Kubernetes secret name, empty string
+    # Default value: ""
+    tlsCertSecret: ""
+    # serviceMonitor: Configure ServiceMonitor for observability self-metrics
+    serviceMonitor:
+      # enabled: Enable/Disable ServiceMonitor creation for observability self-metrics
+      # Allowed values: true, false
+      # Default value: false
+      enabled: false
+      # interval: Prometheus scrape interval for observability self-metrics
+      # Allowed values: duration string (for example: 15s, 30s, 1m)
+      # Default value: "30s"
+      interval: "30s"
+      # scrapeTimeout: Prometheus scrape timeout for observability self-metrics
+      # Allowed values: duration string, empty string
+      # Default value: ""
+      scrapeTimeout: ""
+      # insecureSkipVerify: Skip TLS certificate verification while scraping observability self-metrics
+      # Allowed values: true, false
+      # Default value: false
+      insecureSkipVerify: false
   authorization:
     enabled: false
     # sidecarProxy.image: the container image used for the csm-authorization-sidecar.


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No 

#### What this PR does / why we need it:

Implement CSM metrics powermax  instrumentation

#### Which issue(s) is this PR associated with:

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable

 - [x] Tested with the flag both enabled and disabled; it is working as expected for Powermax
