### PR TITLE
Patch release v1.17.2: PowerScale v2.17.2 multi-NIC NFS support and umbrella chart 1.10.2

### DIFF
--- a/charts/csi-isilon/Chart.yaml
+++ b/charts/csi-isilon/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: csi-isilon
-version: 2.17.1
-appVersion: "2.17.1"
+version: 2.17.2
+appVersion: "2.17.2"
 kubeVersion: ">= 1.25.0"
 # If you are using a complex K8s version like "v1.24.0-mirantis-1", use this kubeVersion check instead
 # kubeVersion: ">= 1.24.0-0"

--- a/charts/csi-isilon/templates/controller.yaml
+++ b/charts/csi-isilon/templates/controller.yaml
@@ -426,6 +426,10 @@ spec:
               value: "{{ .Values.skipCertificateValidation }}"
             - name: X_CSI_ISI_AUTH_TYPE
               value: "{{ .Values.isiAuthType }}"
+            - name: X_CSI_ALLOWED_NETWORKS
+              value: "{{ .Values.allowedNetworks }}"
+            - name: X_CSI_ALLOWED_NETWORKS_MODE
+              value: "{{ .Values.allowedNetworksMode | default "single" }}"
             - name: X_CSI_VERBOSE
               value: "{{ .Values.verbose }}"
             - name: X_CSI_ISI_PORT

--- a/charts/csi-isilon/templates/node.yaml
+++ b/charts/csi-isilon/templates/node.yaml
@@ -196,6 +196,8 @@ spec:
               value: "{{ .Values.isiAuthType }}"
             - name: X_CSI_ALLOWED_NETWORKS
               value: "{{ .Values.allowedNetworks }}"
+            - name: X_CSI_ALLOWED_NETWORKS_MODE
+              value: "{{ .Values.allowedNetworksMode | default "single" }}"
             - name: X_CSI_VERBOSE
               value: "{{ .Values.verbose }}"
             - name: X_CSI_PRIVATE_MOUNT_DIR

--- a/charts/csi-isilon/values.yaml
+++ b/charts/csi-isilon/values.yaml
@@ -2,12 +2,12 @@
 ########################
 # version: version of this values file
 # Note: Do not change this value
-version: "v2.17.1"
+version: "v2.17.2"
 
 images:
   # "driver" defines the container image, used for the driver container.
   driver:
-    image: quay.io/dell/container-storage-modules/csi-isilon:v2.17.1
+    image: quay.io/dell/container-storage-modules/csi-isilon:v2.17.2
   # CSI sidecars
   attacher:
     image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
@@ -45,10 +45,20 @@ certSecretCount: 1
 
 # allowedNetworks: Custom networks for PowerScale export
 #   Specify list of networks which can be used for NFS I/O traffic; CIDR format should be used.
-# Allowed values: list of one or more networks
+#   The driver will select the first node IP that falls within any of the specified CIDR ranges.
+# Allowed values: a quoted, bracketed, comma-separated string of one or more networks in CIDR notation
 # Default value: None
-# Examples: [192.168.1.0/24, 192.168.100.0/22]
-allowedNetworks: []
+# Examples: "[192.168.1.0/24, 192.168.100.0/22]"
+allowedNetworks: ""
+
+# allowedNetworksMode: Controls how the driver selects NFS client IP(s) from the
+# interfaces matching allowedNetworks. "single" preserves the existing first-match
+# behavior. "multi" adds ALL matching IPs to the NFS export client list, enabling
+# multi-path storage access for nodes with multiple network interfaces. "multi"
+# requires allowedNetworks to be set.
+# Allowed values: single, multi
+# Default value: single
+allowedNetworksMode: single
 
 # maxIsilonVolumesPerNode: Specify default value for maximum number of volumes that controller can publish to the node.
 # If value is zero CO SHALL decide how many volumes of this type can be published by the controller to the node.

--- a/container-storage-modules/container-storage-modules/Chart.yaml
+++ b/container-storage-modules/container-storage-modules/Chart.yaml
@@ -30,13 +30,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.1
+version: 1.10.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.10.1"
+appVersion: "1.10.2"
 
 dependencies:
   - name: csi-powerstore
@@ -50,7 +50,7 @@ dependencies:
     condition: csi-powermax.enabled
 
   - name: csi-isilon
-    version: 2.17.1
+    version: 2.17.2
     repository: https://dell.github.io/helm-charts
     condition: csi-isilon.enabled
 

--- a/container-storage-modules/container-storage-modules/values.yaml
+++ b/container-storage-modules/container-storage-modules/values.yaml
@@ -218,11 +218,11 @@ csi-powermax:
 ########################
 csi-isilon:
   enabled: false
-  version: "v2.17.1"
+  version: "v2.17.2"
   images:
     # "driver" defines the container image, used for the driver container.
     driver:
-      image: quay.io/dell/container-storage-modules/csi-isilon:v2.17.1
+      image: quay.io/dell/container-storage-modules/csi-isilon:v2.17.2
     # CSI sidecars
     attacher:
       image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0


### PR DESCRIPTION
## Summary
- Update `csi-isilon` chart to `2.17.2` and driver image to `v2.17.2`
- Change `allowedNetworks` to a string and add `allowedNetworksMode` (`single`/`multi`)
- Add `X_CSI_ALLOWED_NETWORKS` and `X_CSI_ALLOWED_NETWORKS_MODE` env vars to controller and node
- Bump `container-storage-modules` umbrella chart to `1.10.2` and `csi-isilon` dependency to `2.17.2`

## Test plan
- [x] `helm lint` passes for `charts/csi-isilon`
- [x] `helm lint` passes for `container-storage-modules/container-storage-modules`
- [x] `ct lint` passes on changed charts

Generated with [Devin](https://devin.ai)