### PR TITLE
Add fsGroup chown configuration and fix RBAC template syntax for csi-isilon helm chart

### DIFF
--- a/charts/csi-isilon/templates/controller.yaml
+++ b/charts/csi-isilon/templates/controller.yaml
@@ -22,6 +22,8 @@ rules:
   {{- else }}
     verbs: ["get", "list", "watch"]
   {{- end }}
+  {{- else }}
+    verbs: ["get", "list", "watch"]
   {{- end }}
   - apiGroups: [""]
     resources: ["persistentvolumes"]

--- a/charts/csi-isilon/templates/node.yaml
+++ b/charts/csi-isilon/templates/node.yaml
@@ -278,6 +278,14 @@ spec:
             {{ end }}
             - name: X_CSI_MAX_PATH_LIMIT
               value: "{{ .Values.maxPathLen }}"
+            - name: X_CSI_ISILON_ENABLE_DRIVER_FSGROUP_CHOWN
+              value: "{{ .Values.fsGroupChown.enabled }}"
+            - name: X_CSI_ISILON_CHOWN_WORKERS
+              value: "{{ .Values.fsGroupChown.workers }}"
+            - name: X_CSI_ISILON_CHOWN_WRITEBATCH
+              value: "{{ .Values.fsGroupChown.writeBatch }}"
+            - name: X_CSI_ISILON_CHOWN_TIMEOUT_SECONDS
+              value: "{{ .Values.fsGroupChown.timeoutSeconds }}"
             - name: X_CSI_DRIVER_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/csi-isilon/values.yaml
+++ b/charts/csi-isilon/values.yaml
@@ -580,3 +580,23 @@ metrics:
       threshold: 3
       # resetTimeout: How long the circuit stays open before allowing a retry.
       resetTimeout: "30s"
+
+# fsGroupChown: Configure driver-side recursive fsGroup chown for export-backed volumes.
+# This is only used when fsGroupPolicy is ReadWriteOnceWithFSType and the volume's fsType is set.
+fsGroupChown:
+  # enabled: Enable the driver's parallel recursive chown for export-backed volumes.
+  # When disabled, the driver falls back to a sequential recursive chown within the configured timeout.
+  # Default value: true
+  enabled: true
+
+  # workers: Number of parallel os.Chown workers for recursive fsGroup application.
+  # Default value: 8
+  workers: 8
+
+  # writeBatch: Number of completed file paths to buffer before writing the resumable state file.
+  # Default value: 1000
+  writeBatch: 1000
+
+  # timeoutSeconds: Per-NodeStageVolume/NodePublishVolume timeout for recursive chown in seconds.
+  # Default value: 30
+  timeoutSeconds: 30


### PR DESCRIPTION
## Changes
- **controller.yaml**: Fix RBAC template syntax 
-  **node.yaml**: Add fsGroup chown environment variables (enabled, workers, writeBatch, timeoutSeconds)
- **values.yaml**: Add fsGroupChown configuration section with default values
 