### PR TITLE
[charts/csi-isilon] Add multi-NIC allowedNetworksMode support

### DIFF
--- a/charts/csi-isilon/templates/controller.yaml
+++ b/charts/csi-isilon/templates/controller.yaml
@@ -479,6 +479,10 @@ spec:
               value: "{{ .Values.skipCertificateValidation }}"
             - name: X_CSI_ISI_AUTH_TYPE
               value: "{{ .Values.isiAuthType }}"
+            - name: X_CSI_ALLOWED_NETWORKS
+              value: "{{ .Values.allowedNetworks }}"
+            - name: X_CSI_ALLOWED_NETWORKS_MODE
+              value: "{{ .Values.allowedNetworksMode | default "single" }}"
             - name: X_CSI_VERBOSE
               value: "{{ .Values.verbose }}"
             - name: X_CSI_ISI_PORT

--- a/charts/csi-isilon/templates/node.yaml
+++ b/charts/csi-isilon/templates/node.yaml
@@ -230,6 +230,8 @@ spec:
               value: "{{ .Values.isiAuthType }}"
             - name: X_CSI_ALLOWED_NETWORKS
               value: "{{ .Values.allowedNetworks }}"
+            - name: X_CSI_ALLOWED_NETWORKS_MODE
+              value: "{{ .Values.allowedNetworksMode | default "single" }}"
             - name: X_CSI_VERBOSE
               value: "{{ .Values.verbose }}"
             - name: X_CSI_PRIVATE_MOUNT_DIR

--- a/charts/csi-isilon/values.yaml
+++ b/charts/csi-isilon/values.yaml
@@ -51,6 +51,15 @@ certSecretCount: 1
 # Examples: "[192.168.1.0/24, 192.168.100.0/22]"
 allowedNetworks: ""
 
+# allowedNetworksMode: Controls how the driver selects NFS client IP(s) from the
+# interfaces matching allowedNetworks. "single" preserves the existing first-match
+# behavior. "multi" adds ALL matching IPs to the NFS export client list, enabling
+# multi-path storage access for nodes with multiple network interfaces. "multi"
+# requires allowedNetworks to be set.
+# Allowed values: single, multi
+# Default value: single
+allowedNetworksMode: single
+
 # maxIsilonVolumesPerNode: Specify default value for maximum number of volumes that controller can publish to the node.
 # If value is zero CO SHALL decide how many volumes of this type can be published by the controller to the node.
 # This limit is applicable to all the nodes in the cluster for which node label 'max-isilon-volumes-per-node' is not set.


### PR DESCRIPTION
## Summary
Add multi-NIC NFS network selection support to the `csi-isilon` (PowerScale) chart.

- Add `allowedNetworksMode` value to `values.yaml` (supports `single` and `multi`)
- Add `X_CSI_ALLOWED_NETWORKS` and `X_CSI_ALLOWED_NETWORKS_MODE` env vars to the controller template
- Add `X_CSI_ALLOWED_NETWORKS_MODE` env var to the node template

## Test plan
- [x] `helm lint charts/csi-isilon` passes
- [x] `ct lint` passes for changed chart

Generated with [Devin](https://devin.ai)