### PR TITLE
Update code to include pmax resilincy support in helm

### DIFF
--- a/charts/csi-powermax/templates/controller.yaml
+++ b/charts/csi-powermax/templates/controller.yaml
@@ -261,11 +261,36 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if and (hasKey .Values.podmon "metrics") .Values.podmon.metrics.enabled }}
+            - name: X_CSI_METRICS_ENABLED
+              value: "true"
+            - name: X_CSI_METRICS_PORT
+              value: "{{ .Values.podmon.metrics.port }}"
+            - name: X_CSI_METRICS_COLLECTION_INTERVAL
+              value: "{{ .Values.podmon.metrics.collection.interval }}"
+            {{- if .Values.podmon.metrics.tlsCertSecret }}
+            - name: X_CSI_METRICS_TLS_CERT_FILE
+              value: /etc/metrics-tls/tls.crt
+            - name: X_CSI_METRICS_TLS_KEY_FILE
+              value: /etc/metrics-tls/tls.key
+            {{- end }}
+            {{- end }}
+          {{- if and (hasKey .Values.podmon "metrics") .Values.podmon.metrics.enabled }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.podmon.metrics.port }}
+              protocol: TCP
+          {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi
             - name: powermax-config-params
               mountPath: /powermax-config-params
+            {{- if and (hasKey .Values.podmon "metrics") .Values.podmon.metrics.enabled .Values.podmon.metrics.tlsCertSecret }}
+            - name: resiliency-metrics-tls
+              mountPath: /etc/metrics-tls
+              readOnly: true
+            {{- end }}
                 {{- end }}
                 {{- end }}
         - name: attacher
@@ -766,6 +791,11 @@ spec:
           secret:
             secretName: {{ .Values.metrics.tlsCertSecret }}
         {{- end }}
+        {{- end }}
+        {{- if and (hasKey .Values "podmon") .Values.podmon.enabled (hasKey .Values.podmon "metrics") .Values.podmon.metrics.enabled .Values.podmon.metrics.tlsCertSecret }}
+        - name: resiliency-metrics-tls
+          secret:
+            secretName: {{ .Values.podmon.metrics.tlsCertSecret }}
         {{- end }}
         {{- if and (eq .Values.global.proxyAuthToken.enabled true) (not .Values.csireverseproxy.deployAsSidecar) }}
         - name: proxy-auth-token

--- a/charts/csi-powermax/templates/metrics-service.yaml
+++ b/charts/csi-powermax/templates/metrics-service.yaml
@@ -19,3 +19,25 @@ spec:
       protocol: TCP
   type: ClusterIP
 {{- end }}
+
+{{- if and (hasKey .Values "podmon") .Values.podmon.enabled (hasKey .Values.podmon "metrics") .Values.podmon.metrics.enabled }}
+---
+# Service exposing the podmon resiliency metrics endpoint for Prometheus scraping.
+# Created when podmon.enabled AND podmon.metrics.enabled are true.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-resiliency-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  selector:
+    name: {{ .Release.Name }}-controller
+  ports:
+    - name: metrics
+      port: {{ .Values.podmon.metrics.port | default 8444 }}
+      targetPort: {{ .Values.podmon.metrics.port | default 8444 }}
+      protocol: TCP
+  type: ClusterIP
+{{- end }}

--- a/charts/csi-powermax/templates/node.yaml
+++ b/charts/csi-powermax/templates/node.yaml
@@ -197,6 +197,26 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if and (hasKey .Values.podmon "metrics") .Values.podmon.metrics.enabled }}
+            - name: X_CSI_METRICS_ENABLED
+              value: "true"
+            - name: X_CSI_METRICS_PORT
+              value: "{{ .Values.podmon.metrics.port }}"
+            - name: X_CSI_METRICS_COLLECTION_INTERVAL
+              value: "{{ .Values.podmon.metrics.collection.interval }}"
+            {{- if .Values.podmon.metrics.tlsCertSecret }}
+            - name: X_CSI_METRICS_TLS_CERT_FILE
+              value: /etc/metrics-tls/tls.crt
+            - name: X_CSI_METRICS_TLS_KEY_FILE
+              value: /etc/metrics-tls/tls.key
+            {{- end }}
+            {{- end }}
+          {{- if and (hasKey .Values.podmon "metrics") .Values.podmon.metrics.enabled }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.podmon.metrics.port }}
+              protocol: TCP
+          {{- end }}
           volumeMounts:
             - name: kubelet-pods
               mountPath: {{ .Values.kubeletConfigDir }}/pods
@@ -215,6 +235,11 @@ spec:
               mountPath: /var/run
             - name: powermax-config-params
               mountPath: /powermax-config-params
+            {{- if and (hasKey .Values.podmon "metrics") .Values.podmon.metrics.enabled .Values.podmon.metrics.tlsCertSecret }}
+            - name: resiliency-metrics-tls
+              mountPath: /etc/metrics-tls
+              readOnly: true
+            {{- end }}
         {{- end }}
         {{- end }}
         - name: driver
@@ -634,6 +659,11 @@ spec:
             secretName: {{ .Values.metrics.tlsCertSecret }}
         {{- end }}
         {{- if and (eq .Values.global.proxyAuthToken.enabled true) (not .Values.csireverseproxy.deployAsSidecar) }}
+        {{- if and (hasKey .Values "podmon") .Values.podmon.enabled (hasKey .Values.podmon "metrics") .Values.podmon.metrics.enabled .Values.podmon.metrics.tlsCertSecret }}
+        - name: resiliency-metrics-tls
+          secret:
+            secretName: {{ .Values.podmon.metrics.tlsCertSecret }}
+        {{- end }}
         - name: proxy-auth-token
           secret:
             secretName: {{ .Values.global.proxyAuthToken.secretName }}

--- a/charts/csi-powermax/templates/podmonitor.yaml
+++ b/charts/csi-powermax/templates/podmonitor.yaml
@@ -28,3 +28,36 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{- if and (hasKey .Values "podmon") .Values.podmon.enabled (hasKey .Values.podmon "metrics") .Values.podmon.metrics.enabled }}
+{{- if hasKey .Values.podmon.metrics "podMonitor" }}
+{{- if .Values.podmon.metrics.podMonitor.enabled }}
+---
+# PodMonitor for Prometheus Operator integration with podmon resiliency metrics on node pods.
+# Created when podmon.enabled AND podmon.metrics.enabled AND podmon.metrics.podMonitor.enabled are true.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Release.Name }}-resiliency-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-node
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-node
+  podMetricsEndpoints:
+    - port: metrics
+      interval: {{ .Values.podmon.metrics.podMonitor.interval | default "30s" }}
+      {{- if .Values.podmon.metrics.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.podmon.metrics.podMonitor.scrapeTimeout }}
+      {{- end }}
+      path: /metrics
+      {{- if .Values.podmon.metrics.tlsCertSecret }}
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: {{ .Values.podmon.metrics.podMonitor.insecureSkipVerify | default false }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/csi-powermax/templates/servicemonitor.yaml
+++ b/charts/csi-powermax/templates/servicemonitor.yaml
@@ -28,3 +28,36 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{- if and (hasKey .Values "podmon") .Values.podmon.enabled (hasKey .Values.podmon "metrics") .Values.podmon.metrics.enabled }}
+{{- if hasKey .Values.podmon.metrics "serviceMonitor" }}
+{{- if .Values.podmon.metrics.serviceMonitor.enabled }}
+---
+# ServiceMonitor for Prometheus Operator integration with podmon resiliency metrics on controller pods.
+# Created when podmon.enabled AND podmon.metrics.enabled AND podmon.metrics.serviceMonitor.enabled are true.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-resiliency-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-controller
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.podmon.metrics.serviceMonitor.interval | default "30s" }}
+      {{- if .Values.podmon.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.podmon.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      path: /metrics
+      {{- if .Values.podmon.metrics.tlsCertSecret }}
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: {{ .Values.podmon.metrics.serviceMonitor.insecureSkipVerify | default false }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/csi-powermax/values.yaml
+++ b/charts/csi-powermax/values.yaml
@@ -613,6 +613,33 @@ podmon:
       - "--driverPodLabelValue=dell-storage"
       - "--ignoreVolumelessPods=false"
 
+  # Metrics configuration for podmon resiliency
+  metrics:
+    # enabled: Set to true to expose the metrics endpoint on the podmon containers.
+    # Default value: false
+    enabled: false
+    # port: Port on which the metrics endpoint is exposed. Default for podmon: 8444.
+    port: 8444
+    # tlsCertSecret: Name of a Kubernetes TLS Secret (tls.crt / tls.key) used to serve metrics over HTTPS.
+    # When set the operator mounts the secret and configures HTTPS automatically.
+    # Leave unset to serve metrics over plain HTTP.
+    tlsCertSecret: ""
+    # collection: Controls metrics collection cadence inside the resiliency module.
+    collection:
+      interval: 30s
+    # serviceMonitor: Creates a Prometheus Operator ServiceMonitor targeting the controller pods.
+    serviceMonitor:
+      enabled: false
+      interval: 30s
+      scrapeTimeout: ""
+      insecureSkipVerify: false
+    # podMonitor: Creates a Prometheus Operator PodMonitor targeting the node pods.
+    podMonitor:
+      enabled: false
+      interval: 30s
+      scrapeTimeout: ""
+      insecureSkipVerify: false
+
 # metrics: configuration for driver metrics and monitoring
 metrics:
   # enabled: Enable/Disable the shared Prometheus metrics HTTP server.


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/dell/helm-charts/docs/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, GitHub actions
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart?

No

#### What this PR does / why we need it:

#### Which issue(s) is this PR associated with:

- #Issue_Number

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
- [x] Validated with metrics enabled:
```
container-storage-modules]# kubectl -n powermax exec -i powermax-controller-76c6c4d4f4-hrdw6 -c podmon -- curl -s http://127.0.0.1:8444/metrics 2>&1 | grep -E 'connectivity_check_total|connectivity_success_ratio|podmon_healthy'
# HELP dell_csm_resiliency_connectivity_check_total Total connectivity checks performed.
# TYPE dell_csm_resiliency_connectivity_check_total counter
dell_csm_resiliency_connectivity_check_total{driver="csi-powermax"} 5
# HELP dell_csm_resiliency_connectivity_success_ratio Connectivity check success ratio.
# TYPE dell_csm_resiliency_connectivity_success_ratio gauge
dell_csm_resiliency_connectivity_success_ratio{driver="csi-powermax"} 0.2
# HELP dell_csm_resiliency_podmon_healthy Podmon health status (1=healthy, 0=unhealthy).
# TYPE dell_csm_resiliency_podmon_healthy gauge
dell_csm_resiliency_podmon_healthy{driver="csi-powermax",namespace="powermax",node="worker-1-yiy5nycbfyvlv.domain",pod="powermax-controller-76c6c4d4f4-hrdw6"} 1
```
<img width="1391" height="204" alt="image" src="https://github.com/user-attachments/assets/3032cbac-8663-4f3b-9e65-012abde58fed" />

