### PR TITLE
Update container-storage-modules copyright headers to 2023-2026

### DIFF
--- a/container-storage-modules/container-storage-modules/Chart.yaml
+++ b/container-storage-modules/container-storage-modules/Chart.yaml
@@ -1,6 +1,6 @@
 #
 #
-# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2023-2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/container-storage-modules/container-storage-modules/values.yaml
+++ b/container-storage-modules/container-storage-modules/values.yaml
@@ -1,6 +1,6 @@
 #
 #
-# Copyright © 2023-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2023-2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
Update the copyright headers in the `container-storage-modules` umbrella chart to `Copyright © 2023-2026`.

- `container-storage-modules/container-storage-modules/Chart.yaml`
- `container-storage-modules/container-storage-modules/values.yaml`

## Test plan
- [x] `helm lint` passes for `container-storage-modules/container-storage-modules`
- [x] `ct lint` passes for changed chart

Generated with [Devin](https://devin.ai)