### PR TITLE
Add Replication Metrics for PowerScale

### DIFF
--- a/charts/csi-isilon/templates/controller.yaml
+++ b/charts/csi-isilon/templates/controller.yaml
@@ -282,11 +282,34 @@ spec:
               value: /csi-isilon-config-params
             - name: X_CSI_REPLICATION_CONFIG_FILE_NAME
               value: driver-config-params.yaml
+{{- if and .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled }}
+            - name: X_CSI_REPLICATION_METRICS_ENABLED
+              value: "true"
+            - name: X_CSI_REPLICATION_METRICS_PORT
+              value: "{{ .Values.controller.replication.metrics.port | default 8445 }}"
+            - name: X_CSI_REPLICATION_METRICS_COLLECTION_INTERVAL
+              value: "{{ .Values.controller.replication.metrics.collection.interval | default "30s" }}"
+{{- if .Values.controller.replication.metrics.tlsCertSecret }}
+            - name: X_CSI_REPLICATION_METRICS_TLS_CERT_FILE
+              value: /etc/replication-metrics-tls/tls.crt
+            - name: X_CSI_REPLICATION_METRICS_TLS_KEY_FILE
+              value: /etc/replication-metrics-tls/tls.key
+{{- end }}
+          ports:
+            - name: repl-metrics
+              containerPort: {{ .Values.controller.replication.metrics.port | default 8445 }}
+              protocol: TCP
+{{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi
             - name: csi-isilon-config-params
               mountPath: /csi-isilon-config-params
+{{- if and .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled .Values.controller.replication.metrics.tlsCertSecret }}
+            - name: replication-metrics-tls
+              mountPath: /etc/replication-metrics-tls
+              readOnly: true
+{{- end }}
         {{- end }}
         {{- end }}
         {{- end }}
@@ -664,6 +687,13 @@ spec:
         - name: resiliency-metrics-tls
           secret:
             secretName: {{ .Values.podmon.metrics.tlsCertSecret }}
+        {{- end }}
+        {{- if hasKey .Values.controller "replication" }}
+        {{- if and .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled .Values.controller.replication.metrics.tlsCertSecret }}
+        - name: replication-metrics-tls
+          secret:
+            secretName: {{ .Values.controller.replication.metrics.tlsCertSecret }}
+        {{- end }}
         {{- end }}
         {{- if hasKey .Values "authorization" }}
         {{- if eq .Values.authorization.enabled true }}

--- a/charts/csi-isilon/templates/metrics-service.yaml
+++ b/charts/csi-isilon/templates/metrics-service.yaml
@@ -41,3 +41,27 @@ spec:
       protocol: TCP
   type: ClusterIP
 {{- end }}
+
+{{- if hasKey .Values.controller "replication" }}
+{{- if and .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled }}
+---
+# Service exposing the replication metrics endpoint for Prometheus scraping.
+# Created when controller.replication.enabled AND controller.replication.metrics.enabled are true.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-replication-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  selector:
+    app: {{ .Release.Name }}-controller
+  ports:
+    - name: repl-metrics
+      port: {{ .Values.controller.replication.metrics.port | default 8445 }}
+      targetPort: {{ .Values.controller.replication.metrics.port | default 8445 }}
+      protocol: TCP
+  type: ClusterIP
+{{- end }}
+{{- end }}

--- a/charts/csi-isilon/templates/servicemonitor.yaml
+++ b/charts/csi-isilon/templates/servicemonitor.yaml
@@ -64,3 +64,38 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{- if hasKey .Values.controller "replication" }}
+{{- if and .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled }}
+{{- if hasKey .Values.controller.replication.metrics "serviceMonitor" }}
+{{- if .Values.controller.replication.metrics.serviceMonitor.enabled }}
+---
+# ServiceMonitor for Prometheus Operator integration with replication metrics on controller pods.
+# Created when controller.replication.metrics.enabled AND controller.replication.metrics.serviceMonitor.enabled are true.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-replication-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-controller
+  endpoints:
+    - port: repl-metrics
+      interval: {{ .Values.controller.replication.metrics.serviceMonitor.interval | default "30s" }}
+      {{- if .Values.controller.replication.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.controller.replication.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      path: /metrics
+      {{- if .Values.controller.replication.metrics.tlsCertSecret }}
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: {{ .Values.controller.replication.metrics.serviceMonitor.insecureSkipVerify | default false }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/csi-isilon/values.yaml
+++ b/charts/csi-isilon/values.yaml
@@ -174,6 +174,19 @@ controller:
     # Default value: replication.storage.dell.com
     replicationPrefix: "replication.storage.dell.com"
 
+    # Metrics configuration for replication sidecar
+    metrics:
+      enabled: false
+      port: 8445
+      tlsCertSecret: ""
+      collection:
+        interval: 30s
+      serviceMonitor:
+        enabled: false
+        interval: 30s
+        scrapeTimeout: ""
+        insecureSkipVerify: false
+
   snapshot:
     # enabled: Enable/Disable volume snapshot feature
     # Allowed values:

--- a/charts/csi-powermax/templates/controller.yaml
+++ b/charts/csi-powermax/templates/controller.yaml
@@ -419,11 +419,38 @@ spec:
               value: /powermax-config-params
             - name: X_CSI_REPLICATION_CONFIG_FILE_NAME
               value: driver-config-params.yaml
+            {{- if hasKey .Values.replication "metrics" }}
+            - name: X_CSI_REPLICATION_METRICS_ENABLED
+              value: "{{ .Values.replication.metrics.enabled | default false }}"
+            - name: X_CSI_REPLICATION_METRICS_PORT
+              value: "{{ .Values.replication.metrics.port | default 8445 }}"
+            {{- if .Values.replication.metrics.collection }}
+            - name: X_CSI_REPLICATION_METRICS_COLLECTION_INTERVAL
+              value: "{{ .Values.replication.metrics.collection.interval | default "30s" }}"
+            {{- end }}
+            {{- if .Values.replication.metrics.tlsCertSecret }}
+            - name: X_CSI_REPLICATION_METRICS_TLS_CERT_FILE
+              value: /etc/replication-metrics-tls/tls.crt
+            - name: X_CSI_REPLICATION_METRICS_TLS_KEY_FILE
+              value: /etc/replication-metrics-tls/tls.key
+            {{- end }}
+            {{- end }}
+          {{- if and (hasKey .Values.replication "metrics") (.Values.replication.metrics.enabled) }}
+          ports:
+            - containerPort: {{ .Values.replication.metrics.port | default 8445 }}
+              name: repl-metrics
+              protocol: TCP
+          {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi
             - name: powermax-config-params
               mountPath: /powermax-config-params
+            {{- if and (hasKey .Values.replication "metrics") (.Values.replication.metrics.tlsCertSecret) }}
+            - name: replication-metrics-tls
+              mountPath: /etc/replication-metrics-tls
+              readOnly: true
+            {{- end }}
         {{- end }}
         {{- if eq .Values.migration.enabled true}}
         - name: dell-csi-migrator
@@ -796,6 +823,13 @@ spec:
         - name: resiliency-metrics-tls
           secret:
             secretName: {{ .Values.podmon.metrics.tlsCertSecret }}
+        {{- end }}
+        {{- if and (eq .Values.replication.enabled true) (hasKey .Values.replication "metrics") }}
+        {{- if .Values.replication.metrics.tlsCertSecret }}
+        - name: replication-metrics-tls
+          secret:
+            secretName: {{ .Values.replication.metrics.tlsCertSecret }}
+        {{- end }}
         {{- end }}
         {{- if and (eq .Values.global.proxyAuthToken.enabled true) (not .Values.csireverseproxy.deployAsSidecar) }}
         - name: proxy-auth-token

--- a/charts/csi-powermax/templates/metrics-service.yaml
+++ b/charts/csi-powermax/templates/metrics-service.yaml
@@ -41,3 +41,26 @@ spec:
       protocol: TCP
   type: ClusterIP
 {{- end }}
+{{- if and (eq .Values.replication.enabled true) (hasKey .Values.replication "metrics") }}
+{{- if eq .Values.replication.metrics.enabled true }}
+---
+# Service exposing the replication metrics endpoint for Prometheus scraping.
+# Created when replication.enabled and replication.metrics.enabled are true.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-replication-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  selector:
+    name: {{ .Release.Name }}-controller
+  ports:
+    - name: repl-metrics
+      port: {{ .Values.replication.metrics.port | default 8445 }}
+      targetPort: {{ .Values.replication.metrics.port | default 8445 }}
+      protocol: TCP
+  type: ClusterIP
+{{- end }}
+{{- end }}

--- a/charts/csi-powermax/templates/servicemonitor.yaml
+++ b/charts/csi-powermax/templates/servicemonitor.yaml
@@ -61,3 +61,32 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- if and (eq .Values.replication.enabled true) (hasKey .Values.replication "metrics") }}
+{{- if and (eq .Values.replication.metrics.enabled true) (hasKey .Values.replication.metrics "serviceMonitor") }}
+{{- if eq .Values.replication.metrics.serviceMonitor.enabled true }}
+---
+# ServiceMonitor for replication metrics Prometheus Operator integration.
+# Created when replication.metrics.enabled AND replication.metrics.serviceMonitor.enabled are true.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-replication-metrics-monitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-controller
+  endpoints:
+    - port: repl-metrics
+      interval: {{ .Values.replication.metrics.serviceMonitor.interval | default "30s" }}
+      path: /metrics
+      {{- if .Values.replication.metrics.tlsCertSecret }}
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: {{ .Values.replication.metrics.serviceMonitor.insecureSkipVerify | default false }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/csi-powermax/values.yaml
+++ b/charts/csi-powermax/values.yaml
@@ -514,6 +514,35 @@ replication:
   # Examples: "replication.storage.dell.com", "rdf.storage.dell.com"
   replicationPrefix: "replication.storage.dell.com"
 
+  # Metrics configuration for replication sidecar
+  metrics:
+    # enabled: Enable/Disable replication metrics endpoint on the dell-csi-replicator sidecar
+    # Default value: false
+    enabled: false
+    # port: Port for the replication metrics endpoint
+    # Default value: 8445
+    port: 8445
+    # tlsCertSecret: Name of the TLS secret for replication metrics. Leave empty to disable TLS.
+    # Default value: ""
+    tlsCertSecret: ""
+    collection:
+      # interval: How frequently replication metrics are collected
+      # Default value: "30s"
+      interval: 30s
+    serviceMonitor:
+      # enabled: Enable/Disable ServiceMonitor for Prometheus Operator
+      # Default value: false
+      enabled: false
+      # interval: Scrape interval for the ServiceMonitor
+      # Default value: "30s"
+      interval: 30s
+      # scrapeTimeout: Scrape timeout for the ServiceMonitor
+      # Default value: ""
+      scrapeTimeout: ""
+      # insecureSkipVerify: Skip TLS verification for ServiceMonitor
+      # Default value: false
+      insecureSkipVerify: false
+
 # CSM module attributes
 # Set this to true to enable migration
 # Allowed values:


### PR DESCRIPTION
This PR adds replication metrics support for PowerScale helm-charts


**Key Changes:**

- metrics-service.yaml: Added replication metrics service (port 8445)
- servicemonitor.yaml: Added Prometheus ServiceMonitor for replication metrics
- controller.yaml: Updated controller deployment
- values.yaml: Added replication metrics configuration


#### Is this a new chart?

Yes/No

#### What this PR does / why we need it:

#### Which issue(s) is this PR associated with:

- #Issue_Number

#### Special notes for your reviewer:

#### Checklist:

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] Chart Version bumped
- [ ] Variables are documented in the chart README.md
- [ ] Title of the PR starts with the chart name (e.g. `[charts_dir/mychartname]`) if applicable
