### PR TITLE
[charts/csi-powermax] Upgrade PowerMax CSI driver to v2.17.2

### DIFF
--- a/charts/csi-powermax/Chart.yaml
+++ b/charts/csi-powermax/Chart.yaml
@@ -1,7 +1,22 @@
+#
+#
+# Copyright © 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
 apiVersion: v2
-appVersion: "2.17.1"
+appVersion: "2.17.2"
 name: csi-powermax
-version: 2.17.1
+version: 2.17.2
 description: |
   PowerMax CSI (Container Storage Interface) driver Kubernetes
   integration. This chart includes everything required to provision via CSI as

--- a/charts/csi-powermax/values.yaml
+++ b/charts/csi-powermax/values.yaml
@@ -1,3 +1,18 @@
+#
+#
+# Copyright © 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
 ---
 global:
   # CSI driver log level
@@ -109,14 +124,14 @@ global:
 
 # Current version of the driver
 # Don't modify this value as this value will be used by the install script
-version: "v2.17.1"
+version: "v2.17.2"
 
 # "images" defines every container images used for the driver and its sidecars.
 #  To use your own images, or a private registry, change the values here.
 images:
   # "driver" defines the container image, used for the driver container.
   driver:
-    image: quay.io/dell/container-storage-modules/csi-powermax:v2.17.1
+    image: quay.io/dell/container-storage-modules/csi-powermax:v2.17.2
   csireverseproxy:
     image: quay.io/dell/container-storage-modules/csipowermax-reverseproxy:v2.16.1
   # CSI sidecars

--- a/container-storage-modules/container-storage-modules/Chart.yaml
+++ b/container-storage-modules/container-storage-modules/Chart.yaml
@@ -1,6 +1,6 @@
 #
 #
-# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2023-2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/container-storage-modules/container-storage-modules/Chart.yaml
+++ b/container-storage-modules/container-storage-modules/Chart.yaml
@@ -45,7 +45,7 @@ dependencies:
     condition: csi-powerstore.enabled
 
   - name: csi-powermax
-    version: 2.17.1
+    version: 2.17.2
     repository: https://dell.github.io/helm-charts
     condition: csi-powermax.enabled
 

--- a/container-storage-modules/container-storage-modules/values.yaml
+++ b/container-storage-modules/container-storage-modules/values.yaml
@@ -147,11 +147,11 @@ csi-powermax:
       - endpoint: https://backup-1.unisphe.re:8443
   #    - endpoint: https://primary-2.unisphe.re:8443
   #    - endpoint: https://backup-2.unisphe.re:8443
-  version: "v2.17.1"
+  version: "v2.17.2"
   images:
     # "driver" defines the container image, used for the driver container.
     driver:
-      image: quay.io/dell/container-storage-modules/csi-powermax:v2.17.1
+      image: quay.io/dell/container-storage-modules/csi-powermax:v2.17.2
     csireverseproxy:
       image: quay.io/dell/container-storage-modules/csipowermax-reverseproxy:v2.16.1
     # CSI sidecars

--- a/container-storage-modules/container-storage-modules/values.yaml
+++ b/container-storage-modules/container-storage-modules/values.yaml
@@ -1,6 +1,6 @@
 #
 #
-# Copyright © 2023-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2023-2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
Upgrade the `csi-powermax` Helm chart to v2.17.2 and update the `container-storage-modules` umbrella chart dependency.

- Bump `csi-powermax` chart `version` and `appVersion` to `2.17.2`
- Update `csi-powermax` driver image to `v2.17.2`
- Add `Copyright © 2026` header to `csi-powermax/Chart.yaml` and `values.yaml`
- Update `container-storage-modules` umbrella `csi-powermax` dependency to `2.17.2`
- Update `container-storage-modules` `values.yaml` `csi-powermax` version and image to `v2.17.2`

## Test plan
- [x] `helm lint charts/csi-powermax` passes
- [x] `helm lint container-storage-modules/container-storage-modules` passes
- [x] `ct lint` passes for changed chart

Generated with [Devin](https://devin.ai)