### PR TITLE
consolidate MDM configuration in csi-vxflexos helm chart

### DIFF
--- a/charts/csi-vxflexos/templates/node.yaml
+++ b/charts/csi-vxflexos/templates/node.yaml
@@ -47,6 +47,9 @@ rules:
     resources: ["configmaps"]
     verbs: ["get", "update"]
   - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+  - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
 ---
@@ -425,11 +428,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: MDM
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Release.Name }}-config
-                  key: MDM
             - name: MODE
               value: "monitoring"
           volumeMounts:
@@ -446,11 +444,50 @@ spec:
         {{- end }}
       {{- if or (not (hasKey (.Values.node.sdc) "enabled")) (eq .Values.node.sdc.enabled true) }}
       initContainers:
+        - name: mdm-container
+          image: "{{ required "Must provide the driver image repository." .Values.images.driver.image }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          command: ["/csi-vxflexos.sh"]
+          args:
+            - "--array-config=/vxflexos-config/config"
+            - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"
+          env:
+            - name: X_CSI_MODE
+              value: mdm-info
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: vxflexos-config
+              mountPath: /vxflexos-config
+            - name: vxflexos-config-params
+              mountPath: /vxflexos-config-params
+            - name: mdm-dir
+              mountPath: /data
+{{- if ge (int .Values.certSecretCount) 1 }}
+            - name: certs
+              mountPath: /certs
+              readOnly: true
+{{- end }}
         - name: sdc
           securityContext:
             privileged: true
           image: {{ required "Must provide the PowerFlex SDC container image." .Values.images.powerflexSdc.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          command:
+            - "/bin/sh"
+            - "-c"
+            - |
+              set -e
+              if [ ! -f /data/node_mdms.txt ]; then
+                echo "ERROR: /data/node_mdms.txt not generated" >&2
+                exit 1
+              fi
+              set -a
+              source /data/node_mdms.txt
+              set +a
+              /files/scripts/init.sh
           env:
             {{- if eq .Values.node.sdc.sdcSFTPRepo.enabled true }}
             - name: REPO_ADDRESS
@@ -466,11 +503,6 @@ spec:
                   fieldPath: spec.nodeName
             - name: MODE
               value: "config"
-            - name: MDM
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Release.Name }}-config
-                  key: MDM
             - name: HOST_DRV_CFG_PATH
               value: {{ .Values.node.sdc.sdcHostDrvCfgPath }}
           volumeMounts:
@@ -486,6 +518,8 @@ spec:
               mountPath: /rules.d
             - name: scaleio-path-opt
               mountPath: /host_drv_cfg_path
+            - name: mdm-dir
+              mountPath: /data
             {{- if eq .Values.node.sdc.sdcSFTPRepo.enabled true }}
             - name: sftp-keys
               mountPath: /config/
@@ -565,6 +599,8 @@ spec:
           hostPath:
             path: /var/emc-scaleio
             type: DirectoryOrCreate
+        - name: mdm-dir
+          emptyDir: {}
         - name: udev-d
           hostPath:
             path: /etc/udev/rules.d


### PR DESCRIPTION
Added mdm-container init container to write MDM info from secret to /data/node_mdms.txt, and updated SDC init container to source MDM from this file instead of environment variables. 