### PR TITLE
Add driver module alerting updates to Helm charts

### DIFF
--- a/charts/csi-isilon/templates/controller.yaml
+++ b/charts/csi-isilon/templates/controller.yaml
@@ -39,6 +39,8 @@ rules:
   {{- else }}
     verbs: ["get", "list", "watch"]
   {{- end }}
+  {{- else }}
+    verbs: ["get", "list", "watch"]
   {{- end }}
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
@@ -54,6 +56,8 @@ rules:
   {{- else }}
     verbs: ["get", "list", "watch", "patch"]
   {{- end }}
+  {{- else }}
+    verbs: ["get", "list", "watch", "patch"]
   {{- end }}
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments/status"]
@@ -284,11 +288,34 @@ spec:
               value: /csi-isilon-config-params
             - name: X_CSI_REPLICATION_CONFIG_FILE_NAME
               value: driver-config-params.yaml
+{{- if and .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled }}
+            - name: X_CSI_REPLICATION_METRICS_ENABLED
+              value: "true"
+            - name: X_CSI_REPLICATION_METRICS_PORT
+              value: "{{ .Values.controller.replication.metrics.port | default 8445 }}"
+            - name: X_CSI_REPLICATION_METRICS_COLLECTION_INTERVAL
+              value: "{{ .Values.controller.replication.metrics.collection.interval | default "30s" }}"
+{{- if .Values.controller.replication.metrics.tlsCertSecret }}
+            - name: X_CSI_REPLICATION_METRICS_TLS_CERT_FILE
+              value: /etc/replication-metrics-tls/tls.crt
+            - name: X_CSI_REPLICATION_METRICS_TLS_KEY_FILE
+              value: /etc/replication-metrics-tls/tls.key
+{{- end }}
+          ports:
+            - name: repl-metrics
+              containerPort: {{ .Values.controller.replication.metrics.port | default 8445 }}
+              protocol: TCP
+{{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi
             - name: csi-isilon-config-params
               mountPath: /csi-isilon-config-params
+{{- if and .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled .Values.controller.replication.metrics.tlsCertSecret }}
+            - name: replication-metrics-tls
+              mountPath: /etc/replication-metrics-tls
+              readOnly: true
+{{- end }}
         {{- end }}
         {{- end }}
         {{- end }}
@@ -503,12 +530,28 @@ spec:
               value: "{{ .Values.isiVolumePathPermissions }}"
             - name: X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS
               value: "{{ .Values.ignoreUnresolvableHosts }}"
+            - name: X_CSI_ISI_NFS_MOUNT_FQDN
+              value: "{{ .Values.nfsMountFQDN }}"
+            - name: X_CSI_ISI_NFS_TRANSPORT_SECURITY
+              value: "{{ .Values.nfsTransportSecurity }}"
+            - name: X_CSI_ISI_TLS_HANDSHAKE_TIMEOUT_SECONDS
+              value: "{{ .Values.tlsHandshakeTimeoutSeconds }}"
             - name: X_CSI_ISI_NO_PROBE_ON_START
               value: "{{ .Values.noProbeOnStart }}"
             - name: X_CSI_PODMON_ENABLED
               value: "{{ .Values.podmon.enabled }}"
             - name: X_CSI_PODMON_API_PORT
               value: "{{ .Values.podmonAPIPort }}"
+            {{- if .Values.podmonAPITokenSecret }}
+            - name: X_CSI_PODMON_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.podmonAPITokenSecret.name }}
+                  key: {{ .Values.podmonAPITokenSecret.key | default "podmon-api-token" }}
+            {{- else if .Values.podmonAPIToken }}
+            - name: X_CSI_PODMON_API_TOKEN
+              value: "{{ .Values.podmonAPIToken }}"
+            {{- end }}
             {{- if eq .Values.podmon.enabled true }}
               {{- range $key, $value := .Values.podmon.controller.args }}
                 {{- if contains "--arrayConnectivityPollRate" $value }}
@@ -666,6 +709,13 @@ spec:
         - name: resiliency-metrics-tls
           secret:
             secretName: {{ .Values.podmon.metrics.tlsCertSecret }}
+        {{- end }}
+        {{- if hasKey .Values.controller "replication" }}
+        {{- if and .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled .Values.controller.replication.metrics.tlsCertSecret }}
+        - name: replication-metrics-tls
+          secret:
+            secretName: {{ .Values.controller.replication.metrics.tlsCertSecret }}
+        {{- end }}
         {{- end }}
         {{- if hasKey .Values "authorization" }}
         {{- if eq .Values.authorization.enabled true }}

--- a/charts/csi-isilon/templates/metrics-service.yaml
+++ b/charts/csi-isilon/templates/metrics-service.yaml
@@ -41,3 +41,27 @@ spec:
       protocol: TCP
   type: ClusterIP
 {{- end }}
+
+{{- if hasKey .Values.controller "replication" }}
+{{- if and .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled }}
+---
+# Service exposing the replication metrics endpoint for Prometheus scraping.
+# Created when controller.replication.enabled AND controller.replication.metrics.enabled are true.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-replication-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  selector:
+    app: {{ .Release.Name }}-controller
+  ports:
+    - name: repl-metrics
+      port: {{ .Values.controller.replication.metrics.port | default 8445 }}
+      targetPort: {{ .Values.controller.replication.metrics.port | default 8445 }}
+      protocol: TCP
+  type: ClusterIP
+{{- end }}
+{{- end }}

--- a/charts/csi-isilon/templates/node.yaml
+++ b/charts/csi-isilon/templates/node.yaml
@@ -242,6 +242,12 @@ spec:
               value: {{ .Values.isiPath }}
             - name: X_CSI_ISI_NO_PROBE_ON_START
               value: "{{ .Values.noProbeOnStart }}"
+            - name: X_CSI_ISI_NFS_MOUNT_FQDN
+              value: "{{ .Values.nfsMountFQDN }}"
+            - name: X_CSI_ISI_NFS_TRANSPORT_SECURITY
+              value: "{{ .Values.nfsTransportSecurity }}"
+            - name: X_CSI_ISI_TLS_HANDSHAKE_TIMEOUT_SECONDS
+              value: "{{ .Values.tlsHandshakeTimeoutSeconds }}"
             - name: X_CSI_ISI_AUTOPROBE
               value: "{{ .Values.autoProbe }}"
             - name: X_CSI_NODE_NAME
@@ -268,6 +274,16 @@ spec:
               value: "{{ .Values.podmon.enabled }}"
             - name: X_CSI_PODMON_API_PORT
               value: "{{ .Values.podmonAPIPort }}"
+            {{- if .Values.podmonAPITokenSecret }}
+            - name: X_CSI_PODMON_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.podmonAPITokenSecret.name }}
+                  key: {{ .Values.podmonAPITokenSecret.key | default "podmon-api-token" }}
+            {{- else if .Values.podmonAPIToken }}
+            - name: X_CSI_PODMON_API_TOKEN
+              value: "{{ .Values.podmonAPIToken }}"
+            {{- end }}
             {{- if eq .Values.podmon.enabled true }}
               {{- range $key, $value := .Values.podmon.node.args }}
                 {{- if contains "--arrayConnectivityPollRate" $value }}
@@ -328,6 +344,9 @@ spec:
               mountPropagation: "Bidirectional"
             - name: dev
               mountPath: /dev
+            - name: usr-sbin-tlshd
+              mountPath: /host/usr/sbin
+              readOnly: true
             - name: certs
               mountPath: /certs
               readOnly: true
@@ -417,6 +436,10 @@ spec:
           hostPath:
             path: /dev
             type: Directory
+        - name: usr-sbin-tlshd
+          hostPath:
+            path: /usr/sbin
+            type: DirectoryOrCreate
         - name: certs
           projected:
             sources:

--- a/charts/csi-isilon/templates/prometheusrule.yaml
+++ b/charts/csi-isilon/templates/prometheusrule.yaml
@@ -1,0 +1,445 @@
+{{- if eq (include "csi-isilon.isMetricsEnabled" .) "true" }}
+{{- if hasKey .Values.metrics "prometheusRule" }}
+{{- if eq .Values.metrics.prometheusRule.enabled true }}
+---
+# PrometheusRule for PowerScale CSI Driver alerting rules.
+# Created when metrics.enabled AND metrics.prometheusRule.enabled are true.
+# Requires the Prometheus Operator CRDs to be installed in the cluster.
+#
+# NOTE: Driver-level alerts (PS-01 to PS-22) are gated by both metrics.enabled and
+# metrics.prometheusRule.enabled. Resiliency alerts (RES-01 to RES-04) are defined
+# separately under the podmon section and are gated independently by podmon.metrics.prometheusRule.enabled.
+# This allows operators to enable driver alerts without resiliency alerts, or vice versa.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-powerscale-alerts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}
+    platform: powerscale
+    component: csi-driver
+spec:
+  groups:
+    # Volume Operation Failure Alerts (PS-01 to PS-08)
+    # Threshold: volumeOperationFailureThreshold (default 3) — failure count in 5m window.
+    # for: 1m meets the 120s BR latency target for operation failure alerts.
+    - name: powerscale-csi-volume-operations
+      interval: 30s
+      rules:
+        # PS-01: CreateVolume failures
+        - alert: PowerScaleCreateVolumeFailure
+          expr: increase(dell_csi_operation_failure_total{operation="CreateVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+          for: 1m
+          labels:
+            severity: warning
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerScale CSI CreateVolume operation failures detected"
+            description: "Cluster {{`{{ $labels.cluster_name }}`}} has {{`{{ printf \"%.0f\" $value }}`}} CreateVolume failures in the last 5 minutes. Error Code: {{`{{ $labels.error_code }}`}}. Threshold: {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }} failures."
+            runbook_url: ""
+
+        # PS-02: DeleteVolume failures
+        - alert: PowerScaleDeleteVolumeFailure
+          expr: increase(dell_csi_operation_failure_total{operation="DeleteVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+          for: 1m
+          labels:
+            severity: warning
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerScale CSI DeleteVolume operation failures detected"
+            description: "Cluster {{`{{ $labels.cluster_name }}`}} has {{`{{ printf \"%.0f\" $value }}`}} DeleteVolume failures in the last 5 minutes. Error Code: {{`{{ $labels.error_code }}`}}. Threshold: {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }} failures."
+            runbook_url: ""
+
+        # PS-03: ControllerPublishVolume failures
+        - alert: PowerScaleControllerPublishFailure
+          expr: increase(dell_csi_operation_failure_total{operation="ControllerPublishVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+          for: 1m
+          labels:
+            severity: warning
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerScale CSI ControllerPublishVolume operation failures detected"
+            description: "Cluster {{`{{ $labels.cluster_name }}`}} has {{`{{ printf \"%.0f\" $value }}`}} ControllerPublishVolume failures in the last 5 minutes. Error Code: {{`{{ $labels.error_code }}`}}. Threshold: {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }} failures."
+            runbook_url: ""
+
+        # PS-04: ControllerUnpublishVolume failures
+        - alert: PowerScaleControllerUnpublishFailure
+          expr: increase(dell_csi_operation_failure_total{operation="ControllerUnpublishVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+          for: 1m
+          labels:
+            severity: warning
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerScale CSI ControllerUnpublishVolume operation failures detected"
+            description: "Cluster {{`{{ $labels.cluster_name }}`}} has {{`{{ printf \"%.0f\" $value }}`}} ControllerUnpublishVolume failures in the last 5 minutes. Error Code: {{`{{ $labels.error_code }}`}}. Threshold: {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }} failures."
+            runbook_url: ""
+
+        # PS-05: NodeStageVolume failures
+        - alert: PowerScaleNodeStageFailure
+          expr: increase(dell_csi_operation_failure_total{operation="NodeStageVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+          for: 1m
+          labels:
+            severity: warning
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerScale CSI NodeStageVolume operation failures detected"
+            description: "Cluster {{`{{ $labels.cluster_name }}`}} has {{`{{ printf \"%.0f\" $value }}`}} NodeStageVolume failures in the last 5 minutes. Error Code: {{`{{ $labels.error_code }}`}}. Threshold: {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }} failures."
+            runbook_url: ""
+
+        # PS-06: NodeUnstageVolume failures
+        - alert: PowerScaleNodeUnstageFailure
+          expr: increase(dell_csi_operation_failure_total{operation="NodeUnstageVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+          for: 1m
+          labels:
+            severity: warning
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerScale CSI NodeUnstageVolume operation failures detected"
+            description: "Cluster {{`{{ $labels.cluster_name }}`}} has {{`{{ printf \"%.0f\" $value }}`}} NodeUnstageVolume failures in the last 5 minutes. Error Code: {{`{{ $labels.error_code }}`}}. Threshold: {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }} failures."
+            runbook_url: ""
+
+        # PS-07: NodePublishVolume failures
+        - alert: PowerScaleNodePublishFailure
+          expr: increase(dell_csi_operation_failure_total{operation="NodePublishVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+          for: 1m
+          labels:
+            severity: warning
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerScale CSI NodePublishVolume operation failures detected"
+            description: "Cluster {{`{{ $labels.cluster_name }}`}} has {{`{{ printf \"%.0f\" $value }}`}} NodePublishVolume failures in the last 5 minutes. Error Code: {{`{{ $labels.error_code }}`}}. Threshold: {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }} failures."
+            runbook_url: ""
+
+        # PS-08: NodeUnpublishVolume failures
+        - alert: PowerScaleNodeUnpublishFailure
+          expr: increase(dell_csi_operation_failure_total{operation="NodeUnpublishVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+          for: 1m
+          labels:
+            severity: warning
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerScale CSI NodeUnpublishVolume operation failures detected"
+            description: "Cluster {{`{{ $labels.cluster_name }}`}} has {{`{{ printf \"%.0f\" $value }}`}} NodeUnpublishVolume failures in the last 5 minutes. Error Code: {{`{{ $labels.error_code }}`}}. Threshold: {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }} failures."
+            runbook_url: ""
+
+    # Driver Health & Resource Alerts (PS-09 to PS-13)
+    - name: powerscale-csi-driver-health
+      interval: 30s
+      rules:
+        # PS-09: Driver unavailable (critical)
+        # Expression explicitly checks controller AND node counts separately; absent() cannot detect
+        # partial failure (e.g. controllers down, nodes still reporting).
+        - alert: PowerScaleDriverUnavailable
+          expr: (count(dell_csi_driver_uptime_seconds{cluster_name=~".+",instance_type="controller"}) or on() vector(0)) == 0 or (count(dell_csi_driver_uptime_seconds{cluster_name=~".+",instance_type="node"}) or on() vector(0)) == 0
+          for: 5m
+          labels:
+            severity: critical
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerScale CSI driver metrics are unavailable"
+            description: "PowerScale CSI driver has zero controller instances or zero node instances reporting metrics for 5 minutes."
+            runbook_url: ""
+
+        # PS-10: Driver crash looping (warning)
+        - alert: PowerScaleDriverCrashLooping
+          expr: changes(dell_csi_driver_restart_total[{{ .Values.metrics.prometheusRule.driverCrashLoopWindow | default "15m" }}]) > {{ .Values.metrics.prometheusRule.driverCrashLoopRestartThreshold | default 3 }}
+          for: 0m
+          labels:
+            severity: warning
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerScale CSI driver is crash looping"
+            description: "PowerScale CSI driver pod {{`{{ $labels.pod }}`}} (instance type: {{`{{ $labels.instance_type }}`}}) has restarted {{`{{ $value }}`}} times in the last {{ .Values.metrics.prometheusRule.driverCrashLoopWindow | default "15m" }}, indicating a crash loop."
+            runbook_url: ""
+
+        # PS-11: Driver high CPU usage (warning)
+        - alert: PowerScaleDriverHighCPU
+          expr: dell_csi_driver_cpu_usage_percent > {{ .Values.metrics.prometheusRule.cpuWarningThreshold | default 80 }}
+          for: 5m
+          labels:
+            severity: warning
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerScale CSI driver high CPU usage"
+            description: "PowerScale CSI driver pod {{`{{ $labels.pod }}`}} on cluster {{`{{ $labels.cluster_name }}`}} has CPU usage of {{`{{ $value }}`}}% (threshold: {{ .Values.metrics.prometheusRule.cpuWarningThreshold | default 80 }}%) for more than 5 minutes."
+            runbook_url: ""
+
+        # PS-12: Driver high memory usage (warning)
+        - alert: PowerScaleDriverHighMemory
+          expr: dell_csi_driver_memory_usage_bytes > {{ .Values.metrics.prometheusRule.memoryWarningThreshold | default 2147483648 }}
+          for: 5m
+          labels:
+            severity: warning
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerScale CSI driver high memory usage"
+            description: "PowerScale CSI driver pod {{`{{ $labels.pod }}`}} on cluster {{`{{ $labels.cluster_name }}`}} has memory usage of {{`{{ $value }}`}} bytes (threshold: {{ .Values.metrics.prometheusRule.memoryWarningThreshold | default 2147483648 }} bytes) for more than 5 minutes."
+            runbook_url: ""
+
+        # PS-13: Metrics stale (warning)
+        - alert: PowerScaleMetricsStale
+          expr: dell_powerscale_metrics_stale == 1
+          for: 5m
+          labels:
+            severity: warning
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerScale metrics collection is stale on cluster {{`{{ $labels.cluster_name }}`}}"
+            description: "PowerScale metrics collection has reported stale data for 5 minutes on cluster {{`{{ $labels.cluster_name }}`}}. The stale flag is set immediately on any collection failure, regardless of whether cached data is available, ensuring the alert fires even when the cache is empty."
+            runbook_url: ""
+
+    # Quota Capacity Alerts (PS-14 to PS-16)
+    - name: powerscale-csi-quota
+      interval: 30s
+      rules:
+        # PS-14: Quota utilization warning
+        - alert: PowerScaleQuotaWarning
+          expr: dell_powerscale_quota_utilization_ratio * 100 > {{ .Values.metrics.prometheusRule.quotaWarningThreshold | default 80 }}
+          for: 5m
+          labels:
+            severity: warning
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+            access_zone: "{{`{{ $labels.access_zone }}`}}"
+          annotations:
+            summary: "Quota warning for volume {{`{{ $labels.volume_id }}`}} in access zone {{`{{ $labels.access_zone }}`}}"
+            description: 'Volume {{`{{ $labels.volume_id }}`}} in access zone {{`{{ $labels.access_zone }}`}} on cluster {{`{{ $labels.cluster_name }}`}} has exceeded the quota threshold at {{`{{ $value | printf "%.1f" }}`}}% utilization (threshold: {{ .Values.metrics.prometheusRule.quotaWarningThreshold | default 80 }}%).'
+            runbook_url: ""
+
+        # PS-15: Quota utilization critical
+        - alert: PowerScaleQuotaCritical
+          expr: dell_powerscale_quota_utilization_ratio * 100 > {{ .Values.metrics.prometheusRule.quotaCriticalThreshold | default 90 }}
+          for: 5m
+          labels:
+            severity: critical
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+            access_zone: "{{`{{ $labels.access_zone }}`}}"
+          annotations:
+            summary: "Quota critical for volume {{`{{ $labels.volume_id }}`}} in access zone {{`{{ $labels.access_zone }}`}}"
+            description: 'Volume {{`{{ $labels.volume_id }}`}} in access zone {{`{{ $labels.access_zone }}`}} on cluster {{`{{ $labels.cluster_name }}`}} has exceeded the quota threshold at {{`{{ $value | printf "%.1f" }}`}}% utilization (threshold: {{ .Values.metrics.prometheusRule.quotaCriticalThreshold | default 90 }}%). Immediate action required.'
+            runbook_url: ""
+
+        # PS-16: Quota hard breach
+        - alert: PowerScaleQuotaHardBreach
+          expr: dell_powerscale_quota_hard_breach_total > 0
+          for: 0m
+          labels:
+            severity: critical
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "Hard quota breach detected on cluster {{`{{ $labels.cluster_name }}`}}"
+            description: '{{`{{ $value | printf "%.0f" }}`}} volume(s) on cluster {{`{{ $labels.cluster_name }}`}} have exceeded their hard quota limit. Check individual volume quota metrics (dell_powerscale_quota_utilization_ratio) to identify affected volumes. Write operations may be blocked.'
+            runbook_url: ""
+
+    # Node Pool Capacity Alerts (PS-17 to PS-18)
+    - name: powerscale-csi-nodepool
+      interval: 30s
+      rules:
+        # PS-17: Node pool utilization warning
+        - alert: PowerScaleNodePoolWarning
+          expr: dell_powerscale_nodepool_utilization_percent > {{ .Values.metrics.prometheusRule.nodepoolWarningThreshold | default 80 }}
+          for: 5m
+          labels:
+            severity: warning
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerScale node pool utilization warning"
+            description: "Node pool {{`{{ $labels.nodepool_name }}`}} on cluster {{`{{ $labels.cluster_name }}`}} is at {{`{{ $value }}`}}% utilization (threshold: {{ .Values.metrics.prometheusRule.nodepoolWarningThreshold | default 80 }}%)."
+            runbook_url: ""
+
+        # PS-18: Node pool utilization critical
+        - alert: PowerScaleNodePoolCritical
+          expr: dell_powerscale_nodepool_utilization_percent > {{ .Values.metrics.prometheusRule.nodepoolCriticalThreshold | default 90 }}
+          for: 5m
+          labels:
+            severity: critical
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerScale node pool utilization critical"
+            description: "Node pool {{`{{ $labels.nodepool_name }}`}} on cluster {{`{{ $labels.cluster_name }}`}} is at {{`{{ $value }}`}}% utilization (threshold: {{ .Values.metrics.prometheusRule.nodepoolCriticalThreshold | default 90 }}%). Immediate action required."
+            runbook_url: ""
+
+    # Access Control & Auth Alerts (PS-19 to PS-20)
+    - name: powerscale-csi-access-control
+      interval: 30s
+      rules:
+        # PS-19: NFS authentication failure rate
+        - alert: PowerScaleNFSAuthFailureRate
+          expr: rate(dell_powerscale_nfs_mount_auth_failures_total[5m]) > 0
+          for: 5m
+          labels:
+            severity: warning
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerScale NFS authentication failures detected"
+            description: "NFS mount authentication failures detected on cluster {{`{{ $labels.cluster_name }}`}} at a rate of {{`{{ $value }}`}} failures/second over the last 5 minutes."
+            runbook_url: ""
+
+        # PS-20: API error rate
+        - alert: PowerScaleAPIErrorRate
+          expr: (rate(dell_powerscale_api_calls_total{status="failure"}[{{ .Values.metrics.prometheusRule.apiErrorRateWindow | default "5m" }}]) / ignoring(status) sum without(status) (rate(dell_powerscale_api_calls_total[{{ .Values.metrics.prometheusRule.apiErrorRateWindow | default "5m" }}]))) * 100 > {{ .Values.metrics.prometheusRule.apiErrorRateThreshold | default 10 }}
+          for: 5m
+          labels:
+            severity: warning
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerScale API error rate elevated"
+            description: "PowerScale API error rate on cluster {{`{{ $labels.cluster_name }}`}} is {{`{{ $value }}`}}% over the last {{ .Values.metrics.prometheusRule.apiErrorRateWindow | default "5m" }} (threshold: {{ .Values.metrics.prometheusRule.apiErrorRateThreshold | default 10 }}%)."
+            runbook_url: ""
+
+    # NFS Performance Alerts (PS-21 to PS-22)
+    - name: powerscale-csi-nfs-performance
+      interval: 30s
+      rules:
+        # PS-21: NFSv3 high latency
+        - alert: PowerScaleNFSv3HighLatency
+          expr: histogram_quantile(0.99, rate(dell_powerscale_nfs_v3_latency_seconds_bucket[5m])) > {{ .Values.metrics.prometheusRule.nfsV3LatencyWarningSeconds | default 10 }}
+          for: 5m
+          labels:
+            severity: warning
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerScale NFSv3 high latency detected"
+            description: "NFSv3 P99 latency on cluster {{`{{ $labels.cluster_name }}`}} is {{`{{ $value | humanizeDuration }}`}} (threshold: {{ .Values.metrics.prometheusRule.nfsV3LatencyWarningSeconds | default 10 }}s). Note: latency is bucket-approximated from the OneFS optime API; minimum resolution is 100ms."
+            runbook_url: ""
+
+        # PS-22: NFSv4 high latency
+        - alert: PowerScaleNFSv4HighLatency
+          expr: histogram_quantile(0.99, rate(dell_powerscale_nfs_v4_latency_seconds_bucket[5m])) > {{ .Values.metrics.prometheusRule.nfsV4LatencyWarningSeconds | default 10 }}
+          for: 5m
+          labels:
+            severity: warning
+            platform: powerscale
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerScale NFSv4 high latency detected"
+            description: "NFSv4 P99 latency on cluster {{`{{ $labels.cluster_name }}`}} is {{`{{ $value | humanizeDuration }}`}} (threshold: {{ .Values.metrics.prometheusRule.nfsV4LatencyWarningSeconds | default 10 }}s). Note: latency is bucket-approximated from the OneFS optime API; minimum resolution is 100ms."
+            runbook_url: ""
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- if and .Values.podmon .Values.podmon.enabled (hasKey .Values.podmon "metrics") .Values.podmon.metrics.enabled (hasKey .Values.podmon.metrics "prometheusRule") .Values.podmon.metrics.prometheusRule.enabled }}
+---
+# PrometheusRule for CSM Resiliency (podmon) alerting rules.
+# Created when podmon.enabled AND podmon.metrics.prometheusRule.enabled are true.
+# Requires the Prometheus Operator CRDs to be installed in the cluster.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-resiliency-alerts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  groups:
+    - name: csm-resiliency-powerscale
+      interval: 30s
+      rules:
+        # RES-01 — Pod failure detected due to node unreachable
+        - alert: CSMResiliencyPodFailureDetected
+          expr: increase(dell_csm_resiliency_failover_total{reason="node_unreachable",driver="csi-powerscale"}[5m]) > 0
+          for: 0m
+          labels:
+            severity: warning
+            component: csm-resiliency
+            platform: powerscale
+            driver: csi-powerscale
+            alert_id: RES-01
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Resiliency pod failure detected for driver {{`{{ $labels.driver }}`}}"
+            description: "Pod failure detected due to node unreachable for driver {{`{{ $labels.driver }}`}}."
+            runbook_url: ""
+
+        # RES-02 — Connectivity success ratio below threshold
+        - alert: CSMResiliencyConnectivityLost
+          expr: dell_csm_resiliency_connectivity_success_ratio{driver="csi-powerscale"} * 100 < {{ .Values.podmon.metrics.prometheusRule.connectivitySuccessRatio | default 90 }}
+          for: 2m
+          labels:
+            severity: critical
+            component: csm-resiliency
+            platform: powerscale
+            driver: csi-powerscale
+            alert_id: RES-02
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Resiliency connectivity lost for driver {{`{{ $labels.driver }}`}}"
+            description: "Volume connectivity success ratio for driver {{`{{ $labels.driver }}`}} is below {{ .Values.podmon.metrics.prometheusRule.connectivitySuccessRatio | default 90 }}%."
+            runbook_url: ""
+
+        # RES-03 — Automated failover triggered successfully (info: expected behavior)
+        - alert: CSMResiliencyFailoverTriggered
+          expr: increase(dell_csm_resiliency_failover_total{status="success",driver="csi-powerscale"}[5m]) > 0
+          for: 0m
+          labels:
+            severity: info
+            component: csm-resiliency
+            platform: powerscale
+            driver: csi-powerscale
+            alert_id: RES-03
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Resiliency automated failover triggered for driver {{`{{ $labels.driver }}`}}"
+            description: "Automated pod failover operation initiated successfully for driver {{`{{ $labels.driver }}`}}. Reason: {{`{{ $labels.reason }}`}}."
+            runbook_url: ""
+
+        # RES-04 — Automated failover failed
+        - alert: CSMResiliencyFailoverFailed
+          expr: increase(dell_csm_resiliency_failover_total{status="failure",driver="csi-powerscale"}[5m]) > 0
+          for: 0m
+          labels:
+            severity: critical
+            component: csm-resiliency
+            platform: powerscale
+            driver: csi-powerscale
+            alert_id: RES-04
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Resiliency failover failed for driver {{`{{ $labels.driver }}`}}"
+            description: "Automated pod failover operation failed for driver {{`{{ $labels.driver }}`}}. Reason: {{`{{ $labels.reason }}`}}. Manual intervention may be required."
+            runbook_url: ""
+{{- end }}

--- a/charts/csi-isilon/templates/servicemonitor.yaml
+++ b/charts/csi-isilon/templates/servicemonitor.yaml
@@ -64,3 +64,38 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{- if hasKey .Values.controller "replication" }}
+{{- if and .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled }}
+{{- if hasKey .Values.controller.replication.metrics "serviceMonitor" }}
+{{- if .Values.controller.replication.metrics.serviceMonitor.enabled }}
+---
+# ServiceMonitor for Prometheus Operator integration with replication metrics on controller pods.
+# Created when controller.replication.metrics.enabled AND controller.replication.metrics.serviceMonitor.enabled are true.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-replication-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-controller
+  endpoints:
+    - port: repl-metrics
+      interval: {{ .Values.controller.replication.metrics.serviceMonitor.interval | default "30s" }}
+      {{- if .Values.controller.replication.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.controller.replication.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      path: /metrics
+      {{- if .Values.controller.replication.metrics.tlsCertSecret }}
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: {{ .Values.controller.replication.metrics.serviceMonitor.insecureSkipVerify | default false }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/csi-isilon/tests/alert-rules.yaml
+++ b/charts/csi-isilon/tests/alert-rules.yaml
@@ -1,0 +1,297 @@
+# Copyright (C) 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+groups:
+  - interval: 30s
+    name: powerscale-csi-volume-operations
+    rules:
+      - alert: PowerScaleCreateVolumeFailure
+        annotations:
+          description: 'Cluster {{ $labels.cluster_name }} has {{ printf "%.0f" $value }} CreateVolume failures in the last 5 minutes. Error Code: {{ $labels.error_code }}. Threshold: 3 failures.'
+          runbook_url: ''
+          summary: PowerScale CSI CreateVolume operation failures detected
+        expr: increase(dell_csi_operation_failure_total{operation="CreateVolume"}[5m]) > 3
+        for: 1m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: warning
+      - alert: PowerScaleDeleteVolumeFailure
+        annotations:
+          description: 'Cluster {{ $labels.cluster_name }} has {{ printf "%.0f" $value }} DeleteVolume failures in the last 5 minutes. Error Code: {{ $labels.error_code }}. Threshold: 3 failures.'
+          runbook_url: ''
+          summary: PowerScale CSI DeleteVolume operation failures detected
+        expr: increase(dell_csi_operation_failure_total{operation="DeleteVolume"}[5m]) > 3
+        for: 1m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: warning
+      - alert: PowerScaleControllerPublishFailure
+        annotations:
+          description: 'Cluster {{ $labels.cluster_name }} has {{ printf "%.0f" $value }} ControllerPublishVolume failures in the last 5 minutes. Error Code: {{ $labels.error_code }}. Threshold: 3 failures.'
+          runbook_url: ''
+          summary: PowerScale CSI ControllerPublishVolume operation failures detected
+        expr: increase(dell_csi_operation_failure_total{operation="ControllerPublishVolume"}[5m]) > 3
+        for: 1m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: warning
+      - alert: PowerScaleControllerUnpublishFailure
+        annotations:
+          description: 'Cluster {{ $labels.cluster_name }} has {{ printf "%.0f" $value }} ControllerUnpublishVolume failures in the last 5 minutes. Error Code: {{ $labels.error_code }}. Threshold: 3 failures.'
+          runbook_url: ''
+          summary: PowerScale CSI ControllerUnpublishVolume operation failures detected
+        expr: increase(dell_csi_operation_failure_total{operation="ControllerUnpublishVolume"}[5m]) > 3
+        for: 1m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: warning
+      - alert: PowerScaleNodeStageFailure
+        annotations:
+          description: 'Cluster {{ $labels.cluster_name }} has {{ printf "%.0f" $value }} NodeStageVolume failures in the last 5 minutes. Error Code: {{ $labels.error_code }}. Threshold: 3 failures.'
+          runbook_url: ''
+          summary: PowerScale CSI NodeStageVolume operation failures detected
+        expr: increase(dell_csi_operation_failure_total{operation="NodeStageVolume"}[5m]) > 3
+        for: 1m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: warning
+      - alert: PowerScaleNodeUnstageFailure
+        annotations:
+          description: 'Cluster {{ $labels.cluster_name }} has {{ printf "%.0f" $value }} NodeUnstageVolume failures in the last 5 minutes. Error Code: {{ $labels.error_code }}. Threshold: 3 failures.'
+          runbook_url: ''
+          summary: PowerScale CSI NodeUnstageVolume operation failures detected
+        expr: increase(dell_csi_operation_failure_total{operation="NodeUnstageVolume"}[5m]) > 3
+        for: 1m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: warning
+      - alert: PowerScaleNodePublishFailure
+        annotations:
+          description: 'Cluster {{ $labels.cluster_name }} has {{ printf "%.0f" $value }} NodePublishVolume failures in the last 5 minutes. Error Code: {{ $labels.error_code }}. Threshold: 3 failures.'
+          runbook_url: ''
+          summary: PowerScale CSI NodePublishVolume operation failures detected
+        expr: increase(dell_csi_operation_failure_total{operation="NodePublishVolume"}[5m]) > 3
+        for: 1m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: warning
+      - alert: PowerScaleNodeUnpublishFailure
+        annotations:
+          description: 'Cluster {{ $labels.cluster_name }} has {{ printf "%.0f" $value }} NodeUnpublishVolume failures in the last 5 minutes. Error Code: {{ $labels.error_code }}. Threshold: 3 failures.'
+          runbook_url: ''
+          summary: PowerScale CSI NodeUnpublishVolume operation failures detected
+        expr: increase(dell_csi_operation_failure_total{operation="NodeUnpublishVolume"}[5m]) > 3
+        for: 1m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: warning
+  - interval: 30s
+    name: powerscale-csi-driver-health
+    rules:
+      - alert: PowerScaleDriverUnavailable
+        annotations:
+          description: PowerScale CSI driver has zero controller instances or zero node instances reporting metrics for 5 minutes.
+          runbook_url: ''
+          summary: PowerScale CSI driver metrics are unavailable
+        expr: (count(dell_csi_driver_uptime_seconds{cluster_name=~".+",instance_type="controller"}) or on() vector(0)) == 0 or (count(dell_csi_driver_uptime_seconds{cluster_name=~".+",instance_type="node"}) or on() vector(0)) == 0
+        for: 5m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: critical
+      - alert: PowerScaleDriverCrashLooping
+        annotations:
+          description: 'PowerScale CSI driver pod {{ $labels.pod }} (instance type: {{ $labels.instance_type }}) has restarted {{ $value }} times in the last 15m, indicating a crash loop.'
+          runbook_url: ''
+          summary: PowerScale CSI driver is crash looping
+        expr: changes(dell_csi_driver_restart_total[15m]) > 3
+        for: 0m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: warning
+      - alert: PowerScaleDriverHighCPU
+        annotations:
+          description: 'PowerScale CSI driver pod {{ $labels.pod }} on cluster {{ $labels.cluster_name }} has CPU usage of {{ $value }}% (threshold: 80%) for more than 5 minutes.'
+          runbook_url: ''
+          summary: PowerScale CSI driver high CPU usage
+        expr: dell_csi_driver_cpu_usage_percent > 80
+        for: 5m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: warning
+      - alert: PowerScaleDriverHighMemory
+        annotations:
+          description: 'PowerScale CSI driver pod {{ $labels.pod }} on cluster {{ $labels.cluster_name }} has memory usage of {{ $value }} bytes (threshold: 2.147483648e+09 bytes) for more than 5 minutes.'
+          runbook_url: ''
+          summary: PowerScale CSI driver high memory usage
+        expr: dell_csi_driver_memory_usage_bytes > 2.147483648e+09
+        for: 5m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: warning
+      - alert: PowerScaleMetricsStale
+        annotations:
+          description: PowerScale metrics collection has reported stale data for 5 minutes on cluster {{ $labels.cluster_name }}. The stale flag is set immediately on any collection failure, regardless of whether cached data is available, ensuring the alert fires even when the cache is empty.
+          runbook_url: ''
+          summary: PowerScale metrics collection is stale on cluster {{ $labels.cluster_name }}
+        expr: dell_powerscale_metrics_stale == 1
+        for: 5m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: warning
+  - interval: 30s
+    name: powerscale-csi-quota
+    rules:
+      - alert: PowerScaleQuotaWarning
+        annotations:
+          description: 'Volume {{ $labels.volume_id }} in access zone {{ $labels.access_zone }} on cluster {{ $labels.cluster_name }} has exceeded the quota threshold at {{ $value | printf "%.1f" }}% utilization (threshold: 80%).'
+          runbook_url: ''
+          summary: Quota warning for volume {{ $labels.volume_id }} in access zone {{ $labels.access_zone }}
+        expr: dell_powerscale_quota_utilization_ratio * 100 > 80
+        for: 5m
+        labels:
+          access_zone: '{{ $labels.access_zone }}'
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: warning
+      - alert: PowerScaleQuotaCritical
+        annotations:
+          description: 'Volume {{ $labels.volume_id }} in access zone {{ $labels.access_zone }} on cluster {{ $labels.cluster_name }} has exceeded the quota threshold at {{ $value | printf "%.1f" }}% utilization (threshold: 90%). Immediate action required.'
+          runbook_url: ''
+          summary: Quota critical for volume {{ $labels.volume_id }} in access zone {{ $labels.access_zone }}
+        expr: dell_powerscale_quota_utilization_ratio * 100 > 90
+        for: 5m
+        labels:
+          access_zone: '{{ $labels.access_zone }}'
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: critical
+      - alert: PowerScaleQuotaHardBreach
+        annotations:
+          description: '{{ $value | printf "%.0f" }} volume(s) on cluster {{ $labels.cluster_name }} have exceeded their hard quota limit. Check individual volume quota metrics (dell_powerscale_quota_utilization_ratio) to identify affected volumes. Write operations may be blocked.'
+          runbook_url: ''
+          summary: Hard quota breach detected on cluster {{ $labels.cluster_name }}
+        expr: dell_powerscale_quota_hard_breach_total > 0
+        for: 0m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: critical
+  - interval: 30s
+    name: powerscale-csi-nodepool
+    rules:
+      - alert: PowerScaleNodePoolWarning
+        annotations:
+          description: 'Node pool {{ $labels.nodepool_name }} on cluster {{ $labels.cluster_name }} is at {{ $value }}% utilization (threshold: 80%).'
+          runbook_url: ''
+          summary: PowerScale node pool utilization warning
+        expr: dell_powerscale_nodepool_utilization_percent > 80
+        for: 5m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: warning
+      - alert: PowerScaleNodePoolCritical
+        annotations:
+          description: 'Node pool {{ $labels.nodepool_name }} on cluster {{ $labels.cluster_name }} is at {{ $value }}% utilization (threshold: 90%). Immediate action required.'
+          runbook_url: ''
+          summary: PowerScale node pool utilization critical
+        expr: dell_powerscale_nodepool_utilization_percent > 90
+        for: 5m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: critical
+  - interval: 30s
+    name: powerscale-csi-access-control
+    rules:
+      - alert: PowerScaleNFSAuthFailureRate
+        annotations:
+          description: NFS mount authentication failures detected on cluster {{ $labels.cluster_name }} at a rate of {{ $value }} failures/second over the last 5 minutes.
+          runbook_url: ''
+          summary: PowerScale NFS authentication failures detected
+        expr: rate(dell_powerscale_nfs_mount_auth_failures_total[5m]) > 0
+        for: 5m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: warning
+      - alert: PowerScaleAPIErrorRate
+        annotations:
+          description: 'PowerScale API error rate on cluster {{ $labels.cluster_name }} is {{ $value }}% over the last 5m (threshold: 10%).'
+          runbook_url: ''
+          summary: PowerScale API error rate elevated
+        expr: (rate(dell_powerscale_api_calls_total{status="failure"}[5m]) / ignoring(status) sum without(status) (rate(dell_powerscale_api_calls_total[5m]))) * 100 > 10
+        for: 5m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: warning
+  - interval: 30s
+    name: powerscale-csi-nfs-performance
+    rules:
+      - alert: PowerScaleNFSv3HighLatency
+        annotations:
+          description: 'NFSv3 P99 latency on cluster {{ $labels.cluster_name }} is {{ $value | humanizeDuration }} (threshold: 10s). Note: latency is bucket-approximated from the OneFS optime API; minimum resolution is 100ms.'
+          runbook_url: ''
+          summary: PowerScale NFSv3 high latency detected
+        expr: histogram_quantile(0.99, rate(dell_powerscale_nfs_v3_latency_seconds_bucket[5m])) > 10
+        for: 5m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: warning
+      - alert: PowerScaleNFSv4HighLatency
+        annotations:
+          description: 'NFSv4 P99 latency on cluster {{ $labels.cluster_name }} is {{ $value | humanizeDuration }} (threshold: 10s). Note: latency is bucket-approximated from the OneFS optime API; minimum resolution is 100ms.'
+          runbook_url: ''
+          summary: PowerScale NFSv4 high latency detected
+        expr: histogram_quantile(0.99, rate(dell_powerscale_nfs_v4_latency_seconds_bucket[5m])) > 10
+        for: 5m
+        labels:
+          component: csi-driver
+          namespace: test
+          platform: powerscale
+          severity: warning

--- a/charts/csi-isilon/tests/powerscale-alert-rules-test.yaml
+++ b/charts/csi-isilon/tests/powerscale-alert-rules-test.yaml
@@ -1,0 +1,919 @@
+# Copyright © 2022-2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# PowerScale CSI Driver Alert Rules — promtool Unit Test Suite
+#
+# Run with: promtool test rules powerscale-alert-rules-test.yaml
+# Requires: prometheus/prometheus container image, or a local promtool binary.
+#
+# This file validates all 22 PowerScale alert rules across 6 categories with
+# 49 scenarios: fire conditions, no-fire (boundary), and alert recovery.
+# All scenarios run fully offline — no live Prometheus or OneFS required.
+#
+# Timing convention:
+#   - interval: 1m  → one sample per minute.
+#   - For alerts with for: 0m: evaluate at the moment the condition is true.
+#   - For alerts with for: 1m (volume ops PS-01..PS-08): condition must be true for
+#     1 minute; provide data starting at t=0 and evaluate at t=6m to ensure the
+#     for:1m clause is satisfied after increase() stabilises over the 5m window.
+#   - For alerts with for: 5m: provide data from t=0 and evaluate at t=5m or later.
+#   - For rate/increase/histogram_quantile (require ≥2 samples): evaluate at t=10m
+#     to ensure the for: 5m clause is satisfied after the rate stabilises at t=1m.
+#
+# Label matching note (promtool strict mode):
+#   exp_labels must include ALL labels on the fired alert: static rule labels
+#   (severity, platform, component) plus any labels propagated from input series
+#   (cluster_name, operation, pod, instance_type, volume_id, access_zone, etc.).
+#   exp_annotations must match the fully evaluated annotation strings.
+
+rule_files:
+  - alert-rules.yaml
+
+evaluation_interval: 1m
+
+tests:
+
+  # ==========================================================================
+  # Category 1 — Volume Operation Failures (PS-01 to PS-08) — 11 scenarios
+  # Expression: increase(dell_csi_operation_failure_total{operation=X}[5m]) > 3
+  # for: 1m  →  fires after the condition has been true for 1 minute.
+  # Timing convention: counter jumps by 4 (above threshold of 3) at t=0, so
+  # increase() > 3 is true immediately; for:1m is satisfied at eval_time=1m.
+  # A counter jump of exactly 3 stays at boundary (not > 3) and must not fire.
+  # ==========================================================================
+
+  - name: "PS-01 CreateVolume: 4 failures in 5m → PowerScaleCreateVolumeFailure fires (warning)"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{operation="CreateVolume",cluster_name="c1"}'
+        values: '0 4 4 4 4 4 4'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: PowerScaleCreateVolumeFailure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              cluster_name: c1
+              operation: CreateVolume
+            exp_annotations:
+              summary: "PowerScale CSI CreateVolume operation failures detected"
+              description: "Cluster c1 has 4 CreateVolume failures in the last 5 minutes. Error Code: . Threshold: 3 failures."
+              runbook_url: ""
+
+  - name: "PS-01 CreateVolume: exactly 3 failures (boundary, not > 3) → no alert"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{operation="CreateVolume",cluster_name="c1"}'
+        values: '0 3 3 3 3 3 3'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: PowerScaleCreateVolumeFailure
+        exp_alerts: []
+
+  - name: "PS-02 DeleteVolume: 4 failures in 5m → PowerScaleDeleteVolumeFailure fires (warning)"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{operation="DeleteVolume",cluster_name="c1"}'
+        values: '0 4 4 4 4 4 4'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: PowerScaleDeleteVolumeFailure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              cluster_name: c1
+              operation: DeleteVolume
+            exp_annotations:
+              summary: "PowerScale CSI DeleteVolume operation failures detected"
+              description: "Cluster c1 has 4 DeleteVolume failures in the last 5 minutes. Error Code: . Threshold: 3 failures."
+              runbook_url: ""
+
+  - name: "PS-03 ControllerPublishVolume: 4 failures → PowerScaleControllerPublishFailure fires"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{operation="ControllerPublishVolume",cluster_name="c1"}'
+        values: '0 4 4 4 4 4 4'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: PowerScaleControllerPublishFailure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              cluster_name: c1
+              operation: ControllerPublishVolume
+            exp_annotations:
+              summary: "PowerScale CSI ControllerPublishVolume operation failures detected"
+              description: "Cluster c1 has 4 ControllerPublishVolume failures in the last 5 minutes. Error Code: . Threshold: 3 failures."
+              runbook_url: ""
+
+  - name: "PS-04 ControllerUnpublishVolume: 4 failures → PowerScaleControllerUnpublishFailure fires"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{operation="ControllerUnpublishVolume",cluster_name="c1"}'
+        values: '0 4 4 4 4 4 4'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: PowerScaleControllerUnpublishFailure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              cluster_name: c1
+              operation: ControllerUnpublishVolume
+            exp_annotations:
+              summary: "PowerScale CSI ControllerUnpublishVolume operation failures detected"
+              description: "Cluster c1 has 4 ControllerUnpublishVolume failures in the last 5 minutes. Error Code: . Threshold: 3 failures."
+              runbook_url: ""
+
+  - name: "PS-05 NodeStageVolume: 4 failures → PowerScaleNodeStageFailure fires"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{operation="NodeStageVolume",cluster_name="c1"}'
+        values: '0 4 4 4 4 4 4'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: PowerScaleNodeStageFailure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              cluster_name: c1
+              operation: NodeStageVolume
+            exp_annotations:
+              summary: "PowerScale CSI NodeStageVolume operation failures detected"
+              description: "Cluster c1 has 4 NodeStageVolume failures in the last 5 minutes. Error Code: . Threshold: 3 failures."
+              runbook_url: ""
+
+  - name: "PS-06 NodeUnstageVolume: 4 failures → PowerScaleNodeUnstageFailure fires"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{operation="NodeUnstageVolume",cluster_name="c1"}'
+        values: '0 4 4 4 4 4 4'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: PowerScaleNodeUnstageFailure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              cluster_name: c1
+              operation: NodeUnstageVolume
+            exp_annotations:
+              summary: "PowerScale CSI NodeUnstageVolume operation failures detected"
+              description: "Cluster c1 has 4 NodeUnstageVolume failures in the last 5 minutes. Error Code: . Threshold: 3 failures."
+              runbook_url: ""
+
+  - name: "PS-07 NodePublishVolume: 4 failures → PowerScaleNodePublishFailure fires"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{operation="NodePublishVolume",cluster_name="c1"}'
+        values: '0 4 4 4 4 4 4'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: PowerScaleNodePublishFailure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              cluster_name: c1
+              operation: NodePublishVolume
+            exp_annotations:
+              summary: "PowerScale CSI NodePublishVolume operation failures detected"
+              description: "Cluster c1 has 4 NodePublishVolume failures in the last 5 minutes. Error Code: . Threshold: 3 failures."
+              runbook_url: ""
+
+  - name: "PS-08 NodeUnpublishVolume: 4 failures → PowerScaleNodeUnpublishFailure fires"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{operation="NodeUnpublishVolume",cluster_name="c1"}'
+        values: '0 4 4 4 4 4 4'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: PowerScaleNodeUnpublishFailure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              cluster_name: c1
+              operation: NodeUnpublishVolume
+            exp_annotations:
+              summary: "PowerScale CSI NodeUnpublishVolume operation failures detected"
+              description: "Cluster c1 has 4 NodeUnpublishVolume failures in the last 5 minutes. Error Code: . Threshold: 3 failures."
+              runbook_url: ""
+
+  - name: "PS-08 NodeUnpublishVolume: 0 failures → no alert"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{operation="NodeUnpublishVolume",cluster_name="c1"}'
+        values: '0 0 0 0 0 0 0'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: PowerScaleNodeUnpublishFailure
+        exp_alerts: []
+
+  # ==========================================================================
+  # Category 2 — Driver Health (PS-09 to PS-13) — 13 scenarios
+  # ==========================================================================
+
+  # PS-09: PowerScaleDriverUnavailable
+  # Expression: (count(uptime{...,"controller"}) or on() vector(0)) == 0
+  #          OR (count(uptime{...,"node"}) or on() vector(0)) == 0
+  # for: 5m
+  # When a role's series is absent, count() returns empty → "empty or on() vector(0)"
+  # evaluates to vector(0); 0 == 0 is true → alert fires after 5m.
+
+  - name: "PS-09 No controller uptime series → PowerScaleDriverUnavailable fires (critical)"
+    interval: 1m
+    input_series:
+      # Only node series present; controller count evaluates to 0 → alert fires.
+      - series: 'dell_csi_driver_uptime_seconds{cluster_name="c1",instance_type="node"}'
+        values: '0 10 20 30 40 50 60'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleDriverUnavailable
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+            exp_annotations:
+              summary: "PowerScale CSI driver metrics are unavailable"
+              description: "PowerScale CSI driver has zero controller instances or zero node instances reporting metrics for 5 minutes."
+              runbook_url: ""
+
+  - name: "PS-09 No node uptime series → PowerScaleDriverUnavailable fires (critical)"
+    interval: 1m
+    input_series:
+      # Only controller series present; node count evaluates to 0 → alert fires.
+      - series: 'dell_csi_driver_uptime_seconds{cluster_name="c1",instance_type="controller"}'
+        values: '0 10 20 30 40 50 60'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleDriverUnavailable
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+            exp_annotations:
+              summary: "PowerScale CSI driver metrics are unavailable"
+              description: "PowerScale CSI driver has zero controller instances or zero node instances reporting metrics for 5 minutes."
+              runbook_url: ""
+
+  - name: "PS-09 Both controller and node uptime series present → no alert"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_driver_uptime_seconds{cluster_name="c1",instance_type="controller"}'
+        values: '0 10 20 30 40 50 60 70 80 90 100'
+      - series: 'dell_csi_driver_uptime_seconds{cluster_name="c1",instance_type="node"}'
+        values: '0 10 20 30 40 50 60 70 80 90 100'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PowerScaleDriverUnavailable
+        exp_alerts: []
+
+  # PS-10: PowerScaleDriverCrashLooping
+  # Expression: changes(dell_csi_driver_restart_total[15m]) > 3, for: 0m
+  # changes() counts the number of distinct value transitions in the window.
+  # Tip: values '0 0 0 1 2 3 4 4 ...' produce 4 changes → 4 > 3 → fires.
+
+  - name: "PS-10 4 restarts in 15m → PowerScaleDriverCrashLooping fires (warning)"
+    interval: 1m
+    input_series:
+      # Counter changes 4 times (0→1, 1→2, 2→3, 3→4) within the 15m window.
+      - series: 'dell_csi_driver_restart_total{pod="ps-controller-0",instance_type="controller",cluster_name="c1"}'
+        values: '0 0 0 1 2 3 4 4 4 4 4 4 4 4 4 4'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: PowerScaleDriverCrashLooping
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              pod: ps-controller-0
+              instance_type: controller
+              cluster_name: c1
+            exp_annotations:
+              summary: "PowerScale CSI driver is crash looping"
+              description: "PowerScale CSI driver pod ps-controller-0 (instance type: controller) has restarted 4 times in the last 15m, indicating a crash loop."
+              runbook_url: ""
+
+  - name: "PS-10 Exactly 3 restarts (at boundary, not > 3) → no alert"
+    interval: 1m
+    input_series:
+      # Counter changes 3 times (0→1, 1→2, 2→3); 3 is not > 3.
+      - series: 'dell_csi_driver_restart_total{pod="ps-controller-0",instance_type="controller",cluster_name="c1"}'
+        values: '0 0 0 1 2 3 3 3 3 3 3 3 3 3 3 3'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: PowerScaleDriverCrashLooping
+        exp_alerts: []
+
+  - name: "PS-10 2 restarts in 15m → no alert"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_driver_restart_total{pod="ps-controller-0",instance_type="controller",cluster_name="c1"}'
+        values: '0 0 0 0 1 2 2 2 2 2 2 2 2 2 2 2'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: PowerScaleDriverCrashLooping
+        exp_alerts: []
+
+  # PS-11: PowerScaleDriverHighCPU
+  # Expression: dell_csi_driver_cpu_usage_percent > 80, for: 5m
+
+  - name: "PS-11 CPU at 81% sustained 5m → PowerScaleDriverHighCPU fires"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_driver_cpu_usage_percent{pod="ps-controller-0",cluster_name="c1"}'
+        values: '81 81 81 81 81 81'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleDriverHighCPU
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              pod: ps-controller-0
+              cluster_name: c1
+            exp_annotations:
+              summary: "PowerScale CSI driver high CPU usage"
+              description: "PowerScale CSI driver pod ps-controller-0 on cluster c1 has CPU usage of 81% (threshold: 80%) for more than 5 minutes."
+              runbook_url: ""
+
+  - name: "PS-11 CPU at 80% (boundary, not > 80) → no alert"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_driver_cpu_usage_percent{pod="ps-controller-0",cluster_name="c1"}'
+        values: '80 80 80 80 80 80'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleDriverHighCPU
+        exp_alerts: []
+
+  - name: "PS-11 CPU at 79% → no alert"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_driver_cpu_usage_percent{pod="ps-controller-0",cluster_name="c1"}'
+        values: '79 79 79 79 79 79'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleDriverHighCPU
+        exp_alerts: []
+
+  # PS-12: PowerScaleDriverHighMemory
+  # Expression: dell_csi_driver_memory_usage_bytes > 2147483648, for: 5m
+
+  - name: "PS-12 Memory above 2 GiB (2147483649 bytes) sustained 5m → PowerScaleDriverHighMemory fires"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_driver_memory_usage_bytes{pod="ps-controller-0",cluster_name="c1"}'
+        values: '2147483649 2147483649 2147483649 2147483649 2147483649 2147483649'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleDriverHighMemory
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              pod: ps-controller-0
+              cluster_name: c1
+            exp_annotations:
+              summary: "PowerScale CSI driver high memory usage"
+              description: "PowerScale CSI driver pod ps-controller-0 on cluster c1 has memory usage of 2.147483649e+09 bytes (threshold: 2.147483648e+09 bytes) for more than 5 minutes."
+              runbook_url: ""
+
+  - name: "PS-12 Memory exactly 2 GiB (boundary, not > 2147483648) → no alert"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_driver_memory_usage_bytes{pod="ps-controller-0",cluster_name="c1"}'
+        values: '2147483648 2147483648 2147483648 2147483648 2147483648 2147483648'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleDriverHighMemory
+        exp_alerts: []
+
+  # PS-13: PowerScaleMetricsStale
+  # Expression: dell_powerscale_metrics_stale == 1, for: 5m
+
+  - name: "PS-13 Stale flag = 1 sustained 5m → PowerScaleMetricsStale fires"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_metrics_stale{cluster_name="c1"}'
+        values: '1 1 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleMetricsStale
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              cluster_name: c1
+            exp_annotations:
+              summary: "PowerScale metrics collection is stale on cluster c1"
+              description: "PowerScale metrics collection has reported stale data for 5 minutes on cluster c1. The stale flag is set immediately on any collection failure, regardless of whether cached data is available, ensuring the alert fires even when the cache is empty."
+              runbook_url: ""
+
+  - name: "PS-13 Stale flag = 0 → no alert"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_metrics_stale{cluster_name="c1"}'
+        values: '0 0 0 0 0 0'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleMetricsStale
+        exp_alerts: []
+
+  - name: "PS-13 Stale flag set for only 4m → no alert (for: 5m not yet met)"
+    interval: 1m
+    input_series:
+      # Flag becomes 1 at t=1m; at eval_time=5m only 4m of true condition has passed.
+      - series: 'dell_powerscale_metrics_stale{cluster_name="c1"}'
+        values: '0 1 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleMetricsStale
+        exp_alerts: []
+
+  # ==========================================================================
+  # Category 3 — Quota Capacity (PS-14 to PS-16) — 8 scenarios
+  # Ratio metric: dell_powerscale_quota_utilization_ratio in [0,1]; rule multiplies
+  # by 100 and compares to an integer-percent threshold.
+  # Labels from quota_collector: cluster_name, volume_id, access_zone.
+  # ==========================================================================
+
+  # PS-14: PowerScaleQuotaWarning
+  # Expression: dell_powerscale_quota_utilization_ratio * 100 > 80, for: 5m
+
+  - name: "PS-14 Quota at 0.81 → 81% > 80% → PowerScaleQuotaWarning fires"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_quota_utilization_ratio{cluster_name="c1",volume_id="vol-1",access_zone="zone-a"}'
+        values: '0.81 0.81 0.81 0.81 0.81 0.81'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleQuotaWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              access_zone: zone-a
+              cluster_name: c1
+              volume_id: vol-1
+            exp_annotations:
+              summary: "Quota warning for volume vol-1 in access zone zone-a"
+              description: "Volume vol-1 in access zone zone-a on cluster c1 has exceeded the quota threshold at 81.0% utilization (threshold: 80%)."
+              runbook_url: ""
+
+  - name: "PS-14 Quota at 0.80 (80%, not > 80, boundary) → no alert"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_quota_utilization_ratio{cluster_name="c1",volume_id="vol-1",access_zone="zone-a"}'
+        values: '0.80 0.80 0.80 0.80 0.80 0.80'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleQuotaWarning
+        exp_alerts: []
+
+  - name: "PS-14 Quota at 0.79 → 79% < 80% → no alert"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_quota_utilization_ratio{cluster_name="c1",volume_id="vol-1",access_zone="zone-a"}'
+        values: '0.79 0.79 0.79 0.79 0.79 0.79'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleQuotaWarning
+        exp_alerts: []
+
+  # PS-15: PowerScaleQuotaCritical
+  # Expression: dell_powerscale_quota_utilization_ratio * 100 > 90, for: 5m
+
+  - name: "PS-15 Quota at 0.91 → 91% > 90% → PowerScaleQuotaCritical fires"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_quota_utilization_ratio{cluster_name="c1",volume_id="vol-1",access_zone="zone-a"}'
+        values: '0.91 0.91 0.91 0.91 0.91 0.91'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleQuotaCritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              access_zone: zone-a
+              cluster_name: c1
+              volume_id: vol-1
+            exp_annotations:
+              summary: "Quota critical for volume vol-1 in access zone zone-a"
+              description: "Volume vol-1 in access zone zone-a on cluster c1 has exceeded the quota threshold at 91.0% utilization (threshold: 90%). Immediate action required."
+              runbook_url: ""
+
+  - name: "PS-15 Quota at 0.90 (90%, not > 90, boundary) → no alert"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_quota_utilization_ratio{cluster_name="c1",volume_id="vol-1",access_zone="zone-a"}'
+        values: '0.90 0.90 0.90 0.90 0.90 0.90'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleQuotaCritical
+        exp_alerts: []
+
+  # PS-16: PowerScaleQuotaHardBreach
+  # Expression: dell_powerscale_quota_hard_breach_total > 0, for: 0m
+
+  - name: "PS-16 Hard quota breach total = 2 → PowerScaleQuotaHardBreach fires (critical)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_quota_hard_breach_total{cluster_name="c1"}'
+        values: '2 2 2 2 2 2'
+    alert_rule_test:
+      - eval_time: 0m
+        alertname: PowerScaleQuotaHardBreach
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              cluster_name: c1
+            exp_annotations:
+              summary: "Hard quota breach detected on cluster c1"
+              description: "2 volume(s) on cluster c1 have exceeded their hard quota limit. Check individual volume quota metrics (dell_powerscale_quota_utilization_ratio) to identify affected volumes. Write operations may be blocked."
+              runbook_url: ""
+
+  - name: "PS-16 Hard quota breach total = 0 → no alert"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_quota_hard_breach_total{cluster_name="c1"}'
+        values: '0 0 0 0 0 0'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleQuotaHardBreach
+        exp_alerts: []
+
+  # Recovery: quota drops from above warning threshold to below → alert clears.
+  # This test has two eval_time checkpoints: fires at t=5m, clears at t=10m.
+  - name: "PS-14 Recovery: quota drops from 0.85 to 0.70 → PowerScaleQuotaWarning clears"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_quota_utilization_ratio{cluster_name="c1",volume_id="vol-1",access_zone="zone-a"}'
+        # Ratio stays at 0.85 for the first 7m (alert fires at t=5m), then drops to 0.70.
+        values: '0.85 0.85 0.85 0.85 0.85 0.85 0.85 0.70 0.70 0.70 0.70'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleQuotaWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              access_zone: zone-a
+              cluster_name: c1
+              volume_id: vol-1
+            exp_annotations:
+              summary: "Quota warning for volume vol-1 in access zone zone-a"
+              description: "Volume vol-1 in access zone zone-a on cluster c1 has exceeded the quota threshold at 85.0% utilization (threshold: 80%)."
+              runbook_url: ""
+      - eval_time: 10m
+        alertname: PowerScaleQuotaWarning
+        exp_alerts: []
+
+  # ==========================================================================
+  # Category 4 — Node Pool Capacity (PS-17 to PS-18) — 6 scenarios
+  # Expression: dell_powerscale_nodepool_utilization_percent > threshold, for: 5m
+  # Raw percent metric — compare directly to integer threshold (no multiplication).
+  # ==========================================================================
+
+  - name: "PS-17 Node pool at 85% → 85 > 80 → PowerScaleNodePoolWarning fires"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_nodepool_utilization_percent{cluster_name="c1",nodepool_name="pool-a"}'
+        values: '85 85 85 85 85 85'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleNodePoolWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              cluster_name: c1
+              nodepool_name: pool-a
+            exp_annotations:
+              summary: "PowerScale node pool utilization warning"
+              description: "Node pool pool-a on cluster c1 is at 85% utilization (threshold: 80%)."
+              runbook_url: ""
+
+  - name: "PS-17 Node pool at 80% (boundary, not > 80) → no alert"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_nodepool_utilization_percent{cluster_name="c1",nodepool_name="pool-a"}'
+        values: '80 80 80 80 80 80'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleNodePoolWarning
+        exp_alerts: []
+
+  - name: "PS-17 Node pool at 79% → no alert"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_nodepool_utilization_percent{cluster_name="c1",nodepool_name="pool-a"}'
+        values: '79 79 79 79 79 79'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleNodePoolWarning
+        exp_alerts: []
+
+  - name: "PS-18 Node pool at 95% → 95 > 90 → PowerScaleNodePoolCritical fires"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_nodepool_utilization_percent{cluster_name="c1",nodepool_name="pool-a"}'
+        values: '95 95 95 95 95 95'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleNodePoolCritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              cluster_name: c1
+              nodepool_name: pool-a
+            exp_annotations:
+              summary: "PowerScale node pool utilization critical"
+              description: "Node pool pool-a on cluster c1 is at 95% utilization (threshold: 90%). Immediate action required."
+              runbook_url: ""
+
+  - name: "PS-18 Node pool at 90% (boundary, not > 90) → no alert"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_nodepool_utilization_percent{cluster_name="c1",nodepool_name="pool-a"}'
+        values: '90 90 90 90 90 90'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleNodePoolCritical
+        exp_alerts: []
+
+  - name: "PS-18 Node pool at 89% → no alert"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_nodepool_utilization_percent{cluster_name="c1",nodepool_name="pool-a"}'
+        values: '89 89 89 89 89 89'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerScaleNodePoolCritical
+        exp_alerts: []
+
+  # ==========================================================================
+  # Category 5 — Access Control (PS-19 to PS-20) — 6 scenarios
+  # ==========================================================================
+
+  # PS-19: PowerScaleNFSAuthFailureRate
+  # Expression: rate(dell_powerscale_nfs_mount_auth_failures_total[5m]) > 0, for: 5m
+  # rate() needs ≥2 samples → condition first true at t=1m → for:5m satisfied at t≥6m.
+
+  - name: "PS-19 Sustained NFS auth failures → PowerScaleNFSAuthFailureRate fires"
+    interval: 1m
+    input_series:
+      # Counter increases continuously; rate > 0 from t=1m onwards.
+      - series: 'dell_powerscale_nfs_mount_auth_failures_total{cluster_name="c1"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10 11'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PowerScaleNFSAuthFailureRate
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              cluster_name: c1
+            exp_annotations:
+              summary: "PowerScale NFS authentication failures detected"
+              description: "NFS mount authentication failures detected on cluster c1 at a rate of 0.016666666666666666 failures/second over the last 5 minutes."
+              runbook_url: ""
+
+  - name: "PS-19 Constant NFS auth failure counter (zero rate) → no alert"
+    interval: 1m
+    input_series:
+      # Counter has a non-zero value but does not increase → rate = 0.
+      - series: 'dell_powerscale_nfs_mount_auth_failures_total{cluster_name="c1"}'
+        values: '5 5 5 5 5 5 5 5 5 5 5 5'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PowerScaleNFSAuthFailureRate
+        exp_alerts: []
+
+  - name: "PS-19 NFS auth failures for only 4m → no alert (for: 5m not yet met)"
+    interval: 1m
+    input_series:
+      # Evaluate at t=4m: rate > 0 has been true for ≈3m (since t=1m); for:5m not met.
+      - series: 'dell_powerscale_nfs_mount_auth_failures_total{cluster_name="c1"}'
+        values: '0 1 2 3 4 5'
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: PowerScaleNFSAuthFailureRate
+        exp_alerts: []
+
+  # PS-20: PowerScaleAPIErrorRate
+  # Expression: (rate(failures[W]) / ignoring(status) sum without(status)(rate(total[W]))) * 100 > threshold
+  # for: 5m
+  #
+  # The denominator uses "sum without(status)" to aggregate all status values into a
+  # single per-cluster_name total, then "ignoring(status)" drops the status label from
+  # the numerator side for the binary division. This avoids the label-cardinality trap
+  # where dividing failure/failure would always produce 100%.
+  #
+  # Test data: failure and success series both carry cluster_name. The sum without(status)
+  # collapses them into one total-per-cluster series, producing the correct ratio.
+
+  - name: "PS-20 API error rate 15% (15 failures per 100 calls) → PowerScaleAPIErrorRate fires"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_api_calls_total{status="failure",cluster_name="c1"}'
+        values: '0 15 30 45 60 75 90 105 120 135 150'
+      - series: 'dell_powerscale_api_calls_total{status="success",cluster_name="c1"}'
+        values: '0 85 170 255 340 425 510 595 680 765 850'
+    alert_rule_test:
+      # rate(failure[5m]) / sum_without_status(rate(total[5m])) * 100 = 15/100 * 100 = 15 > 10 → fires
+      - eval_time: 10m
+        alertname: PowerScaleAPIErrorRate
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              cluster_name: c1
+            exp_annotations:
+              summary: "PowerScale API error rate elevated"
+              description: "PowerScale API error rate on cluster c1 is 15% over the last 5m (threshold: 10%)."
+              runbook_url: ""
+
+  - name: "PS-20 API error rate 5% → no alert (5 < 10 threshold)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_api_calls_total{status="failure",cluster_name="c1"}'
+        values: '0 5 10 15 20 25 30 35 40 45 50'
+      - series: 'dell_powerscale_api_calls_total{status="success",cluster_name="c1"}'
+        values: '0 95 190 285 380 475 570 665 760 855 950'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PowerScaleAPIErrorRate
+        exp_alerts: []
+
+  - name: "PS-20 API error rate exactly 10% (boundary, not > 10) → no alert"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_api_calls_total{status="failure",cluster_name="c1"}'
+        values: '0 10 20 30 40 50 60 70 80 90 100'
+      - series: 'dell_powerscale_api_calls_total{status="success",cluster_name="c1"}'
+        values: '0 90 180 270 360 450 540 630 720 810 900'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PowerScaleAPIErrorRate
+        exp_alerts: []
+
+  # ==========================================================================
+  # Category 6 — NFS Performance (PS-21 to PS-22) — 4 scenarios
+  # Expression: histogram_quantile(0.99, rate(bucket[5m])) > 10, for: 5m
+  #
+  # Histogram bucket strategy:
+  #   Fires   (P99 ≈ 19.9s > 10s): all observations fall in the le="20" bucket but NOT
+  #           in le="10" → le="10" rate = 0, le="20" rate > 0, le="+Inf" rate > 0.
+  #           histogram_quantile(0.99) = 10 + (0.99/1) * (20-10) = 19.9s.
+  #   No-fire (P99 ≈ 4.95s < 10s): all observations fall in the le="5" bucket →
+  #           all bucket rates equal → histogram_quantile(0.99) = 0 + 0.99 * 5 = 4.95s.
+  #
+  # rate() requires ≥2 samples → for:5m is satisfied at t≥6m; evaluate at t=10m.
+  # ==========================================================================
+
+  - name: "PS-21 NFSv3 P99 latency ≈ 19.9s (> 10s) → PowerScaleNFSv3HighLatency fires"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_nfs_v3_latency_seconds_bucket{le="5",cluster_name="c1"}'
+        values: '0 0 0 0 0 0 0 0 0 0 0'
+      - series: 'dell_powerscale_nfs_v3_latency_seconds_bucket{le="10",cluster_name="c1"}'
+        values: '0 0 0 0 0 0 0 0 0 0 0'
+      - series: 'dell_powerscale_nfs_v3_latency_seconds_bucket{le="20",cluster_name="c1"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10'
+      - series: 'dell_powerscale_nfs_v3_latency_seconds_bucket{le="+Inf",cluster_name="c1"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PowerScaleNFSv3HighLatency
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              cluster_name: c1
+            exp_annotations:
+              summary: "PowerScale NFSv3 high latency detected"
+              description: "NFSv3 P99 latency on cluster c1 is 19.9s (threshold: 10s). Note: latency is bucket-approximated from the OneFS optime API; minimum resolution is 100ms."
+              runbook_url: ""
+
+  - name: "PS-21 NFSv3 P99 latency ≈ 4.95s (< 10s) → no alert"
+    interval: 1m
+    input_series:
+      # All observations in le="5"; all bucket rates equal → P99 ≈ 4.95s.
+      - series: 'dell_powerscale_nfs_v3_latency_seconds_bucket{le="5",cluster_name="c1"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10'
+      - series: 'dell_powerscale_nfs_v3_latency_seconds_bucket{le="10",cluster_name="c1"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10'
+      - series: 'dell_powerscale_nfs_v3_latency_seconds_bucket{le="20",cluster_name="c1"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10'
+      - series: 'dell_powerscale_nfs_v3_latency_seconds_bucket{le="+Inf",cluster_name="c1"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PowerScaleNFSv3HighLatency
+        exp_alerts: []
+
+  - name: "PS-22 NFSv4 P99 latency ≈ 19.9s (> 10s) → PowerScaleNFSv4HighLatency fires"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_nfs_v4_latency_seconds_bucket{le="5",cluster_name="c1"}'
+        values: '0 0 0 0 0 0 0 0 0 0 0'
+      - series: 'dell_powerscale_nfs_v4_latency_seconds_bucket{le="10",cluster_name="c1"}'
+        values: '0 0 0 0 0 0 0 0 0 0 0'
+      - series: 'dell_powerscale_nfs_v4_latency_seconds_bucket{le="20",cluster_name="c1"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10'
+      - series: 'dell_powerscale_nfs_v4_latency_seconds_bucket{le="+Inf",cluster_name="c1"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PowerScaleNFSv4HighLatency
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerscale
+              component: csi-driver
+              namespace: test
+              cluster_name: c1
+            exp_annotations:
+              summary: "PowerScale NFSv4 high latency detected"
+              description: "NFSv4 P99 latency on cluster c1 is 19.9s (threshold: 10s). Note: latency is bucket-approximated from the OneFS optime API; minimum resolution is 100ms."
+              runbook_url: ""
+
+  - name: "PS-22 NFSv4 P99 latency ≈ 4.95s (< 10s) → no alert"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerscale_nfs_v4_latency_seconds_bucket{le="5",cluster_name="c1"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10'
+      - series: 'dell_powerscale_nfs_v4_latency_seconds_bucket{le="10",cluster_name="c1"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10'
+      - series: 'dell_powerscale_nfs_v4_latency_seconds_bucket{le="20",cluster_name="c1"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10'
+      - series: 'dell_powerscale_nfs_v4_latency_seconds_bucket{le="+Inf",cluster_name="c1"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PowerScaleNFSv4HighLatency
+        exp_alerts: []

--- a/charts/csi-isilon/values.yaml
+++ b/charts/csi-isilon/values.yaml
@@ -113,6 +113,26 @@ fsGroupPolicy: ReadWriteOnceWithFSType
 # Default value: 8083
 podmonAPIPort: 8083
 
+# podmonAPIToken: Shared secret token for authenticating podmon API requests
+# When set, the driver will require Bearer token authentication on /array-status endpoints
+# Allowed values: Any string (recommend using a randomly generated token)
+# Security note: podmon API is HTTP; use this token only on trusted cluster-internal networks.
+# For production, use podmonAPITokenSecret to source this value from a Kubernetes Secret.
+# Default value: "" (empty - authentication disabled for backward compatibility)
+podmonAPIToken: ""
+
+# podmonAPITokenSecret: Kubernetes Secret containing the podmon API token
+# When set, the token will be sourced from the specified Secret instead of podmonAPIToken value
+# Allowed values:
+#   name: Secret name (required)
+#   key: Secret key containing the token (required, default: "podmon-api-token")
+# Example:
+#   podmonAPITokenSecret:
+#     name: my-podmon-secret
+#     key: api-token
+# Default value: null (use podmonAPIToken value instead)
+podmonAPITokenSecret: null
+
 # maxPathLen: this parameter is used for setting the maximum Path length for the given volume.
 # Default value: 192
 # Examples: 192, 256
@@ -173,6 +193,19 @@ controller:
     # Allowed values: string
     # Default value: replication.storage.dell.com
     replicationPrefix: "replication.storage.dell.com"
+
+    # Metrics configuration for replication sidecar
+    metrics:
+      enabled: false
+      port: 8445
+      tlsCertSecret: ""
+      collection:
+        interval: 30s
+      serviceMonitor:
+        enabled: false
+        interval: 30s
+        scrapeTimeout: ""
+        insecureSkipVerify: false
 
   snapshot:
     # enabled: Enable/Disable volume snapshot feature
@@ -393,6 +426,32 @@ noProbeOnStart: false
 # Default value: false
 autoProbe: true
 
+# nfsMountFQDN: Specify a global default FQDN to use as the NFS mount target instead of the cluster endpoint IP.
+# This is required for NFS over TLS (mTLS) because certificate validation needs an FQDN, not an IP address.
+# This value acts as a fallback default. The per-cluster "nfsMountFQDN" field in the secret takes precedence
+# over this value, and the StorageClass "SmartConnectZoneFQDN" parameter takes highest precedence.
+# Allowed values: A valid FQDN (e.g., "smartconnect.isilon.example.com")
+# Optional: true
+# Default value: None
+nfsMountFQDN: ""
+
+# nfsTransportSecurity: Specify the global default NFS transport security mode.
+# This is the lowest-precedence fallback. The per-cluster "nfsTransportSecurity" field in the secret
+# takes precedence, and the StorageClass "NFSTransportSecurity" parameter takes highest precedence.
+# When set to "tls" or "mtls", the driver validates TLS/mTLS prerequisites on worker nodes at mount time.
+# Allowed values:
+#   "none": no transport security (default NFS behavior)
+#   "tls": NFS over TLS (encryption only)
+#   "mtls": NFS over mutual TLS (encryption + client certificate authentication)
+# Default value: "none"
+nfsTransportSecurity: "none"
+
+# tlsHandshakeTimeoutSeconds: Specify the TLS handshake timeout in seconds for NFS over TLS/mTLS.
+# This timeout applies to the TLS handshake during mount operations when using TLS or mTLS transport security.
+# Allowed values: positive integer (seconds)
+# Default value: 30
+tlsHandshakeTimeoutSeconds: "30"
+
 authorization:
   enabled: false
   # proxyHost: hostname of the csm-authorization server
@@ -472,6 +531,18 @@ podmon:
       interval: 30s
       scrapeTimeout: ""
       insecureSkipVerify: false
+    # prometheusRule: Controls optional Prometheus Operator PrometheusRule creation for resiliency alerts.
+    prometheusRule:
+      # enabled: When true, a PrometheusRule CR is created for resiliency alerting rules.
+      # Type: bool
+      # Default: true
+      # Effect: Requires the Prometheus Operator CRDs to be installed in the cluster.
+      enabled: true
+      # connectivitySuccessRatio: Minimum acceptable connectivity success ratio as percentage (0-100).
+      # Used by RES-02 (CSMResiliencyConnectivityLost) alert threshold.
+      # Type: integer
+      # Default: 90 (alert fires when connectivity drops below 90%)
+      connectivitySuccessRatio: 90
 
 # metrics: configuration for driver metrics and monitoring
 metrics:
@@ -556,6 +627,67 @@ metrics:
     # Type: bool
     # Default: false
     insecureSkipVerify: false
+
+  # prometheusRule: Controls optional Prometheus Operator PrometheusRule creation for alerting.
+  # When enabled, deploys 22 PowerScale-specific alert rules covering volume operations,
+  # driver health, quota capacity, node pool capacity, access control, and NFS performance.
+  prometheusRule:
+    # enabled: When true, a PrometheusRule CR is created with all PowerScale alert rules.
+    # Type: bool
+    # Default: true
+    # Effect: Requires the Prometheus Operator CRDs to be installed in the cluster.
+    #         Auto-deploys when metrics.enabled is true. Set to false to disable bundled alerts.
+    enabled: true
+    # volumeOperationFailureThreshold: Volume operation failure count threshold in 5m window
+    volumeOperationFailureThreshold: 3
+    # quotaWarningThreshold: Quota utilization warning threshold (percent, 0-100).
+    # Type: integer
+    # Default: 80 (triggers warning at 80% quota usage)
+    quotaWarningThreshold: 80
+    # quotaCriticalThreshold: Quota utilization critical threshold (percent, 0-100).
+    # Type: integer
+    # Default: 90 (triggers critical alert at 90% quota usage)
+    quotaCriticalThreshold: 90
+    # nodepoolWarningThreshold: Node pool utilization warning threshold (percent, 0-100).
+    # Type: integer
+    # Default: 80 (triggers warning at 80% node pool usage)
+    nodepoolWarningThreshold: 80
+    # nodepoolCriticalThreshold: Node pool utilization critical threshold (percent, 0-100).
+    # Type: integer
+    # Default: 90 (triggers critical alert at 90% node pool usage)
+    nodepoolCriticalThreshold: 90
+    # apiErrorRateThreshold: API error rate warning threshold (percent, 0-100).
+    # Type: integer
+    # Default: 10 (triggers warning when API error rate exceeds 10%)
+    apiErrorRateThreshold: 10
+    # apiErrorRateWindow: Time window for API error rate calculation.
+    # Type: string (Prometheus duration, e.g. "5m", "10m")
+    # Default: "5m"
+    apiErrorRateWindow: "5m"
+    # cpuWarningThreshold: Driver CPU usage warning threshold (percent, 0-100).
+    # Type: integer
+    # Default: 80 (triggers warning at 80% CPU usage)
+    cpuWarningThreshold: 80
+    # memoryWarningThreshold: Driver memory usage warning threshold (bytes).
+    # Type: integer
+    # Default: 2147483648 (2 GiB in bytes)
+    memoryWarningThreshold: 2147483648
+    # nfsV3LatencyWarningSeconds: NFSv3 P99 latency warning threshold (seconds).
+    # Type: integer
+    # Default: 10 (triggers warning when P99 latency exceeds 10 seconds)
+    nfsV3LatencyWarningSeconds: 10
+    # nfsV4LatencyWarningSeconds: NFSv4 P99 latency warning threshold (seconds).
+    # Type: integer
+    # Default: 10 (triggers warning when P99 latency exceeds 10 seconds)
+    nfsV4LatencyWarningSeconds: 10
+    # driverCrashLoopRestartThreshold: Number of driver restarts to trigger crash loop alert.
+    # Type: integer
+    # Default: 3 (triggers warning after 3 restarts within the window)
+    driverCrashLoopRestartThreshold: 3
+    # driverCrashLoopWindow: Time window for crash loop restart detection.
+    # Type: string (Prometheus duration, e.g. "15m", "30m")
+    # Default: "15m"
+    driverCrashLoopWindow: "15m"
 
   # collection: Controls how frequently metrics are collected.
   collection:

--- a/charts/csi-powermax/templates/controller.yaml
+++ b/charts/csi-powermax/templates/controller.yaml
@@ -182,6 +182,9 @@ rules:
   - apiGroups: ["apps"]
     resources: ["replicasets"]
     verbs: ["get"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list"]
 ---
 # RoleBinding for Driver-specific Role
 kind: RoleBinding
@@ -419,11 +422,38 @@ spec:
               value: /powermax-config-params
             - name: X_CSI_REPLICATION_CONFIG_FILE_NAME
               value: driver-config-params.yaml
+            {{- if hasKey .Values.replication "metrics" }}
+            - name: X_CSI_REPLICATION_METRICS_ENABLED
+              value: "{{ .Values.replication.metrics.enabled | default false }}"
+            - name: X_CSI_REPLICATION_METRICS_PORT
+              value: "{{ .Values.replication.metrics.port | default 8445 }}"
+            {{- if .Values.replication.metrics.collection }}
+            - name: X_CSI_REPLICATION_METRICS_COLLECTION_INTERVAL
+              value: "{{ .Values.replication.metrics.collection.interval | default "30s" }}"
+            {{- end }}
+            {{- if .Values.replication.metrics.tlsCertSecret }}
+            - name: X_CSI_REPLICATION_METRICS_TLS_CERT_FILE
+              value: /etc/replication-metrics-tls/tls.crt
+            - name: X_CSI_REPLICATION_METRICS_TLS_KEY_FILE
+              value: /etc/replication-metrics-tls/tls.key
+            {{- end }}
+            {{- end }}
+          {{- if and (hasKey .Values.replication "metrics") (.Values.replication.metrics.enabled) }}
+          ports:
+            - containerPort: {{ .Values.replication.metrics.port | default 8445 }}
+              name: repl-metrics
+              protocol: TCP
+          {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi
             - name: powermax-config-params
               mountPath: /powermax-config-params
+            {{- if and (hasKey .Values.replication "metrics") (.Values.replication.metrics.tlsCertSecret) }}
+            - name: replication-metrics-tls
+              mountPath: /etc/replication-metrics-tls
+              readOnly: true
+            {{- end }}
         {{- end }}
         {{- if eq .Values.migration.enabled true}}
         - name: dell-csi-migrator
@@ -569,6 +599,10 @@ spec:
               value: {{ .Values.global.portGroups | toJson }}
             - name: X_CSI_TRANSPORT_PROTOCOL
               value: {{ .Values.global.transportProtocol | default "" }}
+            - name: X_CSI_POWERMAX_HOST_MGMT_MODE
+              value: {{ .Values.global.hostManagementMode | default "create" }}
+            - name: X_CSI_POWERMAX_HOST_ADOPTION_MIN_OVERLAP_RATIO
+              value: {{ .Values.global.hostAdoptionMinOverlapRatio | default "0.5" | quote }}
             - name: X_CSI_REVPROXY_USE_SECRET
               value: {{ $useRevProxySecret | quote }}
               {{- if $useRevProxySecret }}
@@ -644,10 +678,26 @@ spec:
             {{- end }}
             - name: X_CSI_PODMON_API_PORT
               value: "{{ .Values.podmon.podmonAPIPort }}"
+            {{- if .Values.podmon.podmonAPITokenSecret }}
+            - name: X_CSI_PODMON_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.podmon.podmonAPITokenSecret.name }}
+                  key: {{ .Values.podmon.podmonAPITokenSecret.key | default "podmon-api-token" }}
+            {{- else if .Values.podmon.podmonAPIToken }}
+            - name: X_CSI_PODMON_API_TOKEN
+              value: "{{ .Values.podmon.podmonAPIToken }}"
+            {{- end }}
             - name: X_CSI_REVPROXY_TLS_CERT_DIR
               value: /app/tls
             - name: X_CSI_DYNAMIC_SG_ENABLED
               value: {{ .Values.dynamicSGEnabled | default "false" | lower | quote }}
+            {{- if hasKey .Values "multiArrayZone" }}
+            - name: X_CSI_CAPACITY_POLL_INTERVAL
+              value: {{ .Values.multiArrayZone.capacityPollInterval | default "5m" | quote }}
+            - name: X_CSI_CAPACITY_THRESHOLD_FULL
+              value: "{{- if hasKey .Values.multiArrayZone "capacityThresholdFull" }}{{ .Values.multiArrayZone.capacityThresholdFull }}{{ else }}100{{ end }}"
+            {{- end }}
             {{- if hasKey .Values.controller "csiAddonsReplication" }}
             - name: X_CSI_CSIADDONS_REPLICATION_ENABLED
               value: "{{ .Values.controller.csiAddonsReplication.enabled }}"
@@ -796,6 +846,13 @@ spec:
         - name: resiliency-metrics-tls
           secret:
             secretName: {{ .Values.podmon.metrics.tlsCertSecret }}
+        {{- end }}
+        {{- if and (eq .Values.replication.enabled true) (hasKey .Values.replication "metrics") }}
+        {{- if .Values.replication.metrics.tlsCertSecret }}
+        - name: replication-metrics-tls
+          secret:
+            secretName: {{ .Values.replication.metrics.tlsCertSecret }}
+        {{- end }}
         {{- end }}
         {{- if and (eq .Values.global.proxyAuthToken.enabled true) (not .Values.csireverseproxy.deployAsSidecar) }}
         - name: proxy-auth-token

--- a/charts/csi-powermax/templates/metrics-service.yaml
+++ b/charts/csi-powermax/templates/metrics-service.yaml
@@ -41,3 +41,26 @@ spec:
       protocol: TCP
   type: ClusterIP
 {{- end }}
+{{- if and (eq .Values.replication.enabled true) (hasKey .Values.replication "metrics") }}
+{{- if eq .Values.replication.metrics.enabled true }}
+---
+# Service exposing the replication metrics endpoint for Prometheus scraping.
+# Created when replication.enabled and replication.metrics.enabled are true.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-replication-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  selector:
+    name: {{ .Release.Name }}-controller
+  ports:
+    - name: repl-metrics
+      port: {{ .Values.replication.metrics.port | default 8445 }}
+      targetPort: {{ .Values.replication.metrics.port | default 8445 }}
+      protocol: TCP
+  type: ClusterIP
+{{- end }}
+{{- end }}

--- a/charts/csi-powermax/templates/node.yaml
+++ b/charts/csi-powermax/templates/node.yaml
@@ -296,6 +296,10 @@ spec:
               value: {{ .Values.global.portGroups | toJson }}
             - name: X_CSI_TRANSPORT_PROTOCOL
               value: {{ .Values.global.transportProtocol | default "" }}
+            - name: X_CSI_POWERMAX_HOST_MGMT_MODE
+              value: {{ .Values.global.hostManagementMode | default "create" }}
+            - name: X_CSI_POWERMAX_HOST_ADOPTION_MIN_OVERLAP_RATIO
+              value: {{ .Values.global.hostAdoptionMinOverlapRatio | default "0.5" | quote }}
             - name: X_CSI_REVPROXY_USE_SECRET
               value: {{ $useRevProxySecret | quote }}
               {{- if $useRevProxySecret }}
@@ -380,6 +384,16 @@ spec:
             {{- end }}
             - name: X_CSI_PODMON_API_PORT
               value: "{{ .Values.podmon.podmonAPIPort }}"
+            {{- if .Values.podmon.podmonAPITokenSecret }}
+            - name: X_CSI_PODMON_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.podmon.podmonAPITokenSecret.name }}
+                  key: {{ .Values.podmon.podmonAPITokenSecret.key | default "podmon-api-token" }}
+            {{- else if .Values.podmon.podmonAPIToken }}
+            - name: X_CSI_PODMON_API_TOKEN
+              value: "{{ .Values.podmon.podmonAPIToken }}"
+            {{- end }}
             - name: X_CSI_REVPROXY_TLS_CERT_DIR
               value: /app/tls
             - name: X_CSI_DYNAMIC_SG_ENABLED
@@ -416,6 +430,12 @@ spec:
               value: "/etc/metrics-tls/tls.key"
             {{- end }}
             {{- end }}
+          {{- if eq (include "csi-powermax.isMetricsEnabled" .) "true" }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metrics.port | default 8443 }}
+              protocol: TCP
+          {{- end }}
           volumeMounts:
             - name: driver-path
               mountPath: {{ .Values.kubeletConfigDir }}/plugins/powermax.emc.dell.com
@@ -658,12 +678,12 @@ spec:
           secret:
             secretName: {{ .Values.metrics.tlsCertSecret }}
         {{- end }}
-        {{- if and (eq .Values.global.proxyAuthToken.enabled true) (not .Values.csireverseproxy.deployAsSidecar) }}
         {{- if and (hasKey .Values "podmon") .Values.podmon.enabled (hasKey .Values.podmon "metrics") .Values.podmon.metrics.enabled .Values.podmon.metrics.tlsCertSecret }}
         - name: resiliency-metrics-tls
           secret:
             secretName: {{ .Values.podmon.metrics.tlsCertSecret }}
         {{- end }}
+        {{- if and (eq .Values.global.proxyAuthToken.enabled true) (not .Values.csireverseproxy.deployAsSidecar) }}
         - name: proxy-auth-token
           secret:
             secretName: {{ .Values.global.proxyAuthToken.secretName }}

--- a/charts/csi-powermax/templates/prometheusrule.yaml
+++ b/charts/csi-powermax/templates/prometheusrule.yaml
@@ -1,21 +1,405 @@
+# Copyright © 2022-2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 {{- if eq (include "csi-powermax.isMetricsEnabled" .) "true" }}
 {{- if hasKey .Values.metrics "prometheusRule" }}
 {{- if eq .Values.metrics.prometheusRule.enabled true }}
 ---
-# PrometheusRule for Prometheus Operator alerting/recording rules.
+# PrometheusRule for PowerMax CSI Driver alerting rules.
 # Created when metrics.enabled AND metrics.prometheusRule.enabled are true.
 # Requires the Prometheus Operator CRDs to be installed in the cluster.
+#
+# PowerMax alert catalog — 15 alert rules across 3 groups:
+#   Group 1 — powermax-csi-volume-operations  (PM-01 to PM-08)
+#   Group 2 — powermax-csi-driver-health      (PM-09 to PM-12)
+#   Group 3 — powermax-csi-capacity           (PM-13 to PM-15)
+#
+# NOTE: SRDF Replication Alerts (PM-16 to PM-18) are managed by the csm-replication Helm chart
+# since SRDF metrics are emitted by the csm-replication module.
+#
+# NOTE: Driver-level alerts (PM-01 to PM-15) are gated by both metrics.enabled and
+# metrics.prometheusRule.enabled. Resiliency alerts (RES-01 to RES-04) are defined
+# separately under the podmon section and are gated independently by podmon.metrics.prometheusRule.enabled.
+# This allows operators to enable driver alerts without resiliency alerts, or vice versa.
+#
+# PERFORMANCE TARGETS (BR JA-23013):
+# Critical alerts use 1m for: duration to meet the 120s BR target.
+# Warning and capacity alerts use longer durations (5m-10m) as documented exceptions
+# to reduce false positives on transient conditions.
+#
+# All thresholds configurable via .Values.metrics.prometheusRule.*
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ .Release.Name }}-metrics-rules
+  name: {{ .Release.Name }}-powermax-csi-alerts
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}
+    app: {{ .Release.Name }}-controller
 spec:
   groups:
-    - name: {{ .Release.Name }}.rules
-      rules: []
+    # ── Group 1: Volume Operation Failure Alerts (PM-01 to PM-08) ──
+    # Metric: dell_csi_operation_failure_total (CounterVec)
+    # Labels: array_id, operation, error_code
+    # Source: service/interceptors.go
+    # Behavior: Alert fires when failure count exceeds threshold in 5m window.
+    # for: 1m meets the 120s BR latency target.
+    - name: powermax-csi-volume-operations
+      interval: 30s
+      rules:
+        # PM-01
+        - alert: PowerMaxCreateVolumeFailure
+          expr: increase(dell_csi_operation_failure_total{operation="CreateVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+          for: 1m
+          labels:
+            severity: warning
+            platform: powermax
+            component: csi-driver
+            alert_id: PM-01
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax CreateVolume failures detected on array {{`{{ $labels.array_id }}`}}"
+            description: "CreateVolume operation failed {{`{{ printf \"%.0f\" $value }}`}} times in the last 5 minutes on array {{`{{ $labels.array_id }}`}} with error code {{`{{ $labels.error_code }}`}}. Threshold: {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }} failures."
+            runbook_url: ""
+
+        # PM-02
+        - alert: PowerMaxDeleteVolumeFailure
+          expr: increase(dell_csi_operation_failure_total{operation="DeleteVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+          for: 1m
+          labels:
+            severity: warning
+            platform: powermax
+            component: csi-driver
+            alert_id: PM-02
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax DeleteVolume failures detected on array {{`{{ $labels.array_id }}`}}"
+            description: "DeleteVolume operation failed {{`{{ printf \"%.0f\" $value }}`}} times in the last 5 minutes on array {{`{{ $labels.array_id }}`}} with error code {{`{{ $labels.error_code }}`}}. Threshold: {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }} failures."
+            runbook_url: ""
+
+        # PM-03
+        - alert: PowerMaxControllerPublishFailure
+          expr: increase(dell_csi_operation_failure_total{operation="ControllerPublishVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+          for: 1m
+          labels:
+            severity: warning
+            platform: powermax
+            component: csi-driver
+            alert_id: PM-03
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax ControllerPublishVolume failures detected on array {{`{{ $labels.array_id }}`}}"
+            description: "ControllerPublishVolume operation failed {{`{{ printf \"%.0f\" $value }}`}} times in the last 5 minutes on array {{`{{ $labels.array_id }}`}} with error code {{`{{ $labels.error_code }}`}}. Threshold: {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }} failures."
+            runbook_url: ""
+
+        # PM-04
+        - alert: PowerMaxControllerUnpublishFailure
+          expr: increase(dell_csi_operation_failure_total{operation="ControllerUnpublishVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+          for: 1m
+          labels:
+            severity: warning
+            platform: powermax
+            component: csi-driver
+            alert_id: PM-04
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax ControllerUnpublishVolume failures detected on array {{`{{ $labels.array_id }}`}}"
+            description: "ControllerUnpublishVolume operation failed {{`{{ printf \"%.0f\" $value }}`}} times in the last 5 minutes on array {{`{{ $labels.array_id }}`}} with error code {{`{{ $labels.error_code }}`}}. Threshold: {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }} failures."
+            runbook_url: ""
+
+        # PM-05 — NodeStageVolume (corrected: CreateSnapshot was incorrect per ER spec)
+        - alert: PowerMaxNodeStageFailure
+          expr: increase(dell_csi_operation_failure_total{operation="NodeStageVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+          for: 1m
+          labels:
+            severity: warning
+            platform: powermax
+            component: csi-driver
+            alert_id: PM-05
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax NodeStageVolume failures detected on array {{`{{ $labels.array_id }}`}}"
+            description: "NodeStageVolume operation failed {{`{{ printf \"%.0f\" $value }}`}} times in the last 5 minutes on array {{`{{ $labels.array_id }}`}} with error code {{`{{ $labels.error_code }}`}}. Threshold: {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }} failures."
+            runbook_url: ""
+
+        # PM-06 — NodeUnstageVolume (corrected: DeleteSnapshot was incorrect per ER spec)
+        - alert: PowerMaxNodeUnstageFailure
+          expr: increase(dell_csi_operation_failure_total{operation="NodeUnstageVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+          for: 1m
+          labels:
+            severity: warning
+            platform: powermax
+            component: csi-driver
+            alert_id: PM-06
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax NodeUnstageVolume failures detected on array {{`{{ $labels.array_id }}`}}"
+            description: "NodeUnstageVolume operation failed {{`{{ printf \"%.0f\" $value }}`}} times in the last 5 minutes on array {{`{{ $labels.array_id }}`}} with error code {{`{{ $labels.error_code }}`}}. Threshold: {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }} failures."
+            runbook_url: ""
+
+        # PM-07
+        - alert: PowerMaxNodePublishFailure
+          expr: increase(dell_csi_operation_failure_total{operation="NodePublishVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+          for: 1m
+          labels:
+            severity: warning
+            platform: powermax
+            component: csi-driver
+            alert_id: PM-07
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax NodePublishVolume failures detected on array {{`{{ $labels.array_id }}`}}"
+            description: "NodePublishVolume operation failed {{`{{ printf \"%.0f\" $value }}`}} times in the last 5 minutes on array {{`{{ $labels.array_id }}`}} with error code {{`{{ $labels.error_code }}`}}. Threshold: {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }} failures."
+            runbook_url: ""
+
+        # PM-08
+        - alert: PowerMaxNodeUnpublishFailure
+          expr: increase(dell_csi_operation_failure_total{operation="NodeUnpublishVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+          for: 1m
+          labels:
+            severity: warning
+            platform: powermax
+            component: csi-driver
+            alert_id: PM-08
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax NodeUnpublishVolume failures detected on array {{`{{ $labels.array_id }}`}}"
+            description: "NodeUnpublishVolume operation failed {{`{{ printf \"%.0f\" $value }}`}} times in the last 5 minutes on array {{`{{ $labels.array_id }}`}} with error code {{`{{ $labels.error_code }}`}}. Threshold: {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }} failures."
+            runbook_url: ""
+
+    # ── Group 2: Driver Health & Resource Alerts (PM-09 to PM-12) ──
+    - name: powermax-csi-driver-health
+      interval: 30s
+      rules:
+        # PM-09 — Driver pod unavailable: uses absent() on the controller-scoped driver uptime metric.
+        # Source: service/collectors/driver_health_collector.go
+        # Filter by instance_type="controller" so that running node pods do not mask a controller outage.
+        # for: 5m meets the ER requirement; absent() fires after 5 continuous minutes with no metric.
+        # namespace static label is required because absent() only carries labels from its selector;
+        # without it the alert has no namespace label and cannot be routed by AlertmanagerConfig CRD
+        # routes that inject a mandatory namespace matcher (standard Prometheus Operator behaviour).
+        - alert: PowerMaxDriverPodUnavailable
+          expr: absent(dell_csi_driver_uptime_seconds{instance_type="controller"})
+          for: 5m
+          labels:
+            severity: critical
+            platform: powermax
+            component: csi-driver
+            alert_id: PM-09
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax CSI driver pod is unavailable"
+            description: "The PowerMax CSI driver has not reported metrics for 5 minutes. The driver pod may be down or crash-looping. Check kubectl get pods -n {{ .Release.Namespace }}."
+            runbook_url: ""
+
+        # PM-10 — Driver high CPU.
+        # Source: service/collectors/driver_health_collector.go
+        # Metric emits values 0-100; threshold stored as integer percentage.
+        # NOTE: 5m duration is an intentional exception to the 120s BR target to reduce false positives.
+        - alert: PowerMaxDriverHighCPU
+          expr: dell_csi_driver_cpu_usage_percent > {{ .Values.metrics.prometheusRule.cpuWarningThreshold | default 80 }}
+          for: 5m
+          labels:
+            severity: warning
+            platform: powermax
+            component: csi-driver
+            alert_id: PM-10
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax CSI driver high CPU usage"
+            description: "PowerMax CSI driver CPU usage exceeds {{ .Values.metrics.prometheusRule.cpuWarningThreshold | default 80 }}% threshold. Current value: {{`{{ printf \"%.1f\" $value }}`}}%."
+            runbook_url: ""
+
+        # PM-11 — Driver high memory.
+        # Source: service/collectors/driver_health_collector.go
+        # NOTE: 5m duration is an intentional exception to the 120s BR target to reduce false positives.
+        - alert: PowerMaxDriverHighMemory
+          expr: dell_csi_driver_memory_usage_bytes > {{ .Values.metrics.prometheusRule.memoryWarningThreshold | default 2147483648 }}
+          for: 5m
+          labels:
+            severity: warning
+            platform: powermax
+            component: csi-driver
+            alert_id: PM-11
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax CSI driver high memory usage"
+            description: "PowerMax CSI driver memory usage exceeds {{ .Values.metrics.prometheusRule.memoryWarningThreshold | default 2147483648 }} bytes (default: 2 GiB). Current value: {{`{{ $value }}`}} bytes."
+            runbook_url: ""
+
+        # PM-12 — Unisphere API error rate.
+        # Source: pkg/metrics/powermax_api_observer.go
+        # Uses increase() to count failures in window; clamp_min(1) prevents division by zero.
+        # NOTE: 5m duration is an intentional exception to the 120s BR target to reduce false positives.
+        - alert: PowerMaxAPIErrorRateHigh
+          expr: |
+            (
+              sum without(status)(increase(dell_csi_api_call_total{status="failure"}[{{ .Values.metrics.prometheusRule.apiErrorRateWindow | default "5m" }}]))
+              /
+              clamp_min(sum without(status)(increase(dell_csi_api_call_total[{{ .Values.metrics.prometheusRule.apiErrorRateWindow | default "5m" }}])), 1)
+            ) * 100 > {{ .Values.metrics.prometheusRule.apiErrorRateThreshold | default 10 }}
+          for: 5m
+          labels:
+            severity: warning
+            platform: powermax
+            component: csi-driver
+            alert_id: PM-12
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax Unisphere API error rate high on array {{`{{ $labels.array_id }}`}}"
+            description: "Unisphere API error rate exceeds {{ .Values.metrics.prometheusRule.apiErrorRateThreshold | default 10 }}% threshold on array {{`{{ $labels.array_id }}`}}. Current rate: {{`{{ printf \"%.1f\" $value }}`}}%."
+            runbook_url: ""
+
+    # ── Group 3: Capacity Alerts (PM-13 to PM-15) ──
+    - name: powermax-csi-capacity
+      interval: 30s
+      rules:
+        # PM-13 — Storage group capacity warning.
+        # Source: service/collectors/storagegroup_collector.go
+        # Labels: {array_id, storage_group} (corrected from storage_group_name per ER)
+        # NOTE: 10m duration is an exception to the 120s BR target; capacity changes slowly.
+        - alert: PowerMaxStorageGroupCapacityWarning
+          expr: dell_csi_storagegroup_utilization_ratio * 100 > {{ .Values.metrics.prometheusRule.storageGroupCapacityWarning | default 80 }}
+          for: 10m
+          labels:
+            severity: warning
+            platform: powermax
+            component: csi-driver
+            alert_id: PM-13
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax storage group {{`{{ $labels.storage_group }}`}} capacity warning on array {{`{{ $labels.array_id }}`}}"
+            description: "Storage group {{`{{ $labels.storage_group }}`}} on array {{`{{ $labels.array_id }}`}} utilization exceeds {{ .Values.metrics.prometheusRule.storageGroupCapacityWarning | default 80 }}% warning threshold."
+            runbook_url: ""
+
+        # PM-14 — Storage group capacity critical.
+        # for: 1m meets the 120s BR target for critical capacity alerts.
+        - alert: PowerMaxStorageGroupCapacityCritical
+          expr: dell_csi_storagegroup_utilization_ratio * 100 > {{ .Values.metrics.prometheusRule.storageGroupCapacityCritical | default 90 }}
+          for: 1m
+          labels:
+            severity: critical
+            platform: powermax
+            component: csi-driver
+            alert_id: PM-14
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax storage group {{`{{ $labels.storage_group }}`}} capacity critical on array {{`{{ $labels.array_id }}`}}"
+            description: "Storage group {{`{{ $labels.storage_group }}`}} on array {{`{{ $labels.array_id }}`}} utilization exceeds {{ .Values.metrics.prometheusRule.storageGroupCapacityCritical | default 90 }}% critical threshold. Immediate action required."
+            runbook_url: ""
+
+        # PM-15 — SRP snapshot capacity warning (SRP-level; approved permanent solution per PM-15 note).
+        # Source: service/collectors/srp_collector.go
+        # Labels: {array_id, srp_id} (corrected from srp_name per ER)
+        # NOTE: sum by(array_id, srp_id) deduplicates when multiple controller replicas scrape same array.
+        # namespace static label is required because sum by(array_id, srp_id) drops all other labels
+        # including namespace; without it the alert has no namespace label and cannot be routed by
+        # AlertmanagerConfig CRD routes that inject a mandatory namespace matcher (standard Prometheus
+        # Operator behaviour).
+        # NOTE: 10m duration is an exception to the 120s BR target; snapshot capacity changes slowly.
+        - alert: PowerMaxSRPSnapshotCapacityWarning
+          expr: |
+            (
+              sum by(array_id, srp_id) (dell_powermax_srp_capacity_bytes{capacity_type="snapshot"})
+              /
+              sum by(array_id, srp_id) (dell_powermax_srp_capacity_bytes{capacity_type="total"})
+            ) * 100 > {{ .Values.metrics.prometheusRule.srpSnapshotCapacityWarning | default 80 }}
+          for: 10m
+          labels:
+            severity: warning
+            platform: powermax
+            component: csi-driver
+            alert_id: PM-15
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax SRP {{`{{ $labels.srp_id }}`}} snapshot capacity warning on array {{`{{ $labels.array_id }}`}}"
+            description: "SRP {{`{{ $labels.srp_id }}`}} on array {{`{{ $labels.array_id }}`}} snapshot capacity exceeds {{ .Values.metrics.prometheusRule.srpSnapshotCapacityWarning | default 80 }}% threshold."
+            runbook_url: ""
+
 {{- end }}
 {{- end }}
+{{- end }}
+{{- if and .Values.podmon .Values.podmon.enabled (hasKey .Values.podmon "metrics") .Values.podmon.metrics.enabled (hasKey .Values.podmon.metrics "prometheusRule") (eq .Values.podmon.metrics.prometheusRule.enabled true) }}
+---
+# PrometheusRule for PowerMax CSM Resiliency alerting rules.
+# Created when podmon.enabled AND podmon.metrics.prometheusRule.enabled are true.
+# Requires the Prometheus Operator CRDs to be installed in the cluster.
+#
+# CSM Resiliency Alerts (RES-01 to RES-04):
+# Cross-platform PodMon failover and connectivity alerts scoped to this driver.
+# These rules evaluate metrics emitted by PodMon sidecars running in this driver's pods.
+#
+# All thresholds configurable via .Values.podmon.metrics.prometheusRule.*
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-resiliency-alerts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  groups:
+    - name: csm-resiliency-powermax
+      interval: 30s
+      rules:
+        # RES-01 — Pod failure detected due to node unreachable
+        - alert: CSMResiliencyPodFailureDetected
+          expr: increase(dell_csm_resiliency_failover_total{reason="node_unreachable",driver="csi-powermax"}[5m]) > 0
+          for: 0m
+          labels:
+            severity: warning
+            component: csm-resiliency
+            platform: powermax
+            driver: csi-powermax
+            alert_id: RES-01
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Resiliency pod failure detected for driver {{`{{ $labels.driver }}`}}"
+            description: "Pod failure detected due to node unreachable for driver {{`{{ $labels.driver }}`}}."
+            runbook_url: ""
+
+        # RES-02 — Connectivity success ratio below threshold
+        - alert: CSMResiliencyConnectivityLost
+          expr: dell_csm_resiliency_connectivity_success_ratio{driver="csi-powermax"} * 100 < {{ .Values.podmon.metrics.prometheusRule.connectivitySuccessRatio | default 90 }}
+          for: 2m
+          labels:
+            severity: critical
+            component: csm-resiliency
+            platform: powermax
+            driver: csi-powermax
+            alert_id: RES-02
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Resiliency connectivity lost for driver {{`{{ $labels.driver }}`}}"
+            description: "Volume connectivity success ratio for driver {{`{{ $labels.driver }}`}} is below {{ .Values.podmon.metrics.prometheusRule.connectivitySuccessRatio | default 90 }}%."
+            runbook_url: ""
+
+        # RES-03 — Automated failover triggered successfully (info: expected behavior)
+        - alert: CSMResiliencyFailoverTriggered
+          expr: increase(dell_csm_resiliency_failover_total{status="success",driver="csi-powermax"}[5m]) > 0
+          for: 0m
+          labels:
+            severity: info
+            component: csm-resiliency
+            platform: powermax
+            driver: csi-powermax
+            alert_id: RES-03
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Resiliency automated failover triggered for driver {{`{{ $labels.driver }}`}}"
+            description: "Automated pod failover operation initiated successfully for driver {{`{{ $labels.driver }}`}}. Reason: {{`{{ $labels.reason }}`}}."
+            runbook_url: ""
+
+        # RES-04 — Automated failover failed
+        - alert: CSMResiliencyFailoverFailed
+          expr: increase(dell_csm_resiliency_failover_total{status="failure",driver="csi-powermax"}[5m]) > 0
+          for: 0m
+          labels:
+            severity: critical
+            component: csm-resiliency
+            platform: powermax
+            driver: csi-powermax
+            alert_id: RES-04
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Resiliency failover failed for driver {{`{{ $labels.driver }}`}}"
+            description: "Automated pod failover operation failed for driver {{`{{ $labels.driver }}`}}. Reason: {{`{{ $labels.reason }}`}}. Manual intervention may be required."
+            runbook_url: ""
 {{- end }}

--- a/charts/csi-powermax/templates/servicemonitor.yaml
+++ b/charts/csi-powermax/templates/servicemonitor.yaml
@@ -61,3 +61,32 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- if and (eq .Values.replication.enabled true) (hasKey .Values.replication "metrics") }}
+{{- if and (eq .Values.replication.metrics.enabled true) (hasKey .Values.replication.metrics "serviceMonitor") }}
+{{- if eq .Values.replication.metrics.serviceMonitor.enabled true }}
+---
+# ServiceMonitor for replication metrics Prometheus Operator integration.
+# Created when replication.metrics.enabled AND replication.metrics.serviceMonitor.enabled are true.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-replication-metrics-monitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-controller
+  endpoints:
+    - port: repl-metrics
+      interval: {{ .Values.replication.metrics.serviceMonitor.interval | default "30s" }}
+      path: /metrics
+      {{- if .Values.replication.metrics.tlsCertSecret }}
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: {{ .Values.replication.metrics.serviceMonitor.insecureSkipVerify | default false }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/csi-powermax/values.yaml
+++ b/charts/csi-powermax/values.yaml
@@ -16,6 +16,7 @@ global:
   # Please refer to the doc website about a
   # detailed explanation of each configuration parameter
   # X_CSI_MANAGED_ARRAYS: Serial ID of the arrays that will be used for provisioning
+  # For Multi-Array Zone support, include all arrays managed by this driver instance.
   # Default value: None
   # Examples: "000000000001,000000000002"
   managedArrays: "000000000001,000000000002"
@@ -50,6 +51,22 @@ global:
   #   ""      - Automatic selection of transport protocol
   # Default value: "" <empty>
   transportProtocol: ""
+  # "hostManagementMode" controls how the driver manages host objects on PowerMax arrays.
+  # Allowed values:
+  #   "create" - Default. The driver creates new host objects for each node.
+  #   "adopt"  - The driver discovers and adopts pre-existing BFS (Boot from SAN) host
+  #              objects by matching FC WWPN initiators. Use this mode for nodes that
+  #              boot from PowerMax arrays with pre-configured host objects.
+  # Default value: "create"
+  hostManagementMode: "create"
+  # "hostAdoptionMinOverlapRatio" controls the minimum overlap ratio for host adoption validation.
+  # Allowed values: 0.0 to 1.0
+  #   - 0.5 (default) - Directional relaxation with >50% majority for larger HBA counts
+  #   - 0.75 - Stricter threshold for regulated environments
+  #   - 1.0 - Strict match (100% coverage required for all HBA counts)
+  # Note: For 2-WWPN systems, 100% coverage is always required regardless of this setting.
+  # Default value: 0.5
+  hostAdoptionMinOverlapRatio: 0.5
 
   # proxyAuthToken: Shared authentication token between the CSI driver and the reverse proxy.
   # When enabled, the driver sends the token in an X-Proxy-Auth-Token header, and the
@@ -384,6 +401,7 @@ node:
 
   # Topology control provides a way to filter topology keys
   # Please refer to the doc website about a detailed explanation on its configuration and usage
+  # REQUIRED for Multi-Array Zone Support.
   topologyControl:
     # enabled: Enable/Disable Topology Control
     # Allowed values:
@@ -514,6 +532,35 @@ replication:
   # Examples: "replication.storage.dell.com", "rdf.storage.dell.com"
   replicationPrefix: "replication.storage.dell.com"
 
+  # Metrics configuration for replication sidecar
+  metrics:
+    # enabled: Enable/Disable replication metrics endpoint on the dell-csi-replicator sidecar
+    # Default value: false
+    enabled: false
+    # port: Port for the replication metrics endpoint
+    # Default value: 8445
+    port: 8445
+    # tlsCertSecret: Name of the TLS secret for replication metrics. Leave empty to disable TLS.
+    # Default value: ""
+    tlsCertSecret: ""
+    collection:
+      # interval: How frequently replication metrics are collected
+      # Default value: "30s"
+      interval: 30s
+    serviceMonitor:
+      # enabled: Enable/Disable ServiceMonitor for Prometheus Operator
+      # Default value: false
+      enabled: false
+      # interval: Scrape interval for the ServiceMonitor
+      # Default value: "30s"
+      interval: 30s
+      # scrapeTimeout: Scrape timeout for the ServiceMonitor
+      # Default value: ""
+      scrapeTimeout: ""
+      # insecureSkipVerify: Skip TLS verification for ServiceMonitor
+      # Default value: false
+      insecureSkipVerify: false
+
 # CSM module attributes
 # Set this to true to enable migration
 # Allowed values:
@@ -560,6 +607,30 @@ storageCapacity:
   # Default value: 5m
   pollInterval: 5m
 
+# Multi-Array Zone Configuration
+# Settings for multi-array zones where multiple PowerMax arrays share the same zone label.
+# The driver uses capacity-based array selection to distribute volumes across arrays.
+# multiArrayZone: Configuration for Multi-Array Zone Support
+# This feature allows multiple PowerMax arrays to be configured within the same
+# Kubernetes availability zone. The driver will automatically balance provisioning
+# requests based on free capacity and array health.
+multiArrayZone:
+  # capacityPollInterval: Interval at which the background capacity poller refreshes
+  # per-array free-capacity utilization and health for multi-array zones.
+  # Accepts a Go duration string (e.g. "5m", "1m", "30s").
+  # Also defines the staleness window: an array is marked unavailable if no successful
+  # poll has completed within the last interval.
+  # Allowed values: Any valid Go duration string
+  # Default value: "5m"
+  capacityPollInterval: "5m"
+  # capacityThresholdFull: Capacity utilization percentage (0-100) at which an array
+  # is considered full and excluded from selection. A warning event is emitted when
+  # utilization crosses (threshold - 10) percent (e.g. warn at 90% when full=100%,
+  # warn at 80% when full=90%).
+  # Allowed values: 0-100
+  # Default value: 100
+  capacityThresholdFull: 100
+
 # VMware/vSphere virtualization support
 # set enable to true, if you to enable VMware virtualized environment support via RDM
 # Allowed Values:
@@ -588,6 +659,24 @@ podmon:
   # Any valid and free port.
   # Default value: 8083
   podmonAPIPort: 8083
+  # podmonAPIToken: Shared secret token for authenticating podmon API requests
+  # When set, the driver will require Bearer token authentication on /array-status endpoints
+  # Allowed values: Any string (recommend using a randomly generated token)
+  # Security note: podmon API is HTTP; use this token only on trusted cluster-internal networks.
+  # For production, use podmonAPITokenSecret to source this value from a Kubernetes Secret.
+  # Default value: "" (empty - authentication disabled for backward compatibility)
+  podmonAPIToken: ""
+  # podmonAPITokenSecret: Kubernetes Secret containing the podmon API token
+  # When set, the token will be sourced from the specified Secret instead of podmonAPIToken value
+  # Allowed values:
+  #   name: Secret name (required)
+  #   key: Secret key containing the token (required, default: "podmon-api-token")
+  # Example:
+  #   podmonAPITokenSecret:
+  #     name: my-podmon-secret
+  #     key: api-token
+  # Default value: null (use podmonAPIToken value instead)
+  podmonAPITokenSecret: null
   enabled: false
   controller:
     args:
@@ -639,6 +728,18 @@ podmon:
       interval: 30s
       scrapeTimeout: ""
       insecureSkipVerify: false
+    # prometheusRule: Controls optional Prometheus Operator PrometheusRule creation for resiliency alerts.
+    prometheusRule:
+      # enabled: When true, a PrometheusRule CR is created for resiliency alerting rules.
+      # Type: bool
+      # Default: true
+      # Effect: Requires the Prometheus Operator CRDs to be installed in the cluster.
+      enabled: true
+      # connectivitySuccessRatio: Minimum acceptable connectivity success ratio as percentage (0-100).
+      # Used by RES-02 (CSMResiliencyConnectivityLost) alert threshold.
+      # Type: integer
+      # Default: 90 (alert fires when connectivity drops below 90%)
+      connectivitySuccessRatio: 90
 
 # metrics: configuration for driver metrics and monitoring
 metrics:
@@ -716,10 +817,37 @@ metrics:
     # Default: false
     insecureSkipVerify: false
 
-  # prometheusRule: Controls optional Prometheus Operator PrometheusRule creation.
   prometheusRule:
-    # enabled: When true, a PrometheusRule CR is created for alerting/recording rules.
-    # Type: bool
-    # Default: false
-    # Effect: Requires the Prometheus Operator CRDs to be installed in the cluster.
+    # enabled: When true, a PrometheusRule CR is created for the 15 PowerMax CSI driver alert rules.
+    # Requires the Prometheus Operator CRDs (monitoring.coreos.com/v1) to be installed in the cluster.
+    # Type: bool — Default: false
     enabled: false
+    # volumeOperationFailureThreshold: Cumulative failure count threshold for volume operations.
+    # Used by PM-01 to PM-08. Alert fires when increase() in 5m window exceeds this count.
+    # Type: integer — Default: 3
+    volumeOperationFailureThreshold: 3
+    # cpuWarningThreshold: CPU usage threshold as integer percentage (0-100). Used by PM-10.
+    # Type: integer — Default: 80
+    cpuWarningThreshold: 80
+    # memoryWarningThreshold: Memory usage threshold in bytes. Used by PM-11.
+    # Type: integer — Default: 2147483648 (2 GiB)
+    memoryWarningThreshold: 2147483648
+    # apiErrorRateThreshold: Unisphere API error rate threshold as integer percentage (0-100). Used by PM-12.
+    # Type: integer — Default: 10
+    apiErrorRateThreshold: 10
+    # apiErrorRateWindow: Time window for API error rate calculation. Used by PM-12.
+    # Type: string (Prometheus duration) — Default: "5m"
+    apiErrorRateWindow: "5m"
+    # storageGroupCapacityWarning: Storage group utilization warning threshold as integer percentage (0-100).
+    # Used by PM-13. Labels: {array_id, storage_group}.
+    # Type: integer — Default: 80
+    storageGroupCapacityWarning: 80
+    # storageGroupCapacityCritical: Storage group utilization critical threshold as integer percentage (0-100).
+    # Used by PM-14. Labels: {array_id, storage_group}.
+    # Type: integer — Default: 90
+    storageGroupCapacityCritical: 90
+    # srpSnapshotCapacityWarning: SRP snapshot capacity warning threshold as integer percentage (0-100).
+    # Used by PM-15. SRP-level monitoring (per-SG snapshot metric not required per product management decision).
+    # Labels: {array_id, srp_id}.
+    # Type: integer — Default: 80
+    srpSnapshotCapacityWarning: 80

--- a/charts/csi-powerstore/templates/controller.yaml
+++ b/charts/csi-powerstore/templates/controller.yaml
@@ -155,6 +155,11 @@ rules:
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]
+  {{- if eq (include "csi-powerstore.isMetricsEnabled" .) "true" }}
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  {{- end }}
 ---
 
 kind: ClusterRoleBinding
@@ -415,11 +420,34 @@ spec:
               value: /powerstore-config-params
             - name: X_CSI_REPLICATION_CONFIG_FILE_NAME
               value: driver-config-params.yaml
+{{- if and .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled }}
+            - name: X_CSI_REPLICATION_METRICS_ENABLED
+              value: "true"
+            - name: X_CSI_REPLICATION_METRICS_PORT
+              value: "{{ .Values.controller.replication.metrics.port | default 8445 }}"
+            - name: X_CSI_REPLICATION_METRICS_COLLECTION_INTERVAL
+              value: "{{ .Values.controller.replication.metrics.collection.interval | default "30s" }}"
+{{- if .Values.controller.replication.metrics.tlsCertSecret }}
+            - name: X_CSI_REPLICATION_METRICS_TLS_CERT_FILE
+              value: /etc/replication-metrics-tls/tls.crt
+            - name: X_CSI_REPLICATION_METRICS_TLS_KEY_FILE
+              value: /etc/replication-metrics-tls/tls.key
+{{- end }}
+          ports:
+            - name: repl-metrics
+              containerPort: {{ .Values.controller.replication.metrics.port | default 8445 }}
+              protocol: TCP
+{{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi
             - name: powerstore-config-params
               mountPath: /powerstore-config-params
+{{- if and .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled .Values.controller.replication.metrics.tlsCertSecret }}
+            - name: replication-metrics-tls
+              mountPath: /etc/replication-metrics-tls
+              readOnly: true
+{{- end }}
         {{- end }}
         {{- end }}
         {{- if hasKey .Values.controller "healthMonitor" }}
@@ -520,6 +548,8 @@ spec:
               value: {{ .Values.externalAccess }}
             - name: X_CSI_POWERSTORE_EXCLUSIVE_ACCESS
               value: "{{ .Values.exclusiveAccess }}"
+            - name: X_CSI_POWERSTORE_NFS_AUTO_SELECT
+              value: "{{ .Values.nfsAutoSelect }}"
             - name: X_CSI_NFS_ACLS
               value: "{{ .Values.nfsAcls }}"
             {{- if hasKey .Values "disasterRecovery" }}
@@ -567,6 +597,16 @@ spec:
             {{- end }}
             - name: X_CSI_PODMON_API_PORT
               value: "{{ .Values.podmonAPIPort }}"
+            {{- if .Values.podmonAPITokenSecret }}
+            - name: X_CSI_PODMON_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.podmonAPITokenSecret.name }}
+                  key: {{ .Values.podmonAPITokenSecret.key | default "podmon-api-token" }}
+            {{- else if .Values.podmonAPIToken }}
+            - name: X_CSI_PODMON_API_TOKEN
+              value: "{{ .Values.podmonAPIToken }}"
+            {{- end }}
             - name: X_CSI_PODMON_ARRAY_CONNECTIVITY_TIMEOUT
               value: {{ .Values.podmon.arrayConnectivityTimeout | default "10s" | quote}}
             {{- if hasKey .Values.controller "replication" }}
@@ -586,6 +626,12 @@ spec:
             {{- if hasKey .Values.controller "csiAddonsReplication" }}
             - name: X_CSI_CSIADDONS_REPLICATION_ENABLED
               value: "{{ .Values.controller.csiAddonsReplication.enabled }}"
+            {{- end }}
+            {{- if hasKey .Values.disasterRecovery "monitor" }}
+            - name: X_CSI_ALERT_MONITOR_ENABLED
+              value: "{{ .Values.disasterRecovery.monitor.enabled | default true }}"
+            - name: X_CSI_ALERT_MONITOR_POLL_INTERVAL
+              value: "{{ .Values.disasterRecovery.monitor.pollInterval | default "5m" }}"
             {{- end }}
             - name: GOPOWERSTORE_DEBUG
               value: "true"
@@ -733,4 +779,11 @@ spec:
         - name: resiliency-metrics-tls
           secret:
             secretName: {{ .Values.podmon.metrics.tlsCertSecret }}
-        {{- end }}
+{{- end }}
+{{- if hasKey .Values.controller "replication" }}
+{{- if and .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled .Values.controller.replication.metrics.tlsCertSecret }}
+        - name: replication-metrics-tls
+          secret:
+            secretName: {{ .Values.controller.replication.metrics.tlsCertSecret }}
+{{- end }}
+{{- end }}

--- a/charts/csi-powerstore/templates/metrics-service.yaml
+++ b/charts/csi-powerstore/templates/metrics-service.yaml
@@ -41,3 +41,25 @@ spec:
       protocol: TCP
   type: ClusterIP
 {{- end }}
+
+{{- if and (hasKey .Values.controller "replication") .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled }}
+---
+# Service exposing the replication metrics endpoint for Prometheus scraping.
+# Created when controller.replication.enabled AND controller.replication.metrics.enabled are true.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-replication-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  selector:
+    name: {{ .Release.Name }}-controller
+  ports:
+    - name: repl-metrics
+      port: {{ .Values.controller.replication.metrics.port | default 8445 }}
+      targetPort: {{ .Values.controller.replication.metrics.port | default 8445 }}
+      protocol: TCP
+  type: ClusterIP
+{{- end }}

--- a/charts/csi-powerstore/templates/node.yaml
+++ b/charts/csi-powerstore/templates/node.yaml
@@ -337,6 +337,8 @@ spec:
               value: "{{ .Values.nfsClientPort | default 2050 }}"
             - name: X_CSI_NFS_SERVER_PORT
               value: "{{ .Values.nfsServerPort | default 2049 }}"
+            - name: X_CSI_POWERSTORE_NFS_AUTO_SELECT
+              value: "{{ .Values.nfsAutoSelect }}"
             {{- if eq .Values.connection.enableCHAP  true }}
             - name: X_CSI_POWERSTORE_ENABLE_CHAP
               value: "true"
@@ -370,6 +372,16 @@ spec:
             {{- end }}
             - name: X_CSI_PODMON_API_PORT
               value: "{{ .Values.podmonAPIPort }}"
+            {{- if .Values.podmonAPITokenSecret }}
+            - name: X_CSI_PODMON_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.podmonAPITokenSecret.name }}
+                  key: {{ .Values.podmonAPITokenSecret.key | default "podmon-api-token" }}
+            {{- else if .Values.podmonAPIToken }}
+            - name: X_CSI_PODMON_API_TOKEN
+              value: "{{ .Values.podmonAPIToken }}"
+            {{- end }}
             - name: X_CSI_PODMON_ARRAY_CONNECTIVITY_TIMEOUT
               value: {{ .Values.podmon.arrayConnectivityTimeout | default "10s" | quote }}
             {{- if hasKey .Values "fsCheck" }}
@@ -414,6 +426,11 @@ spec:
             {{- end }}
           ports:
             - containerPort: 2050
+            {{- if eq (include "csi-powerstore.isMetricsEnabled" .) "true" }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.port | default 8443 }}
+              protocol: TCP
+            {{- end }}
           volumeMounts:
             - name: driver-path
               mountPath: {{ .Values.kubeletConfigDir }}/plugins/{{ .Values.driverName }}

--- a/charts/csi-powerstore/templates/prometheusrule.yaml
+++ b/charts/csi-powerstore/templates/prometheusrule.yaml
@@ -1,0 +1,381 @@
+{{- if eq (include "csi-powerstore.isMetricsEnabled" .) "true" }}
+{{- if hasKey .Values.metrics "prometheusRule" }}
+{{- if eq .Values.metrics.prometheusRule.enabled true }}
+{{- $pr := .Values.metrics.prometheusRule }}
+{{- $apiWindow := default "5m" $pr.apiErrorRateWindow }}
+{{- $crashLoopWindow := default "15m" $pr.driverCrashLoopWindow }}
+{{- $crashLoopThreshold := default 3 $pr.driverCrashLoopRestartThreshold }}
+{{- $volOpFailureThreshold := default 3 $pr.volumeOperationFailureThreshold }}
+---
+# PrometheusRule for Prometheus Operator alerting rules.
+# Created when metrics.enabled AND metrics.prometheusRule.enabled are true.
+# Requires the Prometheus Operator CRDs to be installed in the cluster.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-powerstore-alerts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}
+    platform: powerstore
+    component: csi-driver
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  groups:
+    # Volume Operation Failure Alerts (PST-01 to PST-08)
+    - name: powerstore-csi-volume-operations
+      interval: 30s
+      rules:
+        # PST-01: CreateVolume failures
+        - alert: PowerStoreCreateVolumeFailure
+          expr: increase(dell_csi_operation_failure_total{operation="CreateVolume"}[5m]) > {{ $volOpFailureThreshold }}
+          for: 0m
+          labels:
+            severity: warning
+            platform: powerstore
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerStore CSI CreateVolume operation failures detected"
+            description: "Array {{`{{ $labels.global_id }}`}} has {{`{{ $value }}`}} CreateVolume failures in the last 5 minutes. Protocol: {{`{{ $labels.protocol }}`}}, Error Code: {{`{{ $labels.error_code }}`}}"
+            runbook_url: ""
+
+        # PST-02: DeleteVolume failures
+        - alert: PowerStoreDeleteVolumeFailure
+          expr: increase(dell_csi_operation_failure_total{operation="DeleteVolume"}[5m]) > {{ $volOpFailureThreshold }}
+          for: 0m
+          labels:
+            severity: warning
+            platform: powerstore
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerStore CSI DeleteVolume operation failures detected"
+            description: "Array {{`{{ $labels.global_id }}`}} has {{`{{ $value }}`}} DeleteVolume failures in the last 5 minutes. Protocol: {{`{{ $labels.protocol }}`}}, Error Code: {{`{{ $labels.error_code }}`}}"
+            runbook_url: ""
+
+        # PST-03: ControllerPublishVolume failures
+        - alert: PowerStoreControllerPublishVolumeFailure
+          expr: increase(dell_csi_operation_failure_total{operation="ControllerPublishVolume"}[5m]) > {{ $volOpFailureThreshold }}
+          for: 0m
+          labels:
+            severity: warning
+            platform: powerstore
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerStore CSI ControllerPublishVolume operation failures detected"
+            description: "Array {{`{{ $labels.global_id }}`}} has {{`{{ $value }}`}} ControllerPublishVolume failures in the last 5 minutes. Protocol: {{`{{ $labels.protocol }}`}}, Error Code: {{`{{ $labels.error_code }}`}}"
+            runbook_url: ""
+
+        # PST-04: ControllerUnpublishVolume failures
+        - alert: PowerStoreControllerUnpublishVolumeFailure
+          expr: increase(dell_csi_operation_failure_total{operation="ControllerUnpublishVolume"}[5m]) > {{ $volOpFailureThreshold }}
+          for: 0m
+          labels:
+            severity: warning
+            platform: powerstore
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerStore CSI ControllerUnpublishVolume operation failures detected"
+            description: "Array {{`{{ $labels.global_id }}`}} has {{`{{ $value }}`}} ControllerUnpublishVolume failures in the last 5 minutes. Protocol: {{`{{ $labels.protocol }}`}}, Error Code: {{`{{ $labels.error_code }}`}}"
+            runbook_url: ""
+
+        # PST-05: NodeStageVolume failures
+        - alert: PowerStoreNodeStageVolumeFailure
+          expr: increase(dell_csi_operation_failure_total{operation="NodeStageVolume"}[5m]) > {{ $volOpFailureThreshold }}
+          for: 0m
+          labels:
+            severity: warning
+            platform: powerstore
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerStore CSI NodeStageVolume operation failures detected"
+            description: "Array {{`{{ $labels.global_id }}`}} has {{`{{ $value }}`}} NodeStageVolume failures in the last 5 minutes. Protocol: {{`{{ $labels.protocol }}`}}, Error Code: {{`{{ $labels.error_code }}`}}"
+            runbook_url: ""
+
+        # PST-06: NodeUnstageVolume failures
+        - alert: PowerStoreNodeUnstageVolumeFailure
+          expr: increase(dell_csi_operation_failure_total{operation="NodeUnstageVolume"}[5m]) > {{ $volOpFailureThreshold }}
+          for: 0m
+          labels:
+            severity: warning
+            platform: powerstore
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerStore CSI NodeUnstageVolume operation failures detected"
+            description: "Array {{`{{ $labels.global_id }}`}} has {{`{{ $value }}`}} NodeUnstageVolume failures in the last 5 minutes. Protocol: {{`{{ $labels.protocol }}`}}, Error Code: {{`{{ $labels.error_code }}`}}"
+            runbook_url: ""
+
+        # PST-07: NodePublishVolume failures
+        - alert: PowerStoreNodePublishVolumeFailure
+          expr: increase(dell_csi_operation_failure_total{operation="NodePublishVolume"}[5m]) > {{ $volOpFailureThreshold }}
+          for: 0m
+          labels:
+            severity: warning
+            platform: powerstore
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerStore CSI NodePublishVolume operation failures detected"
+            description: "Array {{`{{ $labels.global_id }}`}} has {{`{{ $value }}`}} NodePublishVolume failures in the last 5 minutes. Protocol: {{`{{ $labels.protocol }}`}}, Error Code: {{`{{ $labels.error_code }}`}}"
+            runbook_url: ""
+
+        # PST-08: NodeUnpublishVolume failures
+        - alert: PowerStoreNodeUnpublishVolumeFailure
+          expr: increase(dell_csi_operation_failure_total{operation="NodeUnpublishVolume"}[5m]) > {{ $volOpFailureThreshold }}
+          for: 0m
+          labels:
+            severity: warning
+            platform: powerstore
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerStore CSI NodeUnpublishVolume operation failures detected"
+            description: "Array {{`{{ $labels.global_id }}`}} has {{`{{ $value }}`}} NodeUnpublishVolume failures in the last 5 minutes. Protocol: {{`{{ $labels.protocol }}`}}, Error Code: {{`{{ $labels.error_code }}`}}"
+            runbook_url: ""
+
+    # Driver Health & Resource Alerts (PST-09 to PST-14)
+    - name: powerstore-csi-driver-health
+      interval: 30s
+      rules:
+        # PST-09: Driver pod unavailable (critical)
+        # Checks each role separately and treats missing series as zero, so the alert
+        # fires when either the controller or the node metrics drop to zero for 5 minutes.
+        - alert: PowerStoreDriverPodUnavailable
+          expr: (count(dell_csi_driver_uptime_seconds{namespace="{{ .Release.Namespace }}",instance_type="controller"}) or on() vector(0)) == 0 or (count(dell_csi_driver_uptime_seconds{namespace="{{ .Release.Namespace }}",instance_type="node"}) or on() vector(0)) == 0
+          for: 5m
+          labels:
+            severity: critical
+            platform: powerstore
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerStore CSI driver metrics are unavailable"
+            description: "PowerStore CSI driver has zero controller instances or zero node instances reporting metrics for 5 minutes."
+            runbook_url: ""
+
+        # PST-10: Driver crash looping (warning)
+        # Using changes() instead of delta() for more reliable detection across staleness gaps
+        - alert: PowerStoreDriverCrashLooping
+          expr: changes(dell_csi_driver_restart_total[{{ $crashLoopWindow }}]) > {{ $crashLoopThreshold }}
+          for: 0m
+          labels:
+            severity: warning
+            platform: powerstore
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerStore CSI driver is crash looping"
+            description: "PowerStore CSI driver pod {{`{{ $labels.pod }}`}} (instance type: {{`{{ $labels.instance_type }}`}}) has restarted {{`{{ $value }}`}} times in the last {{ $crashLoopWindow }}, indicating a crash loop."
+            runbook_url: ""
+
+        # PST-11: Driver high memory usage (warning)
+        - alert: PowerStoreDriverHighMemoryUsage
+          expr: dell_csi_driver_memory_usage_bytes > {{ $pr.memoryWarningThreshold | default 2147483648 }}
+          for: 5m
+          labels:
+            severity: warning
+            platform: powerstore
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerStore CSI driver high memory usage"
+            description: "PowerStore CSI driver pod {{`{{ $labels.pod }}`}} on node {{`{{ $labels.node }}`}} has memory usage of {{`{{ $value }}`}} bytes (threshold: {{ $pr.memoryWarningThreshold | default 2147483648 }} bytes) for more than 5 minutes."
+            runbook_url: ""
+
+        # PST-12: Driver high CPU usage (warning)
+        - alert: PowerStoreDriverHighCPUUsage
+          expr: dell_csi_driver_cpu_usage_percent > {{ $pr.cpuWarningThreshold | default 80 }}
+          for: 5m
+          labels:
+            severity: warning
+            platform: powerstore
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerStore CSI driver high CPU usage"
+            description: "PowerStore CSI driver pod {{`{{ $labels.pod }}`}} on node {{`{{ $labels.node }}`}} has CPU usage of {{`{{ $value }}`}}% (threshold: {{ $pr.cpuWarningThreshold | default 80 }}%) for more than 5 minutes."
+            runbook_url: ""
+
+        # PST-13: High API error rate (warning)
+        # Division-by-zero guard: only fires when denominator > 0.
+        - alert: PowerStoreHighAPIErrorRate
+          expr: (rate(dell_csi_api_call_total{status="failure"}[{{ $apiWindow }}]) / ignoring(status) sum without(status) (rate(dell_csi_api_call_total[{{ $apiWindow }}]))) * 100 > {{ $pr.apiErrorRateThreshold | default 10 }} and ignoring(status) sum without(status) (rate(dell_csi_api_call_total[{{ $apiWindow }}])) > 0
+          for: 5m
+          labels:
+            severity: warning
+            platform: powerstore
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerStore API error rate elevated"
+            description: "PowerStore API error rate on array {{`{{ $labels.global_id }}`}} endpoint {{`{{ $labels.endpoint }}`}} ({{`{{ $labels.method }}`}}) is {{`{{ $value }}`}}% over the last {{ $apiWindow }} (threshold: {{ $pr.apiErrorRateThreshold | default 10 }}%)."
+            runbook_url: ""
+
+        # PST-14: Metrics stale (warning)
+        - alert: PowerStoreMetricsStale
+          expr: dell_powerstore_metrics_stale == 1
+          for: 5m
+          labels:
+            severity: warning
+            platform: powerstore
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerStore metrics collection is stale on array {{`{{ $labels.global_id }}`}}"
+            description: "PowerStore metrics collection has reported stale data for 5 minutes on array {{`{{ $labels.global_id }}`}}. The stale flag is set immediately on any collection failure, ensuring the alert fires even when the cache is empty."
+            runbook_url: ""
+
+        # PST-15: Authentication failure (critical)
+        - alert: PowerStoreAuthenticationFailure
+          expr: increase(dell_csi_operation_failure_total{error_code="auth_failure"}[5m]) > 0
+          for: 0m
+          labels:
+            severity: critical
+            platform: powerstore
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerStore authentication failures detected"
+            description: "Array {{`{{ $labels.global_id }}`}} has {{`{{ $value }}`}} authentication failures in the last 5 minutes for operation {{`{{ $labels.operation }}`}}. Check array credentials."
+            runbook_url: ""
+
+    # Appliance Capacity Alerts (PST-16 to PST-18)
+    - name: powerstore-csi-appliance-capacity
+      interval: 30s
+      rules:
+        # PST-16: Appliance capacity warning
+        - alert: PowerStoreApplianceCapacityWarning
+          expr: dell_powerstore_appliance_utilization_ratio * 100 > {{ $pr.applianceWarningThreshold | default 80 }}
+          for: 10m
+          labels:
+            severity: warning
+            platform: powerstore
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerStore appliance {{`{{ $labels.appliance_name }}`}} utilization is high"
+            description: 'PowerStore appliance {{`{{ $labels.appliance_name }}`}} on array {{`{{ $labels.global_id }}`}} has exceeded the warning utilization threshold at {{`{{ $value | printf "%.1f" }}`}}% (threshold: {{ $pr.applianceWarningThreshold | default 80 }}%).'
+            runbook_url: ""
+
+        # PST-16: Appliance capacity critical
+        - alert: PowerStoreApplianceCapacityCritical
+          expr: dell_powerstore_appliance_utilization_ratio * 100 > {{ $pr.applianceCriticalThreshold | default 90 }}
+          for: 10m
+          labels:
+            severity: critical
+            platform: powerstore
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerStore appliance {{`{{ $labels.appliance_name }}`}} utilization is critical"
+            description: 'PowerStore appliance {{`{{ $labels.appliance_name }}`}} on array {{`{{ $labels.global_id }}`}} has exceeded the critical utilization threshold at {{`{{ $value | printf "%.1f" }}`}}% (threshold: {{ $pr.applianceCriticalThreshold | default 90 }}%). Immediate action required.'
+            runbook_url: ""
+
+        # PST-17: Thin provisioning over-commitment
+        - alert: PowerStoreThinProvisioningOvercommitment
+          expr: (dell_powerstore_appliance_compression_ratio * dell_powerstore_appliance_utilization_ratio) > 1.0
+          for: 10m
+          labels:
+            severity: warning
+            platform: powerstore
+            component: csi-driver
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerStore thin provisioning over-commitment detected on array {{`{{ $labels.global_id }}`}}"
+            description: "PowerStore appliance {{`{{ $labels.appliance_name }}`}} on array {{`{{ $labels.global_id }}`}} has logical provisioned capacity exceeding physical total."
+            runbook_url: ""
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if and .Values.podmon .Values.podmon.enabled (hasKey .Values.podmon "metrics") .Values.podmon.metrics.enabled (hasKey .Values.podmon.metrics "prometheusRule") (eq .Values.podmon.metrics.prometheusRule.enabled true) }}
+---
+# PrometheusRule for PowerStore CSI Driver resiliency alerting rules.
+# Created when podmon.metrics.prometheusRule.enabled is true.
+# Requires the Prometheus Operator CRDs to be installed in the cluster.
+#
+# CSM Resiliency Alerts (RES-01 to RES-04):
+# Cross-platform PodMon failover and connectivity alerts scoped to this driver.
+# These rules evaluate metrics emitted by PodMon sidecars running in this driver's pods.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-resiliency-alerts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  groups:
+    - name: csm-resiliency-powerstore
+      interval: 30s
+      rules:
+        # RES-01 — Pod failure detected due to node unreachable
+        - alert: CSMResiliencyPodFailureDetected
+          expr: increase(dell_csm_resiliency_failover_total{reason="node_unreachable",driver="csi-powerstore"}[5m]) > 0
+          for: 0m
+          labels:
+            severity: warning
+            component: csm-resiliency
+            platform: powerstore
+            driver: csi-powerstore
+            alert_id: RES-01
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Resiliency pod failure detected for driver {{`{{ $labels.driver }}`}}"
+            description: "Pod failure detected due to node unreachable for driver {{`{{ $labels.driver }}`}}."
+            runbook_url: ""
+
+        # RES-02 — Connectivity success ratio below threshold
+        - alert: CSMResiliencyConnectivityLost
+          expr: dell_csm_resiliency_connectivity_success_ratio{driver="csi-powerstore"} * 100 < {{ .Values.podmon.metrics.prometheusRule.connectivitySuccessRatio | default 90 }}
+          for: 2m
+          labels:
+            severity: critical
+            component: csm-resiliency
+            platform: powerstore
+            driver: csi-powerstore
+            alert_id: RES-02
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Resiliency connectivity lost for driver {{`{{ $labels.driver }}`}}"
+            description: "Volume connectivity success ratio for driver {{`{{ $labels.driver }}`}} is below {{ .Values.podmon.metrics.prometheusRule.connectivitySuccessRatio | default 90 }}%."
+            runbook_url: ""
+
+        # RES-03 — Automated failover triggered successfully (info: expected behavior)
+        - alert: CSMResiliencyFailoverTriggered
+          expr: increase(dell_csm_resiliency_failover_total{status="success",driver="csi-powerstore"}[5m]) > 0
+          for: 0m
+          labels:
+            severity: info
+            component: csm-resiliency
+            platform: powerstore
+            driver: csi-powerstore
+            alert_id: RES-03
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Resiliency automated failover triggered for driver {{`{{ $labels.driver }}`}}"
+            description: "Automated pod failover operation initiated successfully for driver {{`{{ $labels.driver }}`}}. Reason: {{`{{ $labels.reason }}`}}."
+            runbook_url: ""
+
+        # RES-04 — Automated failover failed
+        - alert: CSMResiliencyFailoverFailed
+          expr: increase(dell_csm_resiliency_failover_total{status="failure",driver="csi-powerstore"}[5m]) > 0
+          for: 0m
+          labels:
+            severity: critical
+            component: csm-resiliency
+            platform: powerstore
+            driver: csi-powerstore
+            alert_id: RES-04
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Resiliency failover failed for driver {{`{{ $labels.driver }}`}}"
+            description: "Automated pod failover operation failed for driver {{`{{ $labels.driver }}`}}. Reason: {{`{{ $labels.reason }}`}}. Manual intervention may be required."
+            runbook_url: ""
+{{- end }}

--- a/charts/csi-powerstore/templates/servicemonitor.yaml
+++ b/charts/csi-powerstore/templates/servicemonitor.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-controller
+      name: {{ .Release.Name }}-controller
   endpoints:
     - port: metrics
       interval: {{ .Values.metrics.serviceMonitor.interval | default "30s" }}
@@ -48,7 +48,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-controller
+      name: {{ .Release.Name }}-controller
   endpoints:
     - port: metrics
       interval: {{ .Values.podmon.metrics.serviceMonitor.interval | default "30s" }}
@@ -62,5 +62,37 @@ spec:
         insecureSkipVerify: {{ .Values.podmon.metrics.serviceMonitor.insecureSkipVerify | default false }}
       {{- end }}
 {{- end }}
+{{- end }}
+{{- end }}
+
+{{- if and (hasKey .Values.controller "replication") .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled }}
+{{- if and (hasKey .Values.controller.replication.metrics "serviceMonitor") .Values.controller.replication.metrics.serviceMonitor.enabled }}
+---
+# ServiceMonitor for Prometheus Operator integration with the replication metrics endpoint.
+# Created when controller.replication.enabled AND controller.replication.metrics.enabled
+# AND controller.replication.metrics.serviceMonitor.enabled are true.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-replication-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  selector:
+    matchLabels:
+      name: {{ .Release.Name }}-controller
+  endpoints:
+    - port: repl-metrics
+      interval: {{ .Values.controller.replication.metrics.serviceMonitor.interval | default "30s" }}
+      {{- if .Values.controller.replication.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.controller.replication.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      path: /metrics
+      {{- if .Values.controller.replication.metrics.tlsCertSecret }}
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: {{ .Values.controller.replication.metrics.serviceMonitor.insecureSkipVerify | default false }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/csi-powerstore/tests/alert-rules-test.yaml
+++ b/charts/csi-powerstore/tests/alert-rules-test.yaml
@@ -1,0 +1,346 @@
+# PowerStore Alert Rules Test Suite
+# Tests all 18 alert rules with realistic mock data based on actual PowerStore metrics
+
+rule_files:
+  - alert-rules.yaml
+
+tests:
+  # Test Group 1: Volume Operation Failure Alerts (PST-01 to PST-08)
+  - interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{operation="CreateVolume",global_id="PSc26835c9a0ba",protocol="block",error_code="InternalError"}'
+        values: '0 0 0 0 5 5 5 5 5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerStoreCreateVolumeFailure
+        exp_alerts:
+          - exp_labels:
+              alertname: PowerStoreCreateVolumeFailure
+              component: csi-driver
+              severity: warning
+              platform: powerstore
+              operation: CreateVolume
+              global_id: PSc26835c9a0ba
+              error_code: InternalError
+              protocol: block
+            exp_annotations:
+              summary: "PowerStore CSI CreateVolume operation failures detected"
+              description: "Array PSc26835c9a0ba has 5 CreateVolume failures in the last 5 minutes. Protocol: block, Error Code: InternalError"
+              runbook_url: ""
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{operation="DeleteVolume",global_id="PSc26835c9a0ba",protocol="block",error_code="InternalError"}'
+        values: '0 0 0 0 3 3 3 3 3'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerStoreDeleteVolumeFailure
+        exp_alerts:
+          - exp_labels:
+              alertname: PowerStoreDeleteVolumeFailure
+              component: csi-driver
+              severity: warning
+              platform: powerstore
+              operation: DeleteVolume
+              global_id: PSc26835c9a0ba
+              error_code: InternalError
+              protocol: block
+            exp_annotations:
+              summary: "PowerStore CSI DeleteVolume operation failures detected"
+              description: "Array PSc26835c9a0ba has 3 DeleteVolume failures in the last 5 minutes. Protocol: block, Error Code: InternalError"
+              runbook_url: ""
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{operation="ListVolumes",global_id="PSc26835c9a0ba",protocol="block",error_code="InternalError"}'
+        values: '0 0 0 0 10 10 10 10 10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerStoreCreateVolumeFailure
+        exp_alerts: []  # Should NOT fire - ListVolumes not in tracked operations
+
+  # Test Group 2: Driver Health and Resource Alerts (PST-09 to PST-14)
+
+  # PST-09: Driver Pod Unavailable - fires when zero controller or node instances report metrics
+  - interval: 1m
+    input_series:
+      # No dell_csi_driver_uptime_seconds series at all — simulates all pods down
+      - series: 'dell_csi_driver_uptime_seconds{namespace="csi-powerstore",instance_type="controller"}'
+        values: '_x11'  # stale/absent for the entire duration
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerStoreDriverPodUnavailable
+        exp_alerts:
+          - exp_labels:
+              alertname: PowerStoreDriverPodUnavailable
+              component: csi-driver
+              severity: critical
+              platform: powerstore
+            exp_annotations:
+              summary: "PowerStore CSI driver metrics are unavailable"
+              description: "PowerStore CSI driver has zero controller instances or zero node instances reporting metrics for 5 minutes."
+              runbook_url: ""
+
+  # PST-09 boundary: alert does NOT fire when both controller and node instances are present
+  - interval: 1m
+    input_series:
+      - series: 'dell_csi_driver_uptime_seconds{namespace="csi-powerstore",instance_type="controller"}'
+        values: '100 200 300 400 500 600 700 800 900 1000 1100'
+      - series: 'dell_csi_driver_uptime_seconds{namespace="csi-powerstore",instance_type="node"}'
+        values: '100 200 300 400 500 600 700 800 900 1000 1100'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerStoreDriverPodUnavailable
+        exp_alerts: []  # Should NOT fire - both controller and node are present
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csi_driver_restart_total{global_id="PSc26835c9a0ba",pod="powerstore-controller-7cc98c6ddd-ljqhk",node="node1",namespace="csi-powerstore",instance_type="controller"}'
+        values: '0 1 2 3 4 5 6 7 8'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerStoreDriverCrashLooping
+        exp_alerts:
+          - exp_labels:
+              alertname: PowerStoreDriverCrashLooping
+              component: csi-driver
+              severity: warning
+              platform: powerstore
+              pod: powerstore-controller-7cc98c6ddd-ljqhk
+              node: node1
+              global_id: PSc26835c9a0ba
+              instance_type: controller
+              namespace: csi-powerstore
+            exp_annotations:
+              summary: "PowerStore CSI driver is crash looping"
+              description: "PowerStore CSI driver pod powerstore-controller-7cc98c6ddd-ljqhk (instance type: controller) has restarted 5 times in the last 15m, indicating a crash loop."
+              runbook_url: ""
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csi_driver_memory_usage_bytes{global_id="PSc26835c9a0ba",pod="powerstore-controller-7cc98c6ddd-ljqhk",node="node1",namespace="csi-powerstore",instance_type="controller"}'
+        values: '2684354560 2684354560 2684354560 2684354560 2684354560 2684354560'  # 2.5 GiB > 2 GiB threshold
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerStoreDriverHighMemoryUsage
+        exp_alerts:
+          - exp_labels:
+              alertname: PowerStoreDriverHighMemoryUsage
+              component: csi-driver
+              severity: warning
+              platform: powerstore
+              pod: powerstore-controller-7cc98c6ddd-ljqhk
+              global_id: PSc26835c9a0ba
+              instance_type: controller
+              namespace: csi-powerstore
+              node: node1
+            exp_annotations:
+              summary: "PowerStore CSI driver high memory usage"
+              description: "PowerStore CSI driver pod powerstore-controller-7cc98c6ddd-ljqhk on node node1 has memory usage of 2684354560 bytes (threshold: 2147483648 bytes) for more than 5 minutes."
+              runbook_url: ""
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csi_driver_cpu_usage_percent{global_id="PSc26835c9a0ba",pod="powerstore-controller-7cc98c6ddd-ljqhk",node="node1",namespace="csi-powerstore",instance_type="controller"}'
+        values: '85 85 85 85 85 85'  # 85% > 80% threshold
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerStoreDriverHighCPUUsage
+        exp_alerts:
+          - exp_labels:
+              alertname: PowerStoreDriverHighCPUUsage
+              component: csi-driver
+              severity: warning
+              platform: powerstore
+              pod: powerstore-controller-7cc98c6ddd-ljqhk
+              global_id: PSc26835c9a0ba
+              instance_type: controller
+              namespace: csi-powerstore
+              node: node1
+            exp_annotations:
+              summary: "PowerStore CSI driver high CPU usage"
+              description: "PowerStore CSI driver pod powerstore-controller-7cc98c6ddd-ljqhk on node node1 has CPU usage of 85% (threshold: 80%) for more than 5 minutes."
+              runbook_url: ""
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csi_driver_cpu_usage_percent{global_id="PSc26835c9a0ba",pod="powerstore-controller-7cc98c6ddd-ljqhk",node="node1",namespace="csi-powerstore",instance_type="controller"}'
+        values: '79 79 79 79 79 79'  # 79% < 80% threshold - should NOT fire
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerStoreDriverHighCPUUsage
+        exp_alerts: []  # Should NOT fire - below threshold
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_powerstore_metrics_stale{global_id="PSc26835c9a0ba"}'
+        values: '1 1 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerStoreMetricsStale
+        exp_alerts:
+          - exp_labels:
+              alertname: PowerStoreMetricsStale
+              component: csi-driver
+              severity: warning
+              platform: powerstore
+              global_id: PSc26835c9a0ba
+            exp_annotations:
+              summary: "PowerStore metrics collection is stale on array PSc26835c9a0ba"
+              description: "PowerStore metrics collection has reported stale data for 5 minutes on array PSc26835c9a0ba. The stale flag is set immediately on any collection failure, ensuring the alert fires even when the cache is empty."
+              runbook_url: ""
+
+  # PST-13: High API Error Rate - fires when error ratio exceeds 10% for 5 minutes
+  - interval: 1m
+    input_series:
+      # 20 failure calls and 80 success calls = 20% error rate (above 10% threshold)
+      - series: 'dell_csi_api_call_total{global_id="PSc26835c9a0ba",endpoint="/api/v1/volume",method="POST",status="failure"}'
+        values: '0 4 8 12 16 20 24 28 32 36 40'
+      - series: 'dell_csi_api_call_total{global_id="PSc26835c9a0ba",endpoint="/api/v1/volume",method="POST",status="success"}'
+        values: '0 16 32 48 64 80 96 112 128 144 160'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: PowerStoreHighAPIErrorRate
+        exp_alerts:
+          - exp_labels:
+              alertname: PowerStoreHighAPIErrorRate
+              component: csi-driver
+              severity: warning
+              platform: powerstore
+              global_id: PSc26835c9a0ba
+              endpoint: /api/v1/volume
+              method: POST
+            exp_annotations:
+              summary: "PowerStore API error rate elevated"
+              description: "PowerStore API error rate on array PSc26835c9a0ba endpoint /api/v1/volume (POST) is 20% over the last 5m (threshold: 10%)."
+              runbook_url: ""
+
+  # PST-13 boundary: error rate at 5% should NOT fire (below 10% threshold)
+  - interval: 1m
+    input_series:
+      # 5 failure calls and 95 success calls = 5% error rate (below 10% threshold)
+      - series: 'dell_csi_api_call_total{global_id="PSc26835c9a0ba",endpoint="/api/v1/volume",method="GET",status="failure"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10'
+      - series: 'dell_csi_api_call_total{global_id="PSc26835c9a0ba",endpoint="/api/v1/volume",method="GET",status="success"}'
+        values: '0 19 38 57 76 95 114 133 152 171 190'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: PowerStoreHighAPIErrorRate
+        exp_alerts: []  # Should NOT fire - 5% is below 10% threshold
+
+  # Test Group 3: Capacity, Connectivity, and Authentication Alerts (PST-15 to PST-18)
+  - interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{operation="CreateVolume",global_id="PSc26835c9a0ba",error_code="auth_failure",protocol="block"}'
+        values: '0 0 0 0 1 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerStoreAuthenticationFailure
+        exp_alerts:
+          - exp_labels:
+              alertname: PowerStoreAuthenticationFailure
+              component: csi-driver
+              severity: critical
+              platform: powerstore
+              operation: CreateVolume
+              global_id: PSc26835c9a0ba
+              error_code: auth_failure
+              protocol: block
+            exp_annotations:
+              summary: "PowerStore authentication failures detected"
+              description: "Array PSc26835c9a0ba has 1 authentication failures in the last 5 minutes for operation CreateVolume. Check array credentials."
+              runbook_url: ""
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{operation="CreateVolume",global_id="PSc26835c9a0ba",error_code="internal_error",protocol="block"}'
+        values: '0 0 0 0 5 5 5 5 5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerStoreAuthenticationFailure
+        exp_alerts: []  # Should NOT fire - not auth_failure error code
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_powerstore_appliance_utilization_ratio{global_id="PSc26835c9a0ba",appliance_id="A1",appliance_name="apm8936-appliance-1"}'
+        values: '0.81 0.81 0.81 0.81 0.81 0.81 0.81 0.81 0.81 0.81 0.81'  # 81% > 80% threshold
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PowerStoreApplianceCapacityWarning
+        exp_alerts:
+          - exp_labels:
+              alertname: PowerStoreApplianceCapacityWarning
+              component: csi-driver
+              severity: warning
+              platform: powerstore
+              appliance_id: A1
+              appliance_name: apm8936-appliance-1
+              global_id: PSc26835c9a0ba
+            exp_annotations:
+              summary: "PowerStore appliance apm8936-appliance-1 utilization is high"
+              description: "PowerStore appliance apm8936-appliance-1 on array PSc26835c9a0ba has exceeded the warning utilization threshold at 81% (threshold: 80%)."
+              runbook_url: ""
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_powerstore_appliance_utilization_ratio{global_id="PSc26835c9a0ba",appliance_id="A1",appliance_name="apm8936-appliance-1"}'
+        values: '0.79 0.79 0.79 0.79 0.79 0.79 0.79 0.79 0.79 0.79 0.79'  # 79% < 80% threshold
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PowerStoreApplianceCapacityWarning
+        exp_alerts: []  # Should NOT fire - below threshold
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_powerstore_appliance_utilization_ratio{global_id="PSc26835c9a0ba",appliance_id="A1",appliance_name="apm8936-appliance-1"}'
+        values: '0.91 0.91 0.91 0.91 0.91 0.91 0.91 0.91 0.91 0.91 0.91'  # 91% > 90% threshold
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PowerStoreApplianceCapacityCritical
+        exp_alerts:
+          - exp_labels:
+              alertname: PowerStoreApplianceCapacityCritical
+              component: csi-driver
+              severity: critical
+              platform: powerstore
+              appliance_id: A1
+              appliance_name: apm8936-appliance-1
+              global_id: PSc26835c9a0ba
+            exp_annotations:
+              summary: "PowerStore appliance apm8936-appliance-1 utilization is critical"
+              description: "PowerStore appliance apm8936-appliance-1 on array PSc26835c9a0ba has exceeded the critical utilization threshold at 91% (threshold: 90%). Immediate action required."
+              runbook_url: ""
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_powerstore_appliance_compression_ratio{global_id="PSc26835c9a0ba",appliance_id="A1",appliance_name="apm8936-appliance-1"}'
+        values: '5.0 5.0 5.0 5.0 5.0 5.0 5.0 5.0 5.0 5.0 5.0'
+      - series: 'dell_powerstore_appliance_utilization_ratio{global_id="PSc26835c9a0ba",appliance_id="A1",appliance_name="apm8936-appliance-1"}'
+        values: '0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25'  # 5.0 * 0.25 = 1.25 > 1.0
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PowerStoreThinProvisioningOvercommitment
+        exp_alerts:
+          - exp_labels:
+              alertname: PowerStoreThinProvisioningOvercommitment
+              component: csi-driver
+              severity: warning
+              platform: powerstore
+              appliance_id: A1
+              appliance_name: apm8936-appliance-1
+              global_id: PSc26835c9a0ba
+            exp_annotations:
+              summary: "PowerStore thin provisioning over-commitment detected on array PSc26835c9a0ba"
+              description: "PowerStore appliance apm8936-appliance-1 on array PSc26835c9a0ba has logical provisioned capacity exceeding physical total."
+              runbook_url: ""
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_powerstore_appliance_compression_ratio{global_id="PSc26835c9a0ba",appliance_id="A1",appliance_name="apm8936-appliance-1"}'
+        values: '2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0'
+      - series: 'dell_powerstore_appliance_utilization_ratio{global_id="PSc26835c9a0ba",appliance_id="A1",appliance_name="apm8936-appliance-1"}'
+        values: '0.30 0.30 0.30 0.30 0.30 0.30 0.30 0.30 0.30 0.30 0.30'  # 2.0 * 0.30 = 0.60 < 1.0
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PowerStoreThinProvisioningOvercommitment
+        exp_alerts: []  # Should NOT fire - below threshold

--- a/charts/csi-powerstore/tests/alert-rules.yaml
+++ b/charts/csi-powerstore/tests/alert-rules.yaml
@@ -1,0 +1,223 @@
+groups:
+  - name: csi-powerstore.rules
+    rules:
+      # P4.PST.1: CreateVolume Failure
+      - alert: PowerStoreCreateVolumeFailure
+        expr: increase(dell_csi_operation_failure_total{operation="CreateVolume"}[5m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerstore
+          component: csi-driver
+        annotations:
+          summary: "PowerStore CSI CreateVolume operation failures detected"
+          description: "Array {{ $labels.global_id }} has {{ $value }} CreateVolume failures in the last 5 minutes. Protocol: {{ $labels.protocol }}, Error Code: {{ $labels.error_code }}"
+          runbook_url: ""
+      # P4.PST.2: DeleteVolume Failure
+      - alert: PowerStoreDeleteVolumeFailure
+        expr: increase(dell_csi_operation_failure_total{operation="DeleteVolume"}[5m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerstore
+          component: csi-driver
+        annotations:
+          summary: "PowerStore CSI DeleteVolume operation failures detected"
+          description: "Array {{ $labels.global_id }} has {{ $value }} DeleteVolume failures in the last 5 minutes. Protocol: {{ $labels.protocol }}, Error Code: {{ $labels.error_code }}"
+          runbook_url: ""
+      # P4.PST.3: ControllerPublishVolume Failure
+      - alert: PowerStoreControllerPublishVolumeFailure
+        expr: increase(dell_csi_operation_failure_total{operation="ControllerPublishVolume"}[5m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerstore
+          component: csi-driver
+        annotations:
+          summary: "PowerStore CSI ControllerPublishVolume operation failures detected"
+          description: "Array {{ $labels.global_id }} has {{ $value }} ControllerPublishVolume failures in the last 5 minutes. Protocol: {{ $labels.protocol }}, Error Code: {{ $labels.error_code }}"
+          runbook_url: ""
+      # P4.PST.4: ControllerUnpublishVolume Failure
+      - alert: PowerStoreControllerUnpublishVolumeFailure
+        expr: increase(dell_csi_operation_failure_total{operation="ControllerUnpublishVolume"}[5m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerstore
+          component: csi-driver
+        annotations:
+          summary: "PowerStore CSI ControllerUnpublishVolume operation failures detected"
+          description: "Array {{ $labels.global_id }} has {{ $value }} ControllerUnpublishVolume failures in the last 5 minutes. Protocol: {{ $labels.protocol }}, Error Code: {{ $labels.error_code }}"
+          runbook_url: ""
+      # P4.PST.5: NodeStageVolume Failure
+      - alert: PowerStoreNodeStageVolumeFailure
+        expr: increase(dell_csi_operation_failure_total{operation="NodeStageVolume"}[5m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerstore
+          component: csi-driver
+        annotations:
+          summary: "PowerStore CSI NodeStageVolume operation failures detected"
+          description: "Array {{ $labels.global_id }} has {{ $value }} NodeStageVolume failures in the last 5 minutes. Protocol: {{ $labels.protocol }}, Error Code: {{ $labels.error_code }}"
+          runbook_url: ""
+      # P4.PST.6: NodeUnstageVolume Failure
+      - alert: PowerStoreNodeUnstageVolumeFailure
+        expr: increase(dell_csi_operation_failure_total{operation="NodeUnstageVolume"}[5m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerstore
+          component: csi-driver
+        annotations:
+          summary: "PowerStore CSI NodeUnstageVolume operation failures detected"
+          description: "Array {{ $labels.global_id }} has {{ $value }} NodeUnstageVolume failures in the last 5 minutes. Protocol: {{ $labels.protocol }}, Error Code: {{ $labels.error_code }}"
+          runbook_url: ""
+      # P4.PST.7: NodePublishVolume Failure
+      - alert: PowerStoreNodePublishVolumeFailure
+        expr: increase(dell_csi_operation_failure_total{operation="NodePublishVolume"}[5m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerstore
+          component: csi-driver
+        annotations:
+          summary: "PowerStore CSI NodePublishVolume operation failures detected"
+          description: "Array {{ $labels.global_id }} has {{ $value }} NodePublishVolume failures in the last 5 minutes. Protocol: {{ $labels.protocol }}, Error Code: {{ $labels.error_code }}"
+          runbook_url: ""
+      # P4.PST.8: NodeUnpublishVolume Failure
+      - alert: PowerStoreNodeUnpublishVolumeFailure
+        expr: increase(dell_csi_operation_failure_total{operation="NodeUnpublishVolume"}[5m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerstore
+          component: csi-driver
+        annotations:
+          summary: "PowerStore CSI NodeUnpublishVolume operation failures detected"
+          description: "Array {{ $labels.global_id }} has {{ $value }} NodeUnpublishVolume failures in the last 5 minutes. Protocol: {{ $labels.protocol }}, Error Code: {{ $labels.error_code }}"
+          runbook_url: ""
+      # P4.PST.9: Driver Pod Unavailable
+      - alert: PowerStoreDriverPodUnavailable
+        expr: |
+          (count(dell_csi_driver_uptime_seconds{namespace="csi-powerstore",instance_type="controller"}) or on() vector(0)) == 0
+          or
+          (count(dell_csi_driver_uptime_seconds{namespace="csi-powerstore",instance_type="node"}) or on() vector(0)) == 0
+        for: 5m
+        labels:
+          severity: critical
+          platform: powerstore
+          component: csi-driver
+        annotations:
+          summary: "PowerStore CSI driver metrics are unavailable"
+          description: "PowerStore CSI driver has zero controller instances or zero node instances reporting metrics for 5 minutes."
+          runbook_url: ""
+      # P4.PST.10: Driver CrashLooping
+      - alert: PowerStoreDriverCrashLooping
+        expr: changes(dell_csi_driver_restart_total[15m]) > 3
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerstore
+          component: csi-driver
+        annotations:
+          summary: "PowerStore CSI driver is crash looping"
+          description: "PowerStore CSI driver pod {{ $labels.pod }} (instance type: {{ $labels.instance_type }}) has restarted {{ $value }} times in the last 15m, indicating a crash loop."
+          runbook_url: ""
+      # P4.PST.11: High Memory Usage
+      - alert: PowerStoreDriverHighMemoryUsage
+        expr: dell_csi_driver_memory_usage_bytes > 2147483648
+        for: 5m
+        labels:
+          severity: warning
+          platform: powerstore
+          component: csi-driver
+        annotations:
+          summary: "PowerStore CSI driver high memory usage"
+          description: "PowerStore CSI driver pod {{ $labels.pod }} on node {{ $labels.node }} has memory usage of {{ $value }} bytes (threshold: 2147483648 bytes) for more than 5 minutes."
+          runbook_url: ""
+      # P4.PST.12: High CPU Usage
+      - alert: PowerStoreDriverHighCPUUsage
+        expr: dell_csi_driver_cpu_usage_percent > 80
+        for: 5m
+        labels:
+          severity: warning
+          platform: powerstore
+          component: csi-driver
+        annotations:
+          summary: "PowerStore CSI driver high CPU usage"
+          description: "PowerStore CSI driver pod {{ $labels.pod }} on node {{ $labels.node }} has CPU usage of {{ $value }}% (threshold: 80%) for more than 5 minutes."
+          runbook_url: ""
+      # P4.PST.13: High API Error Rate
+      # Division-by-zero guard: only fires when denominator > 0.
+      - alert: PowerStoreHighAPIErrorRate
+        expr: (rate(dell_csi_api_call_total{status="failure"}[5m]) / ignoring(status) sum without(status) (rate(dell_csi_api_call_total[5m]))) * 100 > 10 and ignoring(status) sum without(status) (rate(dell_csi_api_call_total[5m])) > 0
+        for: 5m
+        labels:
+          severity: warning
+          platform: powerstore
+          component: csi-driver
+        annotations:
+          summary: "PowerStore API error rate elevated"
+          description: "PowerStore API error rate on array {{ $labels.global_id }} endpoint {{ $labels.endpoint }} ({{ $labels.method }}) is {{ $value }}% over the last 5m (threshold: 10%)."
+          runbook_url: ""
+      # P4.PST.14: Metrics Stale
+      - alert: PowerStoreMetricsStale
+        expr: dell_powerstore_metrics_stale == 1
+        for: 5m
+        labels:
+          severity: warning
+          platform: powerstore
+          component: csi-driver
+        annotations:
+          summary: "PowerStore metrics collection is stale on array {{ $labels.global_id }}"
+          description: "PowerStore metrics collection has reported stale data for 5 minutes on array {{ $labels.global_id }}. The stale flag is set immediately on any collection failure, ensuring the alert fires even when the cache is empty."
+          runbook_url: ""
+      # P4.PST.15: Authentication Failure
+      - alert: PowerStoreAuthenticationFailure
+        expr: increase(dell_csi_operation_failure_total{error_code="auth_failure"}[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+          platform: powerstore
+          component: csi-driver
+        annotations:
+          summary: "PowerStore authentication failures detected"
+          description: "Array {{ $labels.global_id }} has {{ $value }} authentication failures in the last 5 minutes for operation {{ $labels.operation }}. Check array credentials."
+          runbook_url: ""
+      # P4.PST.16: Appliance Capacity Warning
+      - alert: PowerStoreApplianceCapacityWarning
+        expr: dell_powerstore_appliance_utilization_ratio > 0.8
+        for: 10m
+        labels:
+          severity: warning
+          platform: powerstore
+          component: csi-driver
+        annotations:
+          summary: "PowerStore appliance {{ $labels.appliance_name }} utilization is high"
+          description: "PowerStore appliance {{ $labels.appliance_name }} on array {{ $labels.global_id }} has exceeded the warning utilization threshold at {{ $value | humanizePercentage }} (threshold: 80%)."
+          runbook_url: ""
+      # P4.PST.17: Appliance Capacity Critical
+      - alert: PowerStoreApplianceCapacityCritical
+        expr: dell_powerstore_appliance_utilization_ratio > 0.9
+        for: 10m
+        labels:
+          severity: critical
+          platform: powerstore
+          component: csi-driver
+        annotations:
+          summary: "PowerStore appliance {{ $labels.appliance_name }} utilization is critical"
+          description: "PowerStore appliance {{ $labels.appliance_name }} on array {{ $labels.global_id }} has exceeded the critical utilization threshold at {{ $value | humanizePercentage }} (threshold: 90%). Immediate action required."
+          runbook_url: ""
+      # P4.PST.18: Thin Provisioning Over-commitment
+      - alert: PowerStoreThinProvisioningOvercommitment
+        expr: (dell_powerstore_appliance_compression_ratio * dell_powerstore_appliance_utilization_ratio) > 1.0
+        for: 10m
+        labels:
+          severity: warning
+          platform: powerstore
+          component: csi-driver
+        annotations:
+          summary: "PowerStore thin provisioning over-commitment detected on array {{ $labels.global_id }}"
+          description: "PowerStore appliance {{ $labels.appliance_name }} on array {{ $labels.global_id }} has logical provisioned capacity exceeding physical total."
+          runbook_url: ""

--- a/charts/csi-powerstore/values.yaml
+++ b/charts/csi-powerstore/values.yaml
@@ -90,6 +90,15 @@ externalAccess:
 # Default Value: false
 exclusiveAccess: false
 
+# nfsAutoSelect: enables NFS source IP auto-discovery via kernel routing query (ER-K8S-JA18622-001-powerstore-nfs-auto-selection).
+# When enabled, the driver discovers which node IP can reach the NAS server's file interface
+# and automatically adds it to the NFS export, eliminating the need for manual host configuration.
+# When externalAccess is also set, both auto-discovered and external IPs are added to the export.
+# When exclusiveAccess is true, nfsAutoSelect is ignored (exclusiveAccess takes precedence).
+# Allowed Values: true or false
+# Default Value: false
+nfsAutoSelect: false
+
 # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
 # Allowed values:
 #  Always: Always pull the image.
@@ -125,6 +134,26 @@ nfsAcls: "0777"
 #   Any valid and free port.
 # Default value: 8083
 podmonAPIPort: 8083
+
+# podmonAPIToken: Shared secret token for authenticating podmon API requests
+# When set, the driver will require Bearer token authentication on /array-status endpoints
+# Allowed values: Any string (recommend using a randomly generated token)
+# Security note: podmon API is HTTP; use this token only on trusted cluster-internal networks.
+# For production, use podmonAPITokenSecret to source this value from a Kubernetes Secret.
+# Default value: "" (empty - authentication disabled for backward compatibility)
+podmonAPIToken: ""
+
+# podmonAPITokenSecret: Kubernetes Secret containing the podmon API token
+# When set, the token will be sourced from the specified Secret instead of podmonAPIToken value
+# Allowed values:
+#   name: Secret name (required)
+#   key: Secret key containing the token (required, default: "podmon-api-token")
+# Example:
+#   podmonAPITokenSecret:
+#     name: my-podmon-secret
+#     key: api-token
+# Default value: null (use podmonAPIToken value instead)
+podmonAPITokenSecret: null
 
 # apiTimeout: Defines the timeout for PowerStore API calls in seconds
 # Allowed values: Number followed by unit (s,m,h)
@@ -254,6 +283,19 @@ controller:
     # Allowed values: string
     # Default value: replication.storage.dell.com
     replicationPrefix: "replication.storage.dell.com"
+
+    # Metrics configuration for replication sidecar
+    metrics:
+      enabled: false
+      port: 8445
+      tlsCertSecret: ""
+      collection:
+        interval: 30s
+      serviceMonitor:
+        enabled: false
+        interval: 30s
+        scrapeTimeout: ""
+        insecureSkipVerify: false
 
   # csiAddonsReplication: allows to configure CSI Addons replication
   # CSI Addons provides additional capabilities like volume group replication
@@ -480,6 +522,18 @@ podmon:
       interval: 30s
       scrapeTimeout: ""
       insecureSkipVerify: false
+    # prometheusRule: Controls optional Prometheus Operator PrometheusRule creation for resiliency alerts.
+    prometheusRule:
+      # enabled: When true, a PrometheusRule CR is created for resiliency alerting rules.
+      # Type: bool
+      # Default: true
+      # Effect: Requires the Prometheus Operator CRDs to be installed in the cluster.
+      enabled: true
+      # connectivitySuccessRatio: Minimum acceptable connectivity success ratio as percentage (0-100).
+      # Used by RES-02 (CSMResiliencyConnectivityLost) alert threshold.
+      # Type: integer
+      # Default: 90 (alert fires when connectivity drops below 90%)
+      connectivitySuccessRatio: 90
 
   # arrayConnectivityTimeout: Defines the timeout (in seconds) for podmon array connectivity timeout check
   # Allowed values: Number followed by unit (s,m,h)
@@ -531,6 +585,16 @@ disasterRecovery:
   # Allowed values: Any valid and free port
   # Default value: 8082
   bindPort: 8082
+  # monitor: Configuration for the PowerStore alert monitor service
+  monitor:
+    # enabled: Enable or disable the alert monitor service
+    # Allowed values: true, false
+    # Default value: true
+    enabled: true
+    # pollInterval: How often the monitor polls for new alerts
+    # Allowed values: Any valid Go duration string (e.g., "30s", "1m", "5m")
+    # Default value: "5m"
+    pollInterval: "5m"
 
 # metrics: configuration for driver metrics and monitoring
 metrics:
@@ -594,6 +658,54 @@ metrics:
     # Type: bool
     # Default: false
     insecureSkipVerify: false
+
+  # prometheusRule: Controls optional Prometheus Operator PrometheusRule creation
+  # and configurable alert thresholds.
+  prometheusRule:
+    # enabled: When true, a PrometheusRule CR is created for alerting rules.
+    # Type: bool
+    # Default: true (auto-deploys when metrics.enabled is true; requires Prometheus Operator CRDs)
+    # Effect: Requires the Prometheus Operator CRDs to be installed in the cluster.
+    #         Auto-deploys when metrics.enabled is true. Set to false to disable bundled alerts.
+    enabled: true
+    # applianceWarningThreshold: Appliance utilization percent (0-100) that triggers a warning alert.
+    # Type: integer
+    # Default: 80 (80%)
+    applianceWarningThreshold: 80
+    # applianceCriticalThreshold: Appliance utilization percent (0-100) that triggers a critical alert.
+    # Type: integer
+    # Default: 90 (90%)
+    applianceCriticalThreshold: 90
+    # apiErrorRateThreshold: API error rate percent (0-100) above which a warning alert fires.
+    # Type: integer
+    # Default: 10 (10%)
+    apiErrorRateThreshold: 10
+    # apiErrorRateWindow: Prometheus range duration for rate() calculations (P4.PST.13).
+    # Type: string (Prometheus duration, e.g. "5m", "10m")
+    # Default: "5m"
+    apiErrorRateWindow: "5m"
+    # cpuWarningThreshold: CPU usage percent (0-100) that triggers a warning alert.
+    # Matches the dell_csi_driver_cpu_usage_percent metric which is already 0-100 scale.
+    # Type: integer
+    # Default: 80 (80%)
+    cpuWarningThreshold: 80
+    # memoryWarningThreshold: Memory usage in bytes above which a warning alert fires.
+    # Type: integer
+    # Default: 2147483648 (2 GiB)
+    memoryWarningThreshold: 2147483648
+    # driverCrashLoopWindow: Prometheus range duration for delta() restart count alert (P4.PST.10).
+    # Type: string (Prometheus duration, e.g. "15m", "10m")
+    # Default: "15m"
+    driverCrashLoopWindow: "15m"
+    # driverCrashLoopRestartThreshold: Number of driver restarts within driverCrashLoopWindow that triggers a warning alert.
+    # Type: integer
+    # Default: 3
+    driverCrashLoopRestartThreshold: 3
+    # volumeOperationFailureThreshold: Minimum number of volume operation failures in the 5-minute window
+    # that triggers a warning alert (PST-01 to PST-08). Set to 0 to fire on any failure.
+    # Type: integer
+    # Default: 3
+    volumeOperationFailureThreshold: 3
 
   # podMonitor: Controls optional Prometheus Operator PodMonitor creation for node DaemonSet pods.
   podMonitor:

--- a/charts/csi-vxflexos/templates/_helpers.tpl
+++ b/charts/csi-vxflexos/templates/_helpers.tpl
@@ -1,4 +1,8 @@
 {{/*
+Copyright © 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+*/}}
+
+{{/*
 Return true if storage capacity tracking is enabled and is supported based on k8s version
 */}}
 {{- define "csi-vxflexos.isStorageCapacitySupported" -}}
@@ -44,6 +48,28 @@ Return true if volumeGroupSnapshot is enabled and properly configured
   {{- end -}}
 {{- else -}}
   {{- false -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if podmon resiliency metrics is enabled
+*/}}
+{{- define "csi-vxflexos.isResiliencyMetricsEnabled" -}}
+{{- if and (hasKey .Values "podmon") (hasKey .Values.podmon "metrics") .Values.podmon.metrics.enabled -}}
+{{- true -}}
+{{- else -}}
+{{- false -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if podmon resiliency metrics TLS is enabled
+*/}}
+{{- define "csi-vxflexos.isResiliencyMetricsTLSEnabled" -}}
+{{- if and (include "csi-vxflexos.isResiliencyMetricsEnabled" .) (hasKey .Values.podmon.metrics "tlsCertSecret") .Values.podmon.metrics.tlsCertSecret -}}
+{{- true -}}
+{{- else -}}
+{{- false -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/csi-vxflexos/templates/controller.yaml
+++ b/charts/csi-vxflexos/templates/controller.yaml
@@ -66,6 +66,9 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "update"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
@@ -194,6 +197,7 @@ spec:
     metadata:
       labels:
         name: {{ .Release.Name }}-controller
+        app: {{ .Release.Name }}-controller
       annotations:
         kubectl.kubernetes.io/default-container: "driver"
     spec:
@@ -237,11 +241,39 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: X_CSI_METRICS_ENABLED
+              value: {{ include "csi-vxflexos.isResiliencyMetricsEnabled" . | quote }}
+            - name: X_CSI_METRICS_PORT
+              value: "{{ .Values.podmon.metrics.port }}"
+            - name: X_CSI_METRICS_COLLECTION_INTERVAL
+              value: "{{ .Values.podmon.metrics.collection.interval }}"
+            {{- if eq (include "csi-vxflexos.isResiliencyMetricsTLSEnabled" .) "true" }}
+            - name: X_CSI_METRICS_TLS_CERT_FILE
+              value: /etc/metrics-tls/tls.crt
+            - name: X_CSI_METRICS_TLS_KEY_FILE
+              value: /etc/metrics-tls/tls.key
+            {{- else }}
+            - name: X_CSI_METRICS_TLS_CERT_FILE
+              value: ""
+            - name: X_CSI_METRICS_TLS_KEY_FILE
+              value: ""
+            {{- end }}
+          {{- if eq (include "csi-vxflexos.isResiliencyMetricsEnabled" .) "true" }}
+          ports:
+            - name: resiliency-metrics
+              containerPort: {{ .Values.podmon.metrics.port }}
+              protocol: TCP
+          {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi
             - name: vxflexos-config-params
               mountPath: /vxflexos-config-params
+            {{- if eq (include "csi-vxflexos.isResiliencyMetricsTLSEnabled" .) "true" }}
+            - name: resiliency-metrics-tls
+              mountPath: /etc/metrics-tls
+              readOnly: true
+            {{- end }}
 {{- end }}
 {{- end }}
         - name: attacher
@@ -278,11 +310,34 @@ spec:
               value: /vxflexos-config-params
             - name: X_CSI_REPLICATION_CONFIG_FILE_NAME
               value: driver-config-params.yaml
+{{- if and .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled }}
+            - name: X_CSI_REPLICATION_METRICS_ENABLED
+              value: "true"
+            - name: X_CSI_REPLICATION_METRICS_PORT
+              value: "{{ .Values.controller.replication.metrics.port | default 8445 }}"
+            - name: X_CSI_REPLICATION_METRICS_COLLECTION_INTERVAL
+              value: "{{ .Values.controller.replication.metrics.collection.interval | default "30s" }}"
+{{- if .Values.controller.replication.metrics.tlsCertSecret }}
+            - name: X_CSI_REPLICATION_METRICS_TLS_CERT_FILE
+              value: /etc/replication-metrics-tls/tls.crt
+            - name: X_CSI_REPLICATION_METRICS_TLS_KEY_FILE
+              value: /etc/replication-metrics-tls/tls.key
+{{- end }}
+          ports:
+            - name: repl-metrics
+              containerPort: {{ .Values.controller.replication.metrics.port | default 8445 }}
+              protocol: TCP
+{{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi
             - name: vxflexos-config-params
               mountPath: /vxflexos-config-params
+{{- if and .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled .Values.controller.replication.metrics.tlsCertSecret }}
+            - name: replication-metrics-tls
+              mountPath: /etc/replication-metrics-tls
+              readOnly: true
+{{- end }}
         {{- end }}
         {{- end }}
         - name: provisioner
@@ -469,18 +524,58 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: X_CSI_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: X_CSI_PODMON_API_PORT
               value: "{{ .Values.podmonAPIPort }}"
+            {{- if .Values.podmonAPITokenSecret }}
+            - name: X_CSI_PODMON_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.podmonAPITokenSecret.name }}
+                  key: {{ .Values.podmonAPITokenSecret.key | default "podmon-api-token" }}
+            {{- else if .Values.podmonAPIToken }}
+            - name: X_CSI_PODMON_API_TOKEN
+              value: "{{ .Values.podmonAPIToken }}"
+            {{- end }}
             {{- if eq (include "csi-vxflexos.isMetricsEnabled" .) "true" }}
             - name: X_CSI_METRICS_ENABLED
               value: "true"
             - name: X_CSI_METRICS_PORT
-              value: "{{ .Values.metrics.port | default 8443 }}"
+              value: "{{ .Values.metrics.port | default 9090 }}"
             {{- if .Values.metrics.tlsCertSecret }}
             - name: X_CSI_METRICS_TLS_CERT_FILE
               value: "/etc/metrics-tls/tls.crt"
             - name: X_CSI_METRICS_TLS_KEY_FILE
               value: "/etc/metrics-tls/tls.key"
+            {{- end }}
+            {{- if hasKey .Values.metrics "leaderElection" }}
+            - name: X_CSI_METRICS_LEADER_ELECTION_ENABLED
+              value: "{{ .Values.metrics.leaderElection.enabled | default false }}"
+            - name: X_CSI_METRICS_LEADER_ELECTION_LEASE_DURATION
+              value: "{{ .Values.metrics.leaderElection.leaseDuration | default "60s" }}"
+            - name: X_CSI_METRICS_LEADER_ELECTION_RENEW_DEADLINE
+              value: "{{ .Values.metrics.leaderElection.renewDeadline | default "40s" }}"
+            - name: X_CSI_METRICS_LEADER_ELECTION_RETRY_PERIOD
+              value: "{{ .Values.metrics.leaderElection.retryPeriod | default "5s" }}"
+            {{- end }}
+            {{- if hasKey .Values.metrics "collection" }}
+            - name: X_CSI_METRICS_COLLECTION_INTERVAL
+              value: "{{ .Values.metrics.collection.interval | default "30s" }}"
+            - name: X_CSI_METRICS_COLLECTION_CACHE_TTL
+              value: "{{ .Values.metrics.collection.cacheTTL | default "25s" }}"
+            {{- end }}
+            {{- if hasKey .Values.metrics "array" }}
+            - name: X_CSI_METRICS_ARRAY_TIMEOUT
+              value: "{{ .Values.metrics.array.timeout | default "30s" }}"
+            - name: X_CSI_METRICS_ARRAY_RATE_LIMIT
+              value: "{{ .Values.metrics.array.rateLimit | default 100 }}"
+            - name: X_CSI_METRICS_ARRAY_CB_THRESHOLD
+              value: "{{ .Values.metrics.array.circuitBreaker.threshold | default 3 }}"
+            - name: X_CSI_METRICS_ARRAY_CB_RESET_TIMEOUT
+              value: "{{ .Values.metrics.array.circuitBreaker.resetTimeout | default "30s" }}"
             {{- end }}
             {{- if eq .Values.metrics.gatewayMonitoring.enabled true }}
             - name: X_CSI_GATEWAY_MONITORING_ENABLED
@@ -548,5 +643,19 @@ spec:
         - name: metrics-tls
           secret:
             secretName: {{ .Values.metrics.tlsCertSecret }}
+{{- end }}
+{{- end }}
+{{- if eq (include "csi-vxflexos.isResiliencyMetricsEnabled" .) "true" }}
+{{- if eq (include "csi-vxflexos.isResiliencyMetricsTLSEnabled" .) "true" }}
+        - name: resiliency-metrics-tls
+          secret:
+            secretName: {{ .Values.podmon.metrics.tlsCertSecret }}
+{{- end }}
+{{- end }}
+{{- if hasKey .Values.controller "replication" }}
+{{- if and .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled .Values.controller.replication.metrics.tlsCertSecret }}
+        - name: replication-metrics-tls
+          secret:
+            secretName: {{ .Values.controller.replication.metrics.tlsCertSecret }}
 {{- end }}
 {{- end }}

--- a/charts/csi-vxflexos/templates/metrics-service.yaml
+++ b/charts/csi-vxflexos/templates/metrics-service.yaml
@@ -14,8 +14,48 @@ spec:
     name: {{ .Release.Name }}-controller
   ports:
     - name: metrics
-      port: {{ .Values.metrics.port | default 8443 }}
-      targetPort: {{ .Values.metrics.port | default 8443 }}
+      port: {{ .Values.metrics.port | default 9090 }}
+      targetPort: {{ .Values.metrics.port | default 9090 }}
+      protocol: TCP
+  type: ClusterIP
+{{- end }}
+{{- if eq (include "csi-vxflexos.isResiliencyMetricsEnabled" .) "true" }}
+---
+# Service exposing the podmon resiliency metrics endpoint for Prometheus scraping.
+# Created when podmon.enabled AND podmon.metrics.enabled are true.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-resiliency-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  selector:
+    name: {{ .Release.Name }}-controller
+  ports:
+    - name: resiliency-metrics
+      port: {{ .Values.podmon.metrics.port | default 8444 }}
+      targetPort: resiliency-metrics
+      protocol: TCP
+  type: ClusterIP
+{{- end }}
+{{- if and (hasKey .Values.controller "replication") .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-replication-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  selector:
+    name: {{ .Release.Name }}-controller
+  ports:
+    - name: repl-metrics
+      port: {{ .Values.controller.replication.metrics.port | default 8445 }}
+      targetPort: {{ .Values.controller.replication.metrics.port | default 8445 }}
       protocol: TCP
   type: ClusterIP
 {{- end }}

--- a/charts/csi-vxflexos/templates/node.yaml
+++ b/charts/csi-vxflexos/templates/node.yaml
@@ -171,6 +171,29 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: X_CSI_METRICS_ENABLED
+              value: {{ include "csi-vxflexos.isResiliencyMetricsEnabled" . | quote }}
+            - name: X_CSI_METRICS_PORT
+              value: "{{ .Values.podmon.metrics.port }}"
+            - name: X_CSI_METRICS_COLLECTION_INTERVAL
+              value: "{{ .Values.podmon.metrics.collection.interval }}"
+            {{- if eq (include "csi-vxflexos.isResiliencyMetricsTLSEnabled" .) "true" }}
+            - name: X_CSI_METRICS_TLS_CERT_FILE
+              value: /etc/metrics-tls/tls.crt
+            - name: X_CSI_METRICS_TLS_KEY_FILE
+              value: /etc/metrics-tls/tls.key
+            {{- else }}
+            - name: X_CSI_METRICS_TLS_CERT_FILE
+              value: ""
+            - name: X_CSI_METRICS_TLS_KEY_FILE
+              value: ""
+            {{- end }}
+          {{- if eq (include "csi-vxflexos.isResiliencyMetricsEnabled" .) "true" }}
+          ports:
+            - name: resiliency-metrics
+              containerPort: {{ .Values.podmon.metrics.port }}
+              protocol: TCP
+          {{- end }}
           volumeMounts:
             - name: kubelet-pods
               mountPath: {{ .Values.kubeletConfigDir }}/pods
@@ -184,6 +207,11 @@ spec:
               mountPath: /var/run
             - name: vxflexos-config-params
               mountPath: /vxflexos-config-params
+            {{- if eq (include "csi-vxflexos.isResiliencyMetricsTLSEnabled" .) "true" }}
+            - name: resiliency-metrics-tls
+              mountPath: /etc/metrics-tls
+              readOnly: true
+            {{- end }}
 {{- end }}
 {{- end }}
 {{- if hasKey .Values "authorization" }}
@@ -253,6 +281,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: X_CSI_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             {{- if hasKey .Values.node "healthMonitor" }}
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: "{{ .Values.node.healthMonitor.enabled }}"
@@ -314,16 +346,42 @@ spec:
             {{- end }}
             - name: X_CSI_PODMON_API_PORT
               value: "{{ .Values.podmonAPIPort }}"
+            {{- if .Values.podmonAPITokenSecret }}
+            - name: X_CSI_PODMON_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.podmonAPITokenSecret.name }}
+                  key: {{ .Values.podmonAPITokenSecret.key | default "podmon-api-token" }}
+            {{- else if .Values.podmonAPIToken }}
+            - name: X_CSI_PODMON_API_TOKEN
+              value: "{{ .Values.podmonAPIToken }}"
+            {{- end }}
             {{- if eq (include "csi-vxflexos.isMetricsEnabled" .) "true" }}
             - name: X_CSI_METRICS_ENABLED
               value: "true"
             - name: X_CSI_METRICS_PORT
-              value: "{{ .Values.metrics.port | default 8443 }}"
+              value: "{{ .Values.metrics.port | default 9090 }}"
             {{- if .Values.metrics.tlsCertSecret }}
             - name: X_CSI_METRICS_TLS_CERT_FILE
               value: "/etc/metrics-tls/tls.crt"
             - name: X_CSI_METRICS_TLS_KEY_FILE
               value: "/etc/metrics-tls/tls.key"
+            {{- end }}
+            {{- if hasKey .Values.metrics "collection" }}
+            - name: X_CSI_METRICS_COLLECTION_INTERVAL
+              value: "{{ .Values.metrics.collection.interval | default "30s" }}"
+            - name: X_CSI_METRICS_COLLECTION_CACHE_TTL
+              value: "{{ .Values.metrics.collection.cacheTTL | default "25s" }}"
+            {{- end }}
+            {{- if hasKey .Values.metrics "array" }}
+            - name: X_CSI_METRICS_ARRAY_TIMEOUT
+              value: "{{ .Values.metrics.array.timeout | default "30s" }}"
+            - name: X_CSI_METRICS_ARRAY_RATE_LIMIT
+              value: "{{ .Values.metrics.array.rateLimit | default 100 }}"
+            - name: X_CSI_METRICS_ARRAY_CB_THRESHOLD
+              value: "{{ .Values.metrics.array.circuitBreaker.threshold | default 3 }}"
+            - name: X_CSI_METRICS_ARRAY_CB_RESET_TIMEOUT
+              value: "{{ .Values.metrics.array.circuitBreaker.resetTimeout | default "30s" }}"
             {{- end }}
             {{- end }}
           volumeMounts:
@@ -599,8 +657,6 @@ spec:
           hostPath:
             path: /var/emc-scaleio
             type: DirectoryOrCreate
-        - name: mdm-dir
-          emptyDir: {}
         - name: udev-d
           hostPath:
             path: /etc/udev/rules.d
@@ -613,6 +669,8 @@ spec:
           hostPath:
             path: /opt/emc
             type: DirectoryOrCreate
+        - name: mdm-dir
+          emptyDir: {}
         - name: vxflexos-config
           secret:
             secretName: {{ .Release.Name }}-config
@@ -636,6 +694,13 @@ spec:
         - name: metrics-tls
           secret:
             secretName: {{ .Values.metrics.tlsCertSecret }}
+{{- end }}
+{{- end }}
+{{- if eq (include "csi-vxflexos.isResiliencyMetricsEnabled" .) "true" }}
+{{- if eq (include "csi-vxflexos.isResiliencyMetricsTLSEnabled" .) "true" }}
+        - name: resiliency-metrics-tls
+          secret:
+            secretName: {{ .Values.podmon.metrics.tlsCertSecret }}
 {{- end }}
 {{- end }}
 {{- if hasKey .Values "authorization" }}

--- a/charts/csi-vxflexos/templates/podmonitor.yaml
+++ b/charts/csi-vxflexos/templates/podmonitor.yaml
@@ -19,11 +19,52 @@ spec:
   podMetricsEndpoints:
     - port: metrics
       interval: {{ .Values.metrics.podMonitor.interval | default "30s" }}
+      {{- if .Values.metrics.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.podMonitor.scrapeTimeout }}
+      {{- end }}
       path: /metrics
       {{- if .Values.metrics.tlsCertSecret }}
       scheme: https
       tlsConfig:
         insecureSkipVerify: {{ .Values.metrics.podMonitor.insecureSkipVerify | default false }}
+      {{- else }}
+      scheme: http
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- if eq (include "csi-vxflexos.isResiliencyMetricsEnabled" .) "true" }}
+{{- if hasKey .Values.podmon.metrics "podMonitor" }}
+{{- if eq .Values.podmon.metrics.podMonitor.enabled true }}
+---
+# PodMonitor for Prometheus Operator integration with podmon resiliency metrics on node pods.
+# Created when podmon.enabled AND podmon.metrics.enabled AND podmon.metrics.podMonitor.enabled are true.
+# Requires the Prometheus Operator CRDs to be installed in the cluster.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Release.Name }}-resiliency-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-node
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-node
+  podMetricsEndpoints:
+    - port: resiliency-metrics
+      interval: {{ .Values.podmon.metrics.podMonitor.interval | default "30s" }}
+      path: /metrics
+      {{- if .Values.podmon.metrics.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.podmon.metrics.podMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.podmon.metrics.tlsCertSecret }}
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: {{ .Values.podmon.metrics.podMonitor.insecureSkipVerify | default false }}
+      {{- else }}
+      scheme: http
       {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/csi-vxflexos/templates/prometheusrule.yaml
+++ b/charts/csi-vxflexos/templates/prometheusrule.yaml
@@ -15,7 +15,573 @@ metadata:
 spec:
   groups:
     - name: {{ .Release.Name }}.rules
-      rules: []
+      rules:
+
+      # ── Category 1: Volume Operation Failures (PF-01–08) ─────────────────
+      # Metric: dell_csi_operation_failure_total{system_id, operation, error_code}
+      # Type: CounterVec | Pattern: increase([5m]) > volumeOperationFailureThreshold, for: 0m, severity: warning
+      # Design note: for: 0m (fires immediately on first evaluation) is intentional for PowerFlex
+      # volume-op failure alerts. PowerScale volume-op alerts use for: 1m to debounce transient
+      # failures; PowerFlex uses for: 0m per ER spec to surface failures as quickly as possible,
+      # accepting occasional transient alerts in exchange for faster detection.
+
+      - alert: PowerFlexCreateVolumeFailure
+        expr: increase(dell_csi_operation_failure_total{namespace="{{ .Release.Namespace }}",operation="CreateVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex CreateVolume failures on system {{ `{{ $labels.system_id }}` }}"
+          description: >
+            {{ `{{ $value | printf "%.0f" }}` }} CreateVolume failure(s) detected in the last 5 minutes
+            on PowerFlex system {{ `{{ $labels.system_id }}` }} (error_code={{ `{{ $labels.error_code }}` }}).
+            Check driver logs and PowerFlex Gateway connectivity.
+          runbook_url: ""
+
+      - alert: PowerFlexDeleteVolumeFailure
+        expr: increase(dell_csi_operation_failure_total{namespace="{{ .Release.Namespace }}",operation="DeleteVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex DeleteVolume failures on system {{ `{{ $labels.system_id }}` }}"
+          description: >
+            {{ `{{ $value | printf "%.0f" }}` }} DeleteVolume failure(s) in the last 5 minutes on
+            system {{ `{{ $labels.system_id }}` }} (error_code={{ `{{ $labels.error_code }}` }}).
+            Orphaned volumes may accumulate. Check Gateway and MDM reachability.
+          runbook_url: ""
+
+      - alert: PowerFlexControllerPublishFailure
+        expr: increase(dell_csi_operation_failure_total{namespace="{{ .Release.Namespace }}",operation="ControllerPublishVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex ControllerPublishVolume failures on system {{ `{{ $labels.system_id }}` }}"
+          description: >
+            {{ `{{ $value | printf "%.0f" }}` }} ControllerPublishVolume failure(s) in the last 5 minutes
+            on system {{ `{{ $labels.system_id }}` }} (error_code={{ `{{ $labels.error_code }}` }}).
+            SDC mapping to volume may have failed. Check SDC registration and node connectivity.
+          runbook_url: ""
+
+      - alert: PowerFlexControllerUnpublishFailure
+        expr: increase(dell_csi_operation_failure_total{namespace="{{ .Release.Namespace }}",operation="ControllerUnpublishVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex ControllerUnpublishVolume failures on system {{ `{{ $labels.system_id }}` }}"
+          description: >
+            {{ `{{ $value | printf "%.0f" }}` }} ControllerUnpublishVolume failure(s) in the last 5 minutes
+            on system {{ `{{ $labels.system_id }}` }} (error_code={{ `{{ $labels.error_code }}` }}).
+            SDC unmap from volume may have failed. Stale SDC mappings may persist.
+          runbook_url: ""
+
+      - alert: PowerFlexNodeStageFailure
+        expr: increase(dell_csi_operation_failure_total{namespace="{{ .Release.Namespace }}",operation="NodeStageVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex NodeStageVolume failures on system {{ `{{ $labels.system_id }}` }}"
+          description: >
+            {{ `{{ $value | printf "%.0f" }}` }} NodeStageVolume failure(s) in the last 5 minutes
+            on system {{ `{{ $labels.system_id }}` }} (error_code={{ `{{ $labels.error_code }}` }}).
+            Block device discovery or filesystem formatting may have failed. Check SDC and device paths.
+          runbook_url: ""
+
+      - alert: PowerFlexNodeUnstageFailure
+        expr: increase(dell_csi_operation_failure_total{namespace="{{ .Release.Namespace }}",operation="NodeUnstageVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex NodeUnstageVolume failures on system {{ `{{ $labels.system_id }}` }}"
+          description: >
+            {{ `{{ $value | printf "%.0f" }}` }} NodeUnstageVolume failure(s) in the last 5 minutes
+            on system {{ `{{ $labels.system_id }}` }} (error_code={{ `{{ $labels.error_code }}` }}).
+            Device unmount or cleanup may have failed. Check node device state.
+          runbook_url: ""
+
+      - alert: PowerFlexNodePublishFailure
+        expr: increase(dell_csi_operation_failure_total{namespace="{{ .Release.Namespace }}",operation="NodePublishVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex NodePublishVolume failures on system {{ `{{ $labels.system_id }}` }}"
+          description: >
+            {{ `{{ $value | printf "%.0f" }}` }} NodePublishVolume failure(s) in the last 5 minutes
+            on system {{ `{{ $labels.system_id }}` }} (error_code={{ `{{ $labels.error_code }}` }}).
+            Bind mount to pod may have failed. Check node filesystem state and kubelet logs.
+          runbook_url: ""
+
+      - alert: PowerFlexNodeUnpublishFailure
+        expr: increase(dell_csi_operation_failure_total{namespace="{{ .Release.Namespace }}",operation="NodeUnpublishVolume"}[5m]) > {{ .Values.metrics.prometheusRule.volumeOperationFailureThreshold | default 3 }}
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex NodeUnpublishVolume failures on system {{ `{{ $labels.system_id }}` }}"
+          description: >
+            {{ `{{ $value | printf "%.0f" }}` }} NodeUnpublishVolume failure(s) in the last 5 minutes
+            on system {{ `{{ $labels.system_id }}` }} (error_code={{ `{{ $labels.error_code }}` }}).
+            Bind unmount from pod may have failed. Stale mount points may remain.
+          runbook_url: ""
+
+      # ── Category 2: Driver Health & Resource (PF-09–12) ──────────────────
+      # Metrics: dell_csi_driver_uptime_seconds, dell_csi_driver_restart_total (GaugeVec),
+      #          dell_csi_driver_cpu_usage_percent, dell_csi_driver_memory_usage_bytes
+
+      # PF-09: count()==0 pattern (from PowerScale) avoids absent(job=) which permanently
+      # fires if Prometheus assigns a different job label than the hardcoded value.
+      # pod=~".+-controller-.+" matches Deployment pods (e.g. vxflexos-controller-<rs>-<pod>)
+      # pod=~".+-node-.+"       matches DaemonSet pods  (e.g. vxflexos-node-<suffix>)
+      # Note: the collector exports pod name in a label named "pod" (not "instance") to avoid
+      # conflicting with the Prometheus scrape-target instance label (honorLabels: false renames
+      # exported "instance" to "exported_instance", breaking any regex that expects pod names).
+      - alert: PowerFlexDriverUnavailable
+        expr: >-
+          (count(dell_csi_driver_uptime_seconds{driver="csi-vxflexos", pod=~".+-controller-.+"}) or on() vector(0)) == 0
+          or (count(dell_csi_driver_uptime_seconds{driver="csi-vxflexos", pod=~".+-node-.+"}) or on() vector(0)) == 0
+        for: 5m
+        labels:
+          severity: critical
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: 'PowerFlex CSI driver pods are unavailable'
+          description: >
+            PowerFlex CSI driver has zero controller or zero node instances reporting metrics
+            for 5 minutes. The driver may be crash-looping, evicted, or pending.
+            Volume operations may be unavailable. Immediate investigation required.
+          runbook_url: ""
+
+      - alert: PowerFlexDriverCrashLooping
+        expr: changes(dell_csi_driver_restart_total{driver="csi-vxflexos"}[15m]) > {{ .Values.metrics.prometheusRule.restartCountThreshold | default 3 }}
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex CSI driver pod {{ `{{ $labels.pod }}` }} is crash-looping"
+          description: >
+            The PowerFlex CSI driver pod {{ `{{ $labels.pod }}` }} has restarted
+            {{ `{{ $value | printf "%.0f" }}` }} times in the last 15 minutes (driver={{ `{{ $labels.driver }}` }}).
+            This indicates a CrashLoopBackOff condition. Check pod events and driver logs.
+          runbook_url: ""
+
+      - alert: PowerFlexDriverHighCPU
+        expr: dell_csi_driver_cpu_usage_percent{driver="csi-vxflexos"} > {{ .Values.metrics.prometheusRule.cpuWarningThreshold | default 80 }}
+        for: 5m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex CSI driver pod {{ `{{ $labels.pod }}` }} has high CPU usage"
+          description: >
+            CPU usage for PowerFlex CSI driver pod {{ `{{ $labels.pod }}` }} is {{ `{{ $value | printf "%.1f" }}` }}%,
+            exceeding the {{ .Values.metrics.prometheusRule.cpuWarningThreshold | default 80 }}% threshold for 5 minutes.
+            Sustained high CPU may indicate excessive concurrent operations or a processing bottleneck.
+          runbook_url: ""
+
+      - alert: PowerFlexDriverHighMemory
+        expr: dell_csi_driver_memory_usage_bytes{driver="csi-vxflexos"} > {{ .Values.metrics.prometheusRule.memoryWarningThreshold | default 2147483648 }}
+        for: 5m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex CSI driver pod {{ `{{ $labels.pod }}` }} has high memory usage"
+          description: >
+            Memory usage for PowerFlex CSI driver pod {{ `{{ $labels.pod }}` }} is
+            {{ `{{ $value | printf "%.0f" }}` }} bytes, exceeding the
+            {{ .Values.metrics.prometheusRule.memoryWarningThreshold | default 2147483648 }}-byte threshold for 5 minutes.
+            This may indicate a memory leak. Review goroutine count and pending operation queues.
+          runbook_url: ""
+
+      # ── Category 3: Storage Capacity & Connectivity (PF-13–17) ───────────
+      # Metrics prefix: dell_powerflex_storage_pool_* (NOT dell_powerflex_pool_*)
+      # Labels: {system_id, array_id, pool_id, pool_name}
+
+      - alert: PowerFlexPoolCapacityWarning
+        expr: dell_powerflex_storage_pool_utilization_ratio * 100 > {{ .Values.metrics.prometheusRule.poolCapacityWarningPercent | default 80 }}
+        for: 5m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex storage pool {{ `{{ $labels.pool_name }}` }} capacity warning"
+          description: >
+            Storage pool {{ `{{ $labels.pool_name }}` }} (pool_id={{ `{{ $labels.pool_id }}` }}) on array
+            {{ `{{ $labels.array_id }}` }} is {{ `{{ $value | printf "%.1f" }}` }}% full, exceeding the
+            {{ .Values.metrics.prometheusRule.poolCapacityWarningPercent | default 80 }}% warning threshold.
+            Plan capacity expansion to avoid service disruption.
+          runbook_url: ""
+
+      - alert: PowerFlexPoolCapacityCritical
+        expr: dell_powerflex_storage_pool_utilization_ratio * 100 > {{ .Values.metrics.prometheusRule.poolCapacityCriticalPercent | default 90 }}
+        for: 5m
+        labels:
+          severity: critical
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex storage pool {{ `{{ $labels.pool_name }}` }} capacity critical"
+          description: >
+            Storage pool {{ `{{ $labels.pool_name }}` }} (pool_id={{ `{{ $labels.pool_id }}` }}) on array
+            {{ `{{ $labels.array_id }}` }} is {{ `{{ $value | printf "%.1f" }}` }}% full, exceeding the
+            {{ .Values.metrics.prometheusRule.poolCapacityCriticalPercent | default 90 }}% critical threshold.
+            Volume creation will fail imminently. Immediate capacity expansion required.
+          runbook_url: ""
+
+      - alert: PowerFlexThinProvisioningHighRatio
+        expr: dell_powerflex_storage_pool_thin_ratio > {{ .Values.metrics.prometheusRule.thinRatioWarningThreshold | default 0.8 }}
+        for: 5m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex pool {{ `{{ $labels.pool_name }}` }} thin provisioning ratio is high"
+          description: >
+            Thin provisioning ratio for pool {{ `{{ $labels.pool_name }}` }} (pool_id={{ `{{ $labels.pool_id }}` }})
+            on array {{ `{{ $labels.array_id }}` }} is {{ `{{ $value | printf "%.2f" }}` }}.
+            If all volumes are simultaneously fully written, pool capacity may be exhausted.
+            Review volume sizing and reclamation policies.
+          runbook_url: ""
+
+      - alert: PowerFlexDataReductionDegraded
+        expr: dell_powerflex_storage_pool_data_reduction_ratio < {{ .Values.metrics.prometheusRule.dataReductionDegradedThreshold | default 1.5 }}
+        for: 15m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex pool {{ `{{ $labels.pool_name }}` }} data reduction ratio is degraded"
+          description: >
+            Data reduction ratio for pool {{ `{{ $labels.pool_name }}` }} (pool_id={{ `{{ $labels.pool_id }}` }})
+            on array {{ `{{ $labels.array_id }}` }} is {{ `{{ $value | printf "%.2f" }}` }}x, below the
+            {{ .Values.metrics.prometheusRule.dataReductionDegradedThreshold | default 1.5 }}x threshold.
+            Compression or deduplication efficiency may have degraded.
+            Review workload data characteristics and verify compression/deduplication features are enabled.
+          runbook_url: ""
+
+      - alert: PowerFlexArrayConnectivityLost
+        expr: dell_powerflex_array_healthy == 0
+        for: 5m
+        labels:
+          severity: critical
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex array {{ `{{ $labels.system_id }}` }} is unreachable"
+          description: >
+            The PowerFlex array (system_id={{ `{{ $labels.system_id }}` }}) has been unreachable for 5 minutes.
+            This alert fires when either: (1) the PowerFlex Gateway cannot be reached, or
+            (2) the MDM cluster state is not "online" or "configured".
+            All volume operations against this array will fail.
+          runbook_url: ""
+
+      # ── Category 4: RCG Replication Alerts (PF-18–26) ────────────────────
+      # Metrics: dell_powerflex_rcg_* — labels: {system_id, rcg_id, rcg_name, ...}
+      # PF-18: info-style metric — {state!="Consistent"} == 1
+      # PF-19: rcg_link_status does NOT exist — use rcg_activity_state{direction="local"}
+      # PF-21: 'and' guard prevents false-positives when RCG is frozen (PF-23) or paused (PF-24)
+      # PF-26: dynamic RPO violation — lag > per-RCG rpo_seconds; rpo > 0 guard skips unconfigured RCGs
+
+      - alert: PowerFlexRCGStateNotConsistent
+        expr: dell_powerflex_rcg_state{state!="Consistent"} == 1
+        for: 5m
+        labels:
+          severity: critical
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex RCG {{ `{{ $labels.rcg_name }}` }} is not in Consistent state"
+          description: >
+            Replication Consistency Group {{ `{{ $labels.rcg_name }}` }} (rcg_id={{ `{{ $labels.rcg_id }}` }})
+            on system {{ `{{ $labels.system_id }}` }} has been in state "{{ `{{ $labels.state }}` }}" for 5 minutes.
+            Expected state: "Consistent". This may indicate a replication link issue, lag overflow,
+            or active failover. Investigate immediately to avoid data protection gap.
+          runbook_url: ""
+
+      - alert: PowerFlexRCGInactive
+        expr: dell_powerflex_rcg_activity_state{direction="local"} == 0
+        for: 5m
+        labels:
+          severity: critical
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex RCG {{ `{{ $labels.rcg_name }}` }} local activity is inactive"
+          description: >
+            Replication Consistency Group {{ `{{ $labels.rcg_name }}` }} (rcg_id={{ `{{ $labels.rcg_id }}` }})
+            on system {{ `{{ $labels.system_id }}` }} local direction has been inactive for 5 minutes.
+            The replication link may be down. Check network connectivity to the remote site.
+          runbook_url: ""
+
+      - alert: PowerFlexRCGLagExceeded
+        expr: dell_powerflex_rcg_lag_persistent_seconds > {{ .Values.metrics.prometheusRule.rcgLagWarningSeconds | default 300 }}
+        for: 5m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex RCG {{ `{{ $labels.rcg_name }}` }} persistent lag exceeds threshold"
+          description: >
+            Replication Consistency Group {{ `{{ $labels.rcg_name }}` }} (rcg_id={{ `{{ $labels.rcg_id }}` }})
+            on system {{ `{{ $labels.system_id }}` }} has persistent lag of {{ `{{ $value | printf "%.0f" }}` }} seconds,
+            exceeding the {{ .Values.metrics.prometheusRule.rcgLagWarningSeconds | default 300 }}-second threshold.
+            Persistent lag represents data not yet durably committed at the target, directly
+            impacting RPO compliance. Investigate replication bandwidth and target-side health.
+          runbook_url: ""
+
+      - alert: PowerFlexRCGBandwidthDegraded
+        expr: >-
+          dell_powerflex_rcg_transmit_bandwidth_kbps < {{ .Values.metrics.prometheusRule.rcgBandwidthWarningKBps | default 10240 }}
+          and on(system_id, rcg_id, rcg_name)
+          dell_powerflex_rcg_activity_state{direction="local"} == 1
+          and on(system_id, rcg_id, rcg_name)
+          dell_powerflex_rcg_lag_persistent_seconds > 0
+          and on(system_id, rcg_id, rcg_name)
+          dell_powerflex_rcg_freeze_state == 0
+          and on(system_id, rcg_id, rcg_name)
+          dell_powerflex_rcg_pause_mode == 0
+        for: 5m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex RCG {{ `{{ $labels.rcg_name }}` }} transmit bandwidth is degraded"
+          description: >
+            Replication Consistency Group {{ `{{ $labels.rcg_name }}` }} (rcg_id={{ `{{ $labels.rcg_id }}` }})
+            on system {{ `{{ $labels.system_id }}` }} transmit bandwidth is {{ `{{ $value | printf "%.0f" }}` }} KB/s,
+            below the {{ .Values.metrics.prometheusRule.rcgBandwidthWarningKBps | default 10240 }} KB/s threshold
+            for 5 minutes while the RCG is actively replicating.
+            Low bandwidth may cause lag buildup. Check network capacity and QoS policies.
+          runbook_url: ""
+
+      - alert: PowerFlexRCGLatencyHigh
+        expr: dell_powerflex_rcg_transmit_latency_seconds > {{ .Values.metrics.prometheusRule.rcgLatencyWarningSeconds | default 5.0 }}
+        for: 5m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex RCG {{ `{{ $labels.rcg_name }}` }} transmit latency is high"
+          description: >
+            Replication Consistency Group {{ `{{ $labels.rcg_name }}` }} (rcg_id={{ `{{ $labels.rcg_id }}` }})
+            on system {{ `{{ $labels.system_id }}` }} transmit latency is {{ `{{ $value | printf "%.2f" }}` }} seconds,
+            exceeding the {{ .Values.metrics.prometheusRule.rcgLatencyWarningSeconds | default 5.0 }}-second threshold
+            for 5 minutes. High transmit latency indicates WAN or network congestion on the replication path.
+          runbook_url: ""
+
+      - alert: PowerFlexRCGFrozen
+        expr: dell_powerflex_rcg_freeze_state == 1
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex RCG {{ `{{ $labels.rcg_name }}` }} is frozen"
+          description: >
+            Replication Consistency Group {{ `{{ $labels.rcg_name }}` }} (rcg_id={{ `{{ $labels.rcg_id }}` }})
+            on system {{ `{{ $labels.system_id }}` }} is in frozen state.
+            Replication is paused and data changes are not being replicated to the target.
+            Verify whether this is an intentional administrative action.
+          runbook_url: ""
+
+      - alert: PowerFlexRCGPaused
+        expr: dell_powerflex_rcg_pause_mode == 1
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex RCG {{ `{{ $labels.rcg_name }}` }} is paused"
+          description: >
+            Replication Consistency Group {{ `{{ $labels.rcg_name }}` }} (rcg_id={{ `{{ $labels.rcg_id }}` }})
+            on system {{ `{{ $labels.system_id }}` }} is in paused mode.
+            Replication data transfer is paused; lag will accumulate.
+            Verify whether this is an intentional administrative action.
+          runbook_url: ""
+
+      - alert: PowerFlexRCGFailoverActive
+        expr: dell_powerflex_rcg_failover_state == 1
+        for: 0m
+        labels:
+          severity: info
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex RCG {{ `{{ $labels.rcg_name }}` }} failover is active"
+          description: >
+            Replication Consistency Group {{ `{{ $labels.rcg_name }}` }} (rcg_id={{ `{{ $labels.rcg_id }}` }})
+            on system {{ `{{ $labels.system_id }}` }} has an active failover state.
+            This alert is informational. Verify that failover was intentional and monitor
+            recovery progress.
+          runbook_url: ""
+
+      - alert: PowerFlexRCGRPOViolation
+        expr: >-
+          dell_powerflex_rcg_lag_persistent_seconds
+          > on(system_id, rcg_id, rcg_name)
+          dell_powerflex_rcg_rpo_seconds
+          and on(system_id, rcg_id, rcg_name)
+          dell_powerflex_rcg_rpo_seconds > 0
+        for: 5m
+        labels:
+          severity: critical
+          platform: powerflex
+          component: csi-driver
+          namespace: {{ .Release.Namespace }}
+        annotations:
+          summary: "PowerFlex RCG {{ `{{ $labels.rcg_name }}` }} RPO violation"
+          description: >
+            Replication Consistency Group {{ `{{ $labels.rcg_name }}` }} (rcg_id={{ `{{ $labels.rcg_id }}` }})
+            on system {{ `{{ $labels.system_id }}` }} has persistent lag of {{ `{{ $value | printf "%.0f" }}` }} seconds,
+            exceeding the per-RCG recovery point objective (RPO).
+            Data protection is at risk. Investigate replication health immediately
+            to prevent data loss exposure.
+          runbook_url: ""
+
 {{- end }}
 {{- end }}
+{{- end }}
+{{- if and .Values.podmon .Values.podmon.enabled (hasKey .Values.podmon "metrics") .Values.podmon.metrics.enabled (hasKey .Values.podmon.metrics "prometheusRule") (eq .Values.podmon.metrics.prometheusRule.enabled true) }}
+---
+# PrometheusRule for PowerFlex CSI Driver resiliency alerting rules.
+# Created when podmon.metrics.prometheusRule.enabled is true.
+# Requires the Prometheus Operator CRDs to be installed in the cluster.
+#
+# CSM Resiliency Alerts (RES-01 to RES-04):
+# Cross-platform PodMon failover and connectivity alerts scoped to this driver.
+# These rules evaluate metrics emitted by PodMon sidecars running in this driver's pods.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-resiliency-alerts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  groups:
+    - name: csm-resiliency-powerflex
+      interval: 30s
+      rules:
+        # RES-01 — Pod failure detected due to node unreachable
+        - alert: CSMResiliencyPodFailureDetected
+          expr: increase(dell_csm_resiliency_failover_total{reason="node_unreachable",driver="csi-vxflexos"}[5m]) > 0
+          for: 0m
+          labels:
+            severity: warning
+            component: csm-resiliency
+            platform: powerflex
+            driver: csi-vxflexos
+            alert_id: RES-01
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Resiliency pod failure detected for driver {{`{{ $labels.driver }}`}}"
+            description: "Pod failure detected due to node unreachable for driver {{`{{ $labels.driver }}`}}."
+            runbook_url: ""
+
+        # RES-02 — Connectivity success ratio below threshold
+        - alert: CSMResiliencyConnectivityLost
+          expr: dell_csm_resiliency_connectivity_success_ratio{driver="csi-vxflexos"} * 100 < {{ .Values.podmon.metrics.prometheusRule.connectivitySuccessRatio | default 90 }}
+          for: 2m
+          labels:
+            severity: critical
+            component: csm-resiliency
+            platform: powerflex
+            driver: csi-vxflexos
+            alert_id: RES-02
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Resiliency connectivity lost for driver {{`{{ $labels.driver }}`}}"
+            description: "Volume connectivity success ratio for driver {{`{{ $labels.driver }}`}} is below {{ .Values.podmon.metrics.prometheusRule.connectivitySuccessRatio | default 90 }}%."
+            runbook_url: ""
+
+        # RES-03 — Automated failover triggered successfully (info: expected behavior)
+        - alert: CSMResiliencyFailoverTriggered
+          expr: increase(dell_csm_resiliency_failover_total{status="success",driver="csi-vxflexos"}[5m]) > 0
+          for: 0m
+          labels:
+            severity: info
+            component: csm-resiliency
+            platform: powerflex
+            driver: csi-vxflexos
+            alert_id: RES-03
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Resiliency automated failover triggered for driver {{`{{ $labels.driver }}`}}"
+            description: "Automated pod failover operation initiated successfully for driver {{`{{ $labels.driver }}`}}. Reason: {{`{{ $labels.reason }}`}}."
+            runbook_url: ""
+
+        # RES-04 — Automated failover failed
+        - alert: CSMResiliencyFailoverFailed
+          expr: increase(dell_csm_resiliency_failover_total{status="failure",driver="csi-vxflexos"}[5m]) > 0
+          for: 0m
+          labels:
+            severity: critical
+            component: csm-resiliency
+            platform: powerflex
+            driver: csi-vxflexos
+            alert_id: RES-04
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Resiliency failover failed for driver {{`{{ $labels.driver }}`}}"
+            description: "Automated pod failover operation failed for driver {{`{{ $labels.driver }}`}}. Reason: {{`{{ $labels.reason }}`}}. Manual intervention may be required."
+            runbook_url: ""
 {{- end }}

--- a/charts/csi-vxflexos/templates/servicemonitor.yaml
+++ b/charts/csi-vxflexos/templates/servicemonitor.yaml
@@ -19,6 +19,9 @@ spec:
   endpoints:
     - port: metrics
       interval: {{ .Values.metrics.serviceMonitor.interval | default "30s" }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
       path: /metrics
       {{- if .Values.metrics.tlsCertSecret }}
       scheme: https
@@ -27,7 +30,73 @@ spec:
         # Set insecureSkipVerify to true if the certificate is self-signed;
         # alternatively configure ca, cert, and keySecret for full verification.
         insecureSkipVerify: {{ .Values.metrics.serviceMonitor.insecureSkipVerify | default false }}
+      {{- else }}
+      scheme: http
       {{- end }}
 {{- end }}
+{{- end }}
+{{- end }}
+
+{{- if eq (include "csi-vxflexos.isResiliencyMetricsEnabled" .) "true" }}
+{{- if hasKey .Values.podmon.metrics "serviceMonitor" }}
+{{- if eq .Values.podmon.metrics.serviceMonitor.enabled true }}
+---
+# ServiceMonitor for Prometheus Operator integration with podmon resiliency metrics on controller pods.
+# Created when podmon.enabled AND podmon.metrics.enabled AND podmon.metrics.serviceMonitor.enabled are true.
+# Requires the Prometheus Operator CRDs to be installed in the cluster.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-resiliency-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-controller
+  endpoints:
+    - port: resiliency-metrics
+      interval: {{ .Values.podmon.metrics.serviceMonitor.interval | default "30s" }}
+      path: /metrics
+      {{- if .Values.podmon.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.podmon.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.podmon.metrics.tlsCertSecret }}
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: {{ .Values.podmon.metrics.serviceMonitor.insecureSkipVerify | default false }}
+      {{- else }}
+      scheme: http
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if and (hasKey .Values.controller "replication") .Values.controller.replication.enabled (hasKey .Values.controller.replication "metrics") .Values.controller.replication.metrics.enabled }}
+{{- if and (hasKey .Values.controller.replication.metrics "serviceMonitor") .Values.controller.replication.metrics.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-replication-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-controller
+  endpoints:
+    - port: repl-metrics
+      interval: {{ .Values.controller.replication.metrics.serviceMonitor.interval | default "30s" }}
+      {{- if .Values.controller.replication.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.controller.replication.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      path: /metrics
+      {{- if .Values.controller.replication.metrics.tlsCertSecret }}
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: {{ .Values.controller.replication.metrics.serviceMonitor.insecureSkipVerify | default false }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/csi-vxflexos/tests/alert-rules-test.yaml
+++ b/charts/csi-vxflexos/tests/alert-rules-test.yaml
@@ -1,0 +1,1235 @@
+# Copyright (C) 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# alert-rules-test.yaml — promtool test rules for all 26 PowerFlex CSI alert rules.
+# Run: promtool test rules tests/alert-rules-test.yaml
+# Rule source: tests/alert-rules.yaml (default-threshold static render of prometheusrule.yaml)
+#
+# Coverage (FR-4.2): 61 test scenarios across all 26 alerts (minimum required: 28).
+#   - PF-01..08: Volume operation failure alerts (2 scenarios each = 16 total)
+#   - PF-09:     Driver unavailable (4 scenarios — controller, node, both absent, both present)
+#   - PF-10:     Driver crash-loop (2 scenarios)
+#   - PF-11:     High CPU (2 scenarios)
+#   - PF-12:     High Memory (2 scenarios)
+#   - PF-13:     Pool capacity warning (2 scenarios)
+#   - PF-14:     Pool capacity critical (2 scenarios)
+#   - PF-15:     Thin provisioning (2 scenarios)
+#   - PF-16:     Data reduction degraded (3 scenarios — includes for:15m guard)
+#   - PF-17:     Array connectivity lost (2 scenarios)
+#   - PF-18:     RCG state not consistent (2 scenarios)
+#   - PF-19:     RCG inactive (2 scenarios)
+#   - PF-20:     RCG lag exceeded (2 scenarios)
+#   - PF-21:     RCG bandwidth degraded + activity/lag/freeze/pause guards (6 scenarios)
+#   - PF-22:     RCG latency high (2 scenarios)
+#   - PF-23:     RCG frozen (2 scenarios)
+#   - PF-24:     RCG paused (2 scenarios)
+#   - PF-25:     RCG failover active (2 scenarios)
+#   - PF-26:     RCG RPO violation — dynamic lag > rpo (3 scenarios)
+#
+# Notation: `v+sx n` = start v, step s, n times (n+1 values total)
+#           `vx n`   = v repeated (n+1 values, zero step shorthand)
+
+rule_files:
+  - alert-rules.yaml
+
+evaluation_interval: 1m
+
+tests:
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-01: PowerFlexCreateVolumeFailure
+  # expr: increase(dell_csi_operation_failure_total{namespace="vxflexos",operation="CreateVolume"}[5m]) > 3
+  # for: 0m
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-01 FIRE: CreateVolume counter increments over 5 minutes"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{error_code="5",namespace="vxflexos",operation="CreateVolume",system_id="sys-abc"}'
+        values: '0+1x5'   # 0,1,2,3,4,5 — counter increases; increase([5m])=5 at t=5m
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexCreateVolumeFailure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerflex
+              component: csi-driver
+              namespace: vxflexos
+              error_code: "5"
+              operation: CreateVolume
+              system_id: sys-abc
+            exp_annotations:
+              summary: "PowerFlex CreateVolume failures on system sys-abc"
+              description: |
+                5 CreateVolume failure(s) detected in the last 5 minutes on PowerFlex system sys-abc (error_code=5). Check driver logs and PowerFlex Gateway connectivity.
+              runbook_url: ""
+
+  - name: "PF-01 NO-FIRE: CreateVolume counter stable (no recent failures)"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{error_code="5",namespace="vxflexos",operation="CreateVolume",system_id="sys-abc"}'
+        values: '10x5'   # counter fixed at 10; increase([5m])=0
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexCreateVolumeFailure
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-02: PowerFlexDeleteVolumeFailure
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-02 FIRE: DeleteVolume counter increments"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{error_code="5",namespace="vxflexos",operation="DeleteVolume",system_id="sys-abc"}'
+        values: '0+2x5'   # 0,2,4,6,8,10 — increase([5m])=10
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexDeleteVolumeFailure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerflex
+              component: csi-driver
+              namespace: vxflexos
+              error_code: "5"
+              operation: DeleteVolume
+              system_id: sys-abc
+            exp_annotations:
+              summary: "PowerFlex DeleteVolume failures on system sys-abc"
+              description: |
+                10 DeleteVolume failure(s) in the last 5 minutes on system sys-abc (error_code=5). Orphaned volumes may accumulate. Check Gateway and MDM reachability.
+              runbook_url: ""
+
+  - name: "PF-02 NO-FIRE: DeleteVolume counter stable"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{error_code="5",namespace="vxflexos",operation="DeleteVolume",system_id="sys-abc"}'
+        values: '5x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexDeleteVolumeFailure
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-03: PowerFlexControllerPublishFailure
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-03 FIRE: ControllerPublishVolume counter increments"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{error_code="5",namespace="vxflexos",operation="ControllerPublishVolume",system_id="sys-abc"}'
+        values: '0+1x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexControllerPublishFailure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerflex
+              component: csi-driver
+              namespace: vxflexos
+              error_code: "5"
+              operation: ControllerPublishVolume
+              system_id: sys-abc
+            exp_annotations:
+              summary: "PowerFlex ControllerPublishVolume failures on system sys-abc"
+              description: |
+                5 ControllerPublishVolume failure(s) in the last 5 minutes on system sys-abc (error_code=5). SDC mapping to volume may have failed. Check SDC registration and node connectivity.
+              runbook_url: ""
+
+  - name: "PF-03 NO-FIRE: ControllerPublishVolume stable"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{error_code="5",namespace="vxflexos",operation="ControllerPublishVolume",system_id="sys-abc"}'
+        values: '3x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexControllerPublishFailure
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-04: PowerFlexControllerUnpublishFailure
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-04 FIRE: ControllerUnpublishVolume counter increments"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{error_code="5",namespace="vxflexos",operation="ControllerUnpublishVolume",system_id="sys-abc"}'
+        values: '0+1x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexControllerUnpublishFailure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerflex
+              component: csi-driver
+              namespace: vxflexos
+              error_code: "5"
+              operation: ControllerUnpublishVolume
+              system_id: sys-abc
+            exp_annotations:
+              summary: "PowerFlex ControllerUnpublishVolume failures on system sys-abc"
+              description: |
+                5 ControllerUnpublishVolume failure(s) in the last 5 minutes on system sys-abc (error_code=5). SDC unmap from volume may have failed. Stale SDC mappings may persist.
+              runbook_url: ""
+
+  - name: "PF-04 NO-FIRE: ControllerUnpublishVolume stable"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{error_code="5",namespace="vxflexos",operation="ControllerUnpublishVolume",system_id="sys-abc"}'
+        values: '7x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexControllerUnpublishFailure
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-05: PowerFlexNodeStageFailure
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-05 FIRE: NodeStageVolume counter increments"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{error_code="server_error",namespace="vxflexos",operation="NodeStageVolume",system_id="unknown"}'
+        values: '0+1x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexNodeStageFailure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerflex
+              component: csi-driver
+              namespace: vxflexos
+              error_code: server_error
+              operation: NodeStageVolume
+              system_id: unknown
+            exp_annotations:
+              summary: "PowerFlex NodeStageVolume failures on system unknown"
+              description: |
+                5 NodeStageVolume failure(s) in the last 5 minutes on system unknown (error_code=server_error). Block device discovery or filesystem formatting may have failed. Check SDC and device paths.
+              runbook_url: ""
+
+  - name: "PF-05 NO-FIRE: NodeStageVolume stable (mirrors live value)"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{error_code="server_error",namespace="vxflexos",operation="NodeStageVolume",system_id="unknown"}'
+        values: '9x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexNodeStageFailure
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-06: PowerFlexNodeUnstageFailure
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-06 FIRE: NodeUnstageVolume counter increments"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{error_code="5",namespace="vxflexos",operation="NodeUnstageVolume",system_id="sys-abc"}'
+        values: '0+1x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexNodeUnstageFailure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerflex
+              component: csi-driver
+              namespace: vxflexos
+              error_code: "5"
+              operation: NodeUnstageVolume
+              system_id: sys-abc
+            exp_annotations:
+              summary: "PowerFlex NodeUnstageVolume failures on system sys-abc"
+              description: |
+                5 NodeUnstageVolume failure(s) in the last 5 minutes on system sys-abc (error_code=5). Device unmount or cleanup may have failed. Check node device state.
+              runbook_url: ""
+
+  - name: "PF-06 NO-FIRE: NodeUnstageVolume stable"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{error_code="5",namespace="vxflexos",operation="NodeUnstageVolume",system_id="sys-abc"}'
+        values: '2x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexNodeUnstageFailure
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-07: PowerFlexNodePublishFailure
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-07 FIRE: NodePublishVolume counter increments"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{error_code="5",namespace="vxflexos",operation="NodePublishVolume",system_id="sys-abc"}'
+        values: '0+1x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexNodePublishFailure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerflex
+              component: csi-driver
+              namespace: vxflexos
+              error_code: "5"
+              operation: NodePublishVolume
+              system_id: sys-abc
+            exp_annotations:
+              summary: "PowerFlex NodePublishVolume failures on system sys-abc"
+              description: |
+                5 NodePublishVolume failure(s) in the last 5 minutes on system sys-abc (error_code=5). Bind mount to pod may have failed. Check node filesystem state and kubelet logs.
+              runbook_url: ""
+
+  - name: "PF-07 NO-FIRE: NodePublishVolume stable"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{error_code="5",namespace="vxflexos",operation="NodePublishVolume",system_id="sys-abc"}'
+        values: '4x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexNodePublishFailure
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-08: PowerFlexNodeUnpublishFailure
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-08 FIRE: NodeUnpublishVolume counter increments"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{error_code="5",namespace="vxflexos",operation="NodeUnpublishVolume",system_id="sys-abc"}'
+        values: '0+1x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexNodeUnpublishFailure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerflex
+              component: csi-driver
+              namespace: vxflexos
+              error_code: "5"
+              operation: NodeUnpublishVolume
+              system_id: sys-abc
+            exp_annotations:
+              summary: "PowerFlex NodeUnpublishVolume failures on system sys-abc"
+              description: |
+                5 NodeUnpublishVolume failure(s) in the last 5 minutes on system sys-abc (error_code=5). Bind unmount from pod may have failed. Stale mount points may remain.
+              runbook_url: ""
+
+  - name: "PF-08 NO-FIRE: NodeUnpublishVolume stable"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_operation_failure_total{error_code="5",namespace="vxflexos",operation="NodeUnpublishVolume",system_id="sys-abc"}'
+        values: '6x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexNodeUnpublishFailure
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-09: PowerFlexDriverUnavailable
+  # expr: (count(dell_csi_driver_uptime_seconds{driver="csi-vxflexos", pod=~".+-controller-.+"}) or on() vector(0)) == 0
+  #       or (count(dell_csi_driver_uptime_seconds{driver="csi-vxflexos", pod=~".+-node-.+"}) or on() vector(0)) == 0
+  # for: 5m
+  # Uses count()==0 (PowerScale pattern) instead of absent(job=) to avoid false positives
+  # when Prometheus assigns a job label different from a hardcoded value.
+  # pod=~".+-controller-.+" matches Deployment pods (vxflexos-controller-<rs>-<pod>)
+  # pod=~".+-node-.+"       matches DaemonSet pods  (vxflexos-node-<suffix>)
+  # count() returns no series labels, so the alert fires as a single instance.
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-09 FIRE: no series present — both count()==0 arms true, one alert fires"
+    interval: 1m
+    input_series: []  # no input → count() returns no data → or on() vector(0) → 0==0 → true
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexDriverUnavailable
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              platform: powerflex
+              component: csi-driver
+            exp_annotations:
+              summary: "PowerFlex CSI driver pods are unavailable"
+              description: >
+                PowerFlex CSI driver has zero controller or zero node instances reporting metrics
+                for 5 minutes. The driver may be crash-looping, evicted, or pending.
+                Volume operations may be unavailable. Immediate investigation required.
+              runbook_url: ""
+
+  - name: "PF-09 FIRE: only node pods reporting — controller count==0 arm fires"
+    interval: 1m
+    input_series:
+      # Only node DaemonSet pods present; controller Deployment pods are down.
+      # "vxflexos-node-worker1" matches .+-node-.+ but NOT .+-controller-.+
+      - series: 'dell_csi_driver_uptime_seconds{driver="csi-vxflexos",pod="vxflexos-node-worker1"}'
+        values: '25000+60x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexDriverUnavailable
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              platform: powerflex
+              component: csi-driver
+            exp_annotations:
+              summary: "PowerFlex CSI driver pods are unavailable"
+              description: >
+                PowerFlex CSI driver has zero controller or zero node instances reporting metrics
+                for 5 minutes. The driver may be crash-looping, evicted, or pending.
+                Volume operations may be unavailable. Immediate investigation required.
+              runbook_url: ""
+
+  - name: "PF-09 FIRE: only controller pods reporting — node count==0 arm fires"
+    interval: 1m
+    input_series:
+      # Only controller Deployment pods present; node DaemonSet pods are down.
+      # "vxflexos-controller-abc-xyz" matches .+-controller-.+ but NOT .+-node-.+
+      - series: 'dell_csi_driver_uptime_seconds{driver="csi-vxflexos",pod="vxflexos-controller-abc-xyz"}'
+        values: '100000+60x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexDriverUnavailable
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              platform: powerflex
+              component: csi-driver
+            exp_annotations:
+              summary: "PowerFlex CSI driver pods are unavailable"
+              description: >
+                PowerFlex CSI driver has zero controller or zero node instances reporting metrics
+                for 5 minutes. The driver may be crash-looping, evicted, or pending.
+                Volume operations may be unavailable. Immediate investigation required.
+              runbook_url: ""
+
+  - name: "PF-09 NO-FIRE: both controller and node metrics present"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_driver_uptime_seconds{driver="csi-vxflexos",pod="vxflexos-controller-abc-xyz"}'
+        values: '100000+60x5'
+      - series: 'dell_csi_driver_uptime_seconds{driver="csi-vxflexos",pod="vxflexos-node-worker1"}'
+        values: '25000+60x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexDriverUnavailable
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-10: PowerFlexDriverCrashLooping
+  # expr: changes(dell_csi_driver_restart_total{driver="csi-vxflexos"}[15m]) > 3
+  # for: 0m  — uses changes() (counts value transitions) rather than delta() because
+  #            changes() is resilient to staleness gaps caused by container restarts.
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-10 FIRE: restart count transitions=4 in 15 minutes (above threshold of 3)"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_driver_restart_total{driver="csi-vxflexos",pod="vxflexos-controller-abc"}'
+        # t=0 is baseline (excluded from (0m,15m] window at eval_time=15m). t=1 stays at 0,
+        # then 4 increments at t=2..5. changes((0m,15m])=4>3 → FIRE.
+        values: '0 0 1 2 3 4 4 4 4 4 4 4 4 4 4 4'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: PowerFlexDriverCrashLooping
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerflex
+              component: csi-driver
+              driver: csi-vxflexos
+              pod: vxflexos-controller-abc
+            exp_annotations:
+              summary: "PowerFlex CSI driver pod vxflexos-controller-abc is crash-looping"
+              description: |
+                The PowerFlex CSI driver pod vxflexos-controller-abc has restarted 4 times in the last 15 minutes (driver=csi-vxflexos). This indicates a CrashLoopBackOff condition. Check pod events and driver logs.
+              runbook_url: ""
+
+  - name: "PF-10 NO-FIRE: restart count transitions=2 (at or below threshold of 3)"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_driver_restart_total{driver="csi-vxflexos",pod="vxflexos-controller-abc"}'
+        # 2 transitions in window — does not exceed threshold of 3
+        values: '0 0 1 2 2 2 2 2 2 2 2 2 2 2 2 2'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: PowerFlexDriverCrashLooping
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-11: PowerFlexDriverHighCPU
+  # expr: dell_csi_driver_cpu_usage_percent{driver="csi-vxflexos"} > 80
+  # for: 5m
+  # Note: Only controller pod emits this metric (driver-level limitation).
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-11 FIRE: CPU at 85% for 5 minutes (above 80% threshold)"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_driver_cpu_usage_percent{driver="csi-vxflexos",pod="vxflexos-controller-abc"}'
+        values: '85x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexDriverHighCPU
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerflex
+              component: csi-driver
+              driver: csi-vxflexos
+              pod: vxflexos-controller-abc
+            exp_annotations:
+              summary: "PowerFlex CSI driver pod vxflexos-controller-abc has high CPU usage"
+              description: |
+                CPU usage for PowerFlex CSI driver pod vxflexos-controller-abc is 85.0%, exceeding the 80% threshold for 5 minutes. Sustained high CPU may indicate excessive concurrent operations or a processing bottleneck.
+              runbook_url: ""
+
+  - name: "PF-11 NO-FIRE: CPU at 79% (below 80% threshold)"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_driver_cpu_usage_percent{driver="csi-vxflexos",pod="vxflexos-controller-abc"}'
+        values: '79x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexDriverHighCPU
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-12: PowerFlexDriverHighMemory
+  # expr: dell_csi_driver_memory_usage_bytes{driver="csi-vxflexos"} > 2147483648
+  # for: 5m — default 2 GiB = 2147483648 bytes
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-12 FIRE: memory at 2.5 GiB for 5 minutes (above 2 GiB threshold)"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_driver_memory_usage_bytes{driver="csi-vxflexos",pod="vxflexos-controller-abc"}'
+        values: '2684354560x5'   # 2.5 GiB
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexDriverHighMemory
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerflex
+              component: csi-driver
+              driver: csi-vxflexos
+              pod: vxflexos-controller-abc
+            exp_annotations:
+              summary: "PowerFlex CSI driver pod vxflexos-controller-abc has high memory usage"
+              description: |
+                Memory usage for PowerFlex CSI driver pod vxflexos-controller-abc is 2684354560 bytes, exceeding the 2 GiB (2147483648 bytes) threshold for 5 minutes. This may indicate a memory leak. Review goroutine count and pending operation queues.
+              runbook_url: ""
+
+  - name: "PF-12 NO-FIRE: memory at 1.5 GiB (below 2 GiB threshold)"
+    interval: 1m
+    input_series:
+      - series: 'dell_csi_driver_memory_usage_bytes{driver="csi-vxflexos",pod="vxflexos-controller-abc"}'
+        values: '1610612736x5'   # 1.5 GiB
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexDriverHighMemory
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-13: PowerFlexPoolCapacityWarning
+  # expr: dell_powerflex_storage_pool_utilization_ratio * 100 > 80
+  # for: 5m
+  # Source labels: {array_id, pool_id, pool_name} — verified against live cluster
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-13 FIRE: pool utilization at 81% for 5 minutes (above 80% warning threshold)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_storage_pool_utilization_ratio{array_id="array-001",pool_id="pool-001",pool_name="test-pool"}'
+        values: '0.81x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexPoolCapacityWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerflex
+              component: csi-driver
+              array_id: array-001
+              pool_id: pool-001
+              pool_name: test-pool
+            exp_annotations:
+              summary: "PowerFlex storage pool test-pool capacity warning"
+              description: |
+                Storage pool test-pool (pool_id=pool-001) on array array-001 is 81.0% full, exceeding the 80% warning threshold. Plan capacity expansion to avoid service disruption.
+              runbook_url: ""
+
+  - name: "PF-13 NO-FIRE: pool utilization at 79% (below 80% warning threshold boundary)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_storage_pool_utilization_ratio{array_id="array-001",pool_id="pool-001",pool_name="test-pool"}'
+        values: '0.79x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexPoolCapacityWarning
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-14: PowerFlexPoolCapacityCritical
+  # expr: dell_powerflex_storage_pool_utilization_ratio * 100 > 90
+  # for: 5m
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-14 FIRE: pool utilization at 91% for 5 minutes (above 90% critical threshold)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_storage_pool_utilization_ratio{array_id="array-001",pool_id="pool-001",pool_name="test-pool"}'
+        values: '0.91x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexPoolCapacityCritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              platform: powerflex
+              component: csi-driver
+              array_id: array-001
+              pool_id: pool-001
+              pool_name: test-pool
+            exp_annotations:
+              summary: "PowerFlex storage pool test-pool capacity critical"
+              description: |
+                Storage pool test-pool (pool_id=pool-001) on array array-001 is 91.0% full, exceeding the 90% critical threshold. Volume creation will fail imminently. Immediate capacity expansion required.
+              runbook_url: ""
+
+  - name: "PF-14 NO-FIRE: pool utilization at 89% (below 90% critical threshold boundary)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_storage_pool_utilization_ratio{array_id="array-001",pool_id="pool-001",pool_name="test-pool"}'
+        values: '0.89x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexPoolCapacityCritical
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-15: PowerFlexThinProvisioningHighRatio
+  # expr: dell_powerflex_storage_pool_thin_ratio > 0.8
+  # for: 5m
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-15 FIRE: thin ratio at 0.85 for 5 minutes (above 0.8 threshold)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_storage_pool_thin_ratio{array_id="array-001",pool_id="pool-001",pool_name="test-pool"}'
+        values: '0.85x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexThinProvisioningHighRatio
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerflex
+              component: csi-driver
+              array_id: array-001
+              pool_id: pool-001
+              pool_name: test-pool
+            exp_annotations:
+              summary: "PowerFlex pool test-pool thin provisioning ratio is high"
+              description: |
+                Thin provisioning ratio for pool test-pool (pool_id=pool-001) on array array-001 is 0.85. If all volumes are simultaneously fully written, pool capacity may be exhausted. Review volume sizing and reclamation policies.
+              runbook_url: ""
+
+  - name: "PF-15 NO-FIRE: thin ratio at 0.75 (below 0.8 threshold)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_storage_pool_thin_ratio{array_id="array-001",pool_id="pool-001",pool_name="test-pool"}'
+        values: '0.75x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexThinProvisioningHighRatio
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-16: PowerFlexDataReductionDegraded
+  # expr: dell_powerflex_storage_pool_data_reduction_ratio < 1.5
+  # for: 15m  — longer window prevents false positives on transient workload shifts
+  # Three scenarios: fire at 15m, no-fire ratio OK, no-fire (for:15m guard at 5m)
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-16 FIRE: data reduction ratio at 1.3 for 15 minutes (below 1.5 threshold)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_storage_pool_data_reduction_ratio{array_id="array-001",pool_id="pool-001",pool_name="test-pool"}'
+        values: '1.3x15'   # 1.3 < 1.5 continuously for 16 samples (t=0..15m)
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: PowerFlexDataReductionDegraded
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerflex
+              component: csi-driver
+              array_id: array-001
+              pool_id: pool-001
+              pool_name: test-pool
+            exp_annotations:
+              summary: "PowerFlex pool test-pool data reduction ratio is degraded"
+              description: |
+                Data reduction ratio for pool test-pool (pool_id=pool-001) on array array-001 is 1.30x, below the 1.5x threshold. Compression or deduplication efficiency may have degraded. Review workload data characteristics and verify compression/deduplication features are enabled.
+              runbook_url: ""
+
+  - name: "PF-16 NO-FIRE: data reduction ratio at 2.0 (above 1.5 threshold — healthy)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_storage_pool_data_reduction_ratio{array_id="array-001",pool_id="pool-001",pool_name="test-pool"}'
+        values: '2.0x15'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: PowerFlexDataReductionDegraded
+        exp_alerts: []
+
+  - name: "PF-16 NO-FIRE: for:15m guard — ratio below threshold for only 5 minutes"
+    # BR scenario: transient dip for <15m must NOT fire
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_storage_pool_data_reduction_ratio{array_id="array-001",pool_id="pool-001",pool_name="test-pool"}'
+        values: '1.3x5'   # only 6 values (t=0..5m); condition true for only 5m < for:15m
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexDataReductionDegraded
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-17: PowerFlexArrayConnectivityLost
+  # expr: dell_powerflex_array_healthy == 0
+  # for: 5m — Labels: {system_id} (verified against live cluster value=0)
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-17 FIRE: array_healthy=0 for 5 minutes (array unreachable)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_array_healthy{system_id="sys-001"}'
+        values: '0x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexArrayConnectivityLost
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              platform: powerflex
+              component: csi-driver
+              system_id: sys-001
+            exp_annotations:
+              summary: "PowerFlex array sys-001 is unreachable"
+              description: |
+                The PowerFlex array (system_id=sys-001) has been unreachable for 5 minutes. This alert fires when either: (1) the PowerFlex Gateway cannot be reached, or (2) the MDM cluster state is not "online" or "configured". All volume operations against this array will fail.
+              runbook_url: ""
+
+  - name: "PF-17 NO-FIRE: array_healthy=1 (array reachable)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_array_healthy{system_id="sys-001"}'
+        values: '1x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexArrayConnectivityLost
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-18: PowerFlexRCGStateNotConsistent
+  # expr: dell_powerflex_rcg_state{state!="Consistent"} == 1
+  # for: 5m
+  # Source: info-style metric — rcgState.WithLabelValues(..., rcg.State).Set(1)
+  # The state label holds the current state string; value is always 1.
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-18 FIRE: RCG in Inconsistent state for 5 minutes"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg",state="Inconsistent"}'
+        values: '1x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexRCGStateNotConsistent
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              platform: powerflex
+              component: csi-driver
+              system_id: sys-001
+              rcg_id: rcg-001
+              rcg_name: test-rcg
+              state: Inconsistent
+            exp_annotations:
+              summary: "PowerFlex RCG test-rcg is not in Consistent state"
+              description: |
+                Replication Consistency Group test-rcg (rcg_id=rcg-001) on system sys-001 has been in state "Inconsistent" for 5 minutes. Expected state: "Consistent". This may indicate a replication link issue, lag overflow, or active failover. Investigate immediately to avoid data protection gap.
+              runbook_url: ""
+
+  - name: "PF-18 NO-FIRE: RCG in Consistent state (filter excludes it)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg",state="Consistent"}'
+        values: '1x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexRCGStateNotConsistent
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-19: PowerFlexRCGInactive
+  # expr: dell_powerflex_rcg_activity_state{direction="local"} == 0
+  # for: 5m
+  # Source: rcgActivityState.WithLabelValues(..., "local").Set(encodeActivityState(...))
+  # Labels: {system_id, rcg_id, rcg_name, direction}
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-19 FIRE: RCG local activity state inactive (=0) for 5 minutes"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_activity_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg",direction="local"}'
+        values: '0x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexRCGInactive
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              platform: powerflex
+              component: csi-driver
+              system_id: sys-001
+              rcg_id: rcg-001
+              rcg_name: test-rcg
+              direction: local
+            exp_annotations:
+              summary: "PowerFlex RCG test-rcg local activity is inactive"
+              description: |
+                Replication Consistency Group test-rcg (rcg_id=rcg-001) on system sys-001 local direction has been inactive for 5 minutes. The replication link may be down. Check network connectivity to the remote site.
+              runbook_url: ""
+
+  - name: "PF-19 NO-FIRE: RCG local activity state active (=1)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_activity_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg",direction="local"}'
+        values: '1x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexRCGInactive
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-20: PowerFlexRCGLagExceeded
+  # expr: dell_powerflex_rcg_lag_persistent_seconds > 300
+  # for: 5m
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-20 FIRE: persistent lag at 350s for 5 minutes (above 300s threshold)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_lag_persistent_seconds{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '350x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexRCGLagExceeded
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerflex
+              component: csi-driver
+              system_id: sys-001
+              rcg_id: rcg-001
+              rcg_name: test-rcg
+            exp_annotations:
+              summary: "PowerFlex RCG test-rcg persistent lag exceeds threshold"
+              description: |
+                Replication Consistency Group test-rcg (rcg_id=rcg-001) on system sys-001 has persistent lag of 350 seconds, exceeding the 300-second threshold. Persistent lag represents data not yet durably committed at the target, directly impacting RPO compliance. Investigate replication bandwidth and target-side health.
+              runbook_url: ""
+
+  - name: "PF-20 NO-FIRE: persistent lag at 290s (below 300s threshold)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_lag_persistent_seconds{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '290x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexRCGLagExceeded
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-21: PowerFlexRCGBandwidthDegraded
+  # expr: dell_powerflex_rcg_transmit_bandwidth_kbps < 10240
+  #       and on(system_id, rcg_id, rcg_name)
+  #       dell_powerflex_rcg_activity_state{direction="local"} == 1
+  #       and on(system_id, rcg_id, rcg_name)
+  #       dell_powerflex_rcg_lag_persistent_seconds > 0
+  # for: 5m
+  #
+  # CRITICAL FIX: `on(system_id, rcg_id, rcg_name)` is REQUIRED for each join.
+  # Source (rcg_collector.go):
+  #   rcg_transmit_bandwidth_kbps labels: {system_id, rcg_id, rcg_name}            (3 labels)
+  #   rcg_activity_state labels:          {system_id, rcg_id, rcg_name, direction}  (4 labels)
+  #   rcg_lag_persistent_seconds labels:  {system_id, rcg_id, rcg_name}            (3 labels)
+  #   rcg_freeze_state labels:            {system_id, rcg_id, rcg_name}            (3 labels)
+  #   rcg_pause_mode labels:              {system_id, rcg_id, rcg_name}            (3 labels)
+  # Without `on()`, default `and` requires identical label sets → returns nothing in production.
+  # With `on()`, join matches on {system_id, rcg_id, rcg_name}; direction is NOT propagated.
+  #
+  # FALSE-POSITIVE FIX (PF-21): lag_persistent_seconds > 0 guard prevents firing when
+  # replication is healthy but idle (no app writes → bandwidth=0, lag=0).
+  # Alert only fires when data is waiting to replicate (lag>0) but bandwidth is insufficient.
+  #
+  # FREEZE/PAUSE FIX (PF-21): freeze_state == 0 and pause_mode == 0 guards prevent firing
+  # when the RCG is intentionally frozen/paused. Live evidence shows activity_state=1 can
+  # coexist with freeze_state=1 (e.g. failover scenarios), so activity alone is insufficient.
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-21 FIRE: bandwidth below threshold, RCG active, lag > 0, not frozen, not paused"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_transmit_bandwidth_kbps{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '5000x5'   # 5000 KB/s < 10240
+      - series: 'dell_powerflex_rcg_activity_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg",direction="local"}'
+        values: '1x5'   # active; on() joins on {system_id,rcg_id,rcg_name}
+      - series: 'dell_powerflex_rcg_lag_persistent_seconds{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '30x5'   # 30s persistent lag — data waiting to replicate
+      - series: 'dell_powerflex_rcg_freeze_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0x5'   # not frozen — freeze guard passes
+      - series: 'dell_powerflex_rcg_pause_mode{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0x5'   # not paused — pause guard passes
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexRCGBandwidthDegraded
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerflex
+              component: csi-driver
+              system_id: sys-001
+              rcg_id: rcg-001
+              rcg_name: test-rcg   # direction is NOT in result (left-side labels only)
+            exp_annotations:
+              summary: "PowerFlex RCG test-rcg transmit bandwidth is degraded"
+              description: |
+                Replication Consistency Group test-rcg (rcg_id=rcg-001) on system sys-001 transmit bandwidth is 5000 KB/s, below the 10240 KB/s threshold for 5 minutes while the RCG is actively replicating. Low bandwidth may cause lag buildup. Check network capacity and QoS policies.
+              runbook_url: ""
+
+  - name: "PF-21 NO-FIRE: bandwidth=0, activity=1, lag=0 — idle replication (false positive guard)"
+    # PF-21 false-positive scenario: RCG is active but no app writes → bw=0 AND lag=0.
+    # Before fix this would fire because bw < 10240 AND activity=1.
+    # After fix: lag_persistent_seconds=0 guard suppresses the alert.
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_transmit_bandwidth_kbps{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0x5'   # 0 KB/s — no writes; would have triggered without the lag guard
+      - series: 'dell_powerflex_rcg_activity_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg",direction="local"}'
+        values: '1x5'   # active (healthy idle replication)
+      - series: 'dell_powerflex_rcg_lag_persistent_seconds{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0x5'   # lag=0: everything is replicated; no data waiting
+      - series: 'dell_powerflex_rcg_freeze_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0x5'
+      - series: 'dell_powerflex_rcg_pause_mode{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexRCGBandwidthDegraded
+        exp_alerts: []
+
+  - name: "PF-21 NO-FIRE guard: bandwidth low but RCG inactive (activity=0 prevents false positive)"
+    # BR scenario: bandwidth=0, activity=0 → activity guard suppresses alert
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_transmit_bandwidth_kbps{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0x5'   # 0 KB/s — would trigger without the activity guard
+      - series: 'dell_powerflex_rcg_activity_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg",direction="local"}'
+        values: '0x5'   # inactive
+      - series: 'dell_powerflex_rcg_lag_persistent_seconds{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '60x5'   # lag > 0 but activity=0 still suppresses
+      - series: 'dell_powerflex_rcg_freeze_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0x5'
+      - series: 'dell_powerflex_rcg_pause_mode{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexRCGBandwidthDegraded
+        exp_alerts: []
+
+  - name: "PF-21 NO-FIRE: bandwidth above threshold while RCG active"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_transmit_bandwidth_kbps{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '12000x5'   # 12000 KB/s > 10240 — above threshold (OK)
+      - series: 'dell_powerflex_rcg_activity_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg",direction="local"}'
+        values: '1x5'
+      - series: 'dell_powerflex_rcg_lag_persistent_seconds{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '30x5'   # lag present but bandwidth is fine
+      - series: 'dell_powerflex_rcg_freeze_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0x5'
+      - series: 'dell_powerflex_rcg_pause_mode{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexRCGBandwidthDegraded
+        exp_alerts: []
+
+  - name: "PF-21 NO-FIRE: frozen RCG (freeze_state=1) with activity=1 and lag>0 — freeze guard suppresses"
+    # Reviewer-identified gap: activity_state=1 can coexist with freeze_state=1 (observed in live evidence).
+    # The old expression would fire here; the freeze_state==0 guard must suppress it.
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_transmit_bandwidth_kbps{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '1000x5'   # 1000 KB/s < 10240 — would trigger without freeze guard
+      - series: 'dell_powerflex_rcg_activity_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg",direction="local"}'
+        values: '1x5'   # active — as observed in live frozen-RCG evidence
+      - series: 'dell_powerflex_rcg_lag_persistent_seconds{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '120x5'   # 120s positive lag — would trigger without freeze guard
+      - series: 'dell_powerflex_rcg_freeze_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '1x5'   # FROZEN — freeze guard (== 0) prevents alert from firing
+      - series: 'dell_powerflex_rcg_pause_mode{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexRCGBandwidthDegraded
+        exp_alerts: []
+
+  - name: "PF-21 NO-FIRE: paused RCG (pause_mode=1) with activity=1 and lag>0 — pause guard suppresses"
+    # Validates the pause_mode==0 guard independently of freeze_state.
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_transmit_bandwidth_kbps{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '500x5'   # 500 KB/s < 10240
+      - series: 'dell_powerflex_rcg_activity_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg",direction="local"}'
+        values: '1x5'   # active
+      - series: 'dell_powerflex_rcg_lag_persistent_seconds{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '60x5'   # positive lag
+      - series: 'dell_powerflex_rcg_freeze_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0x5'
+      - series: 'dell_powerflex_rcg_pause_mode{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '1x5'   # PAUSED — pause guard (== 0) prevents alert from firing
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexRCGBandwidthDegraded
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-22: PowerFlexRCGLatencyHigh
+  # expr: dell_powerflex_rcg_transmit_latency_seconds > 5.0
+  # for: 5m
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-22 FIRE: RCG transmit latency at 6.5s for 5 minutes (above 5.0s threshold)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_transmit_latency_seconds{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '6.5x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexRCGLatencyHigh
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerflex
+              component: csi-driver
+              system_id: sys-001
+              rcg_id: rcg-001
+              rcg_name: test-rcg
+            exp_annotations:
+              summary: "PowerFlex RCG test-rcg transmit latency is high"
+              description: |
+                Replication Consistency Group test-rcg (rcg_id=rcg-001) on system sys-001 transmit latency is 6.50 seconds, exceeding the 5.0-second threshold for 5 minutes. High transmit latency indicates WAN or network congestion on the replication path.
+              runbook_url: ""
+
+  - name: "PF-22 NO-FIRE: RCG transmit latency at 4.5s (below 5.0s threshold)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_transmit_latency_seconds{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '4.5x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexRCGLatencyHigh
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-23: PowerFlexRCGFrozen
+  # expr: dell_powerflex_rcg_freeze_state == 1
+  # for: 0m — fires immediately; freeze is a discrete state, not a rate
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-23 FIRE: RCG freeze state active (=1)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_freeze_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0 1 1 1'
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: PowerFlexRCGFrozen
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerflex
+              component: csi-driver
+              system_id: sys-001
+              rcg_id: rcg-001
+              rcg_name: test-rcg
+            exp_annotations:
+              summary: "PowerFlex RCG test-rcg is frozen"
+              description: |
+                Replication Consistency Group test-rcg (rcg_id=rcg-001) on system sys-001 is in frozen state. Replication is paused and data changes are not being replicated to the target. Verify whether this is an intentional administrative action.
+              runbook_url: ""
+
+  - name: "PF-23 NO-FIRE: RCG not frozen (freeze_state=0)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_freeze_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0x3'
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: PowerFlexRCGFrozen
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-24: PowerFlexRCGPaused
+  # expr: dell_powerflex_rcg_pause_mode == 1
+  # for: 0m
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-24 FIRE: RCG pause mode active (=1)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_pause_mode{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0 1 1 1'
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: PowerFlexRCGPaused
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: powerflex
+              component: csi-driver
+              system_id: sys-001
+              rcg_id: rcg-001
+              rcg_name: test-rcg
+            exp_annotations:
+              summary: "PowerFlex RCG test-rcg is paused"
+              description: |
+                Replication Consistency Group test-rcg (rcg_id=rcg-001) on system sys-001 is in paused mode. Replication data transfer is paused; lag will accumulate. Verify whether this is an intentional administrative action.
+              runbook_url: ""
+
+  - name: "PF-24 NO-FIRE: RCG not paused (pause_mode=0)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_pause_mode{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0x3'
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: PowerFlexRCGPaused
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-25: PowerFlexRCGFailoverActive
+  # expr: dell_powerflex_rcg_failover_state == 1
+  # for: 0m
+  # severity: warning — uses warning (not info) for compatibility with standard Alertmanager routes
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-25 FIRE: RCG failover state active (=1)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_failover_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0 1 1 1'
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: PowerFlexRCGFailoverActive
+        exp_alerts:
+          - exp_labels:
+              severity: info
+              platform: powerflex
+              component: csi-driver
+              system_id: sys-001
+              rcg_id: rcg-001
+              rcg_name: test-rcg
+            exp_annotations:
+              summary: "PowerFlex RCG test-rcg failover is active"
+              description: |
+                Replication Consistency Group test-rcg (rcg_id=rcg-001) on system sys-001 has an active failover state. This alert is informational. Verify that failover was intentional and monitor recovery progress.
+              runbook_url: ""
+
+  - name: "PF-25 NO-FIRE: RCG failover state not active (=0)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_failover_state{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0x3'
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: PowerFlexRCGFailoverActive
+        exp_alerts: []
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # PF-26: PowerFlexRCGRPOViolation
+  # expr: dell_powerflex_rcg_lag_persistent_seconds > on(...) dell_powerflex_rcg_rpo_seconds
+  #       and on(...) dell_powerflex_rcg_rpo_seconds > 0
+  # for: 5m
+  # severity: critical — lag exceeding per-RCG RPO means data protection is at risk
+  # Guard: rpo_seconds > 0 prevents false-positives on RCGs without RPO configured
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: "PF-26 FIRE: lag 350s exceeds per-RCG RPO 300s (RPO violation)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_lag_persistent_seconds{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '350x10'
+      - series: 'dell_powerflex_rcg_rpo_seconds{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '300x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexRCGRPOViolation
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              platform: powerflex
+              component: csi-driver
+              system_id: sys-001
+              rcg_id: rcg-001
+              rcg_name: test-rcg
+            exp_annotations:
+              summary: "PowerFlex RCG test-rcg RPO violation"
+              description: |
+                Replication Consistency Group test-rcg (rcg_id=rcg-001) on system sys-001 has persistent lag of 350 seconds, exceeding the per-RCG recovery point objective (RPO). Data protection is at risk. Investigate replication health immediately to prevent data loss exposure.
+              runbook_url: ""
+
+  - name: "PF-26 NO-FIRE: lag 250s below per-RCG RPO 300s (within RPO)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_lag_persistent_seconds{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '250x10'
+      - series: 'dell_powerflex_rcg_rpo_seconds{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '300x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexRCGRPOViolation
+        exp_alerts: []
+
+  - name: "PF-26 NO-FIRE: lag 350s but RPO=0 (RPO not configured, guard prevents fire)"
+    interval: 1m
+    input_series:
+      - series: 'dell_powerflex_rcg_lag_persistent_seconds{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '350x10'
+      - series: 'dell_powerflex_rcg_rpo_seconds{system_id="sys-001",rcg_id="rcg-001",rcg_name="test-rcg"}'
+        values: '0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PowerFlexRCGRPOViolation
+        exp_alerts: []

--- a/charts/csi-vxflexos/tests/alert-rules.yaml
+++ b/charts/csi-vxflexos/tests/alert-rules.yaml
@@ -1,0 +1,460 @@
+# Copyright (C) 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+groups:
+  - name: powerflex-csi-driver-alerts
+    rules:
+
+      # ── Category 1: Volume Operation Failures (PF-01–08) ─────────────────────
+      # Metric: dell_csi_operation_failure_total{system_id, operation, error_code}
+      # Type: CounterVec | Driver: csi-vxflexos
+      # Pattern: increase([5m]) > 0, for: 0m, severity: warning
+
+      - alert: PowerFlexCreateVolumeFailure
+        expr: increase(dell_csi_operation_failure_total{namespace="vxflexos",operation="CreateVolume"}[5m]) > 3
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex CreateVolume failures on system {{ $labels.system_id }}"
+          description: >
+            {{ $value | printf "%.0f" }} CreateVolume failure(s) detected in the last 5 minutes
+            on PowerFlex system {{ $labels.system_id }} (error_code={{ $labels.error_code }}).
+            Check driver logs and PowerFlex Gateway connectivity.
+          runbook_url: ""
+
+      - alert: PowerFlexDeleteVolumeFailure
+        expr: increase(dell_csi_operation_failure_total{namespace="vxflexos",operation="DeleteVolume"}[5m]) > 3
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex DeleteVolume failures on system {{ $labels.system_id }}"
+          description: >
+            {{ $value | printf "%.0f" }} DeleteVolume failure(s) in the last 5 minutes on
+            system {{ $labels.system_id }} (error_code={{ $labels.error_code }}).
+            Orphaned volumes may accumulate. Check Gateway and MDM reachability.
+          runbook_url: ""
+
+      - alert: PowerFlexControllerPublishFailure
+        expr: increase(dell_csi_operation_failure_total{namespace="vxflexos",operation="ControllerPublishVolume"}[5m]) > 3
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex ControllerPublishVolume failures on system {{ $labels.system_id }}"
+          description: >
+            {{ $value | printf "%.0f" }} ControllerPublishVolume failure(s) in the last 5 minutes
+            on system {{ $labels.system_id }} (error_code={{ $labels.error_code }}).
+            SDC mapping to volume may have failed. Check SDC registration and node connectivity.
+          runbook_url: ""
+
+      - alert: PowerFlexControllerUnpublishFailure
+        expr: increase(dell_csi_operation_failure_total{namespace="vxflexos",operation="ControllerUnpublishVolume"}[5m]) > 3
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex ControllerUnpublishVolume failures on system {{ $labels.system_id }}"
+          description: >
+            {{ $value | printf "%.0f" }} ControllerUnpublishVolume failure(s) in the last 5 minutes
+            on system {{ $labels.system_id }} (error_code={{ $labels.error_code }}).
+            SDC unmap from volume may have failed. Stale SDC mappings may persist.
+          runbook_url: ""
+
+      - alert: PowerFlexNodeStageFailure
+        expr: increase(dell_csi_operation_failure_total{namespace="vxflexos",operation="NodeStageVolume"}[5m]) > 3
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex NodeStageVolume failures on system {{ $labels.system_id }}"
+          description: >
+            {{ $value | printf "%.0f" }} NodeStageVolume failure(s) in the last 5 minutes
+            on system {{ $labels.system_id }} (error_code={{ $labels.error_code }}).
+            Block device discovery or filesystem formatting may have failed. Check SDC and device paths.
+          runbook_url: ""
+
+      - alert: PowerFlexNodeUnstageFailure
+        expr: increase(dell_csi_operation_failure_total{namespace="vxflexos",operation="NodeUnstageVolume"}[5m]) > 3
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex NodeUnstageVolume failures on system {{ $labels.system_id }}"
+          description: >
+            {{ $value | printf "%.0f" }} NodeUnstageVolume failure(s) in the last 5 minutes
+            on system {{ $labels.system_id }} (error_code={{ $labels.error_code }}).
+            Device unmount or cleanup may have failed. Check node device state.
+          runbook_url: ""
+
+      - alert: PowerFlexNodePublishFailure
+        expr: increase(dell_csi_operation_failure_total{namespace="vxflexos",operation="NodePublishVolume"}[5m]) > 3
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex NodePublishVolume failures on system {{ $labels.system_id }}"
+          description: >
+            {{ $value | printf "%.0f" }} NodePublishVolume failure(s) in the last 5 minutes
+            on system {{ $labels.system_id }} (error_code={{ $labels.error_code }}).
+            Bind mount to pod may have failed. Check node filesystem state and kubelet logs.
+          runbook_url: ""
+
+      - alert: PowerFlexNodeUnpublishFailure
+        expr: increase(dell_csi_operation_failure_total{namespace="vxflexos",operation="NodeUnpublishVolume"}[5m]) > 3
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex NodeUnpublishVolume failures on system {{ $labels.system_id }}"
+          description: >
+            {{ $value | printf "%.0f" }} NodeUnpublishVolume failure(s) in the last 5 minutes
+            on system {{ $labels.system_id }} (error_code={{ $labels.error_code }}).
+            Bind unmount from pod may have failed. Stale mount points may remain.
+          runbook_url: ""
+
+      # ── Category 2: Driver Health & Resource (PF-09–12) ──────────────────────
+      # Metrics: dell_csi_driver_uptime_seconds, dell_csi_driver_restart_total (GaugeVec),
+      #          dell_csi_driver_cpu_usage_percent, dell_csi_driver_memory_usage_bytes
+      # Labels on all: {driver="csi-vxflexos", pod}
+      # Note: label is "pod" (not "instance") to avoid conflict with Prometheus scrape-target
+      # instance label; with honorLabels: false, an exported "instance" label would be renamed
+      # to "exported_instance", so pod name regex matches would silently fail.
+
+      - alert: PowerFlexDriverUnavailable
+        expr: >-
+          (count(dell_csi_driver_uptime_seconds{driver="csi-vxflexos", pod=~".+-controller-.+"}) or on() vector(0)) == 0
+          or (count(dell_csi_driver_uptime_seconds{driver="csi-vxflexos", pod=~".+-node-.+"}) or on() vector(0)) == 0
+        for: 5m
+        labels:
+          severity: critical
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex CSI driver pods are unavailable"
+          description: >
+            PowerFlex CSI driver has zero controller or zero node instances reporting metrics
+            for 5 minutes. The driver may be crash-looping, evicted, or pending.
+            Volume operations may be unavailable. Immediate investigation required.
+          runbook_url: ""
+
+      - alert: PowerFlexDriverCrashLooping
+        expr: changes(dell_csi_driver_restart_total{driver="csi-vxflexos"}[15m]) > 3
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex CSI driver pod {{ $labels.pod }} is crash-looping"
+          description: >
+            The PowerFlex CSI driver pod {{ $labels.pod }} has restarted
+            {{ $value | printf "%.0f" }} times in the last 15 minutes (driver={{ $labels.driver }}).
+            This indicates a CrashLoopBackOff condition. Check pod events and driver logs.
+          runbook_url: ""
+
+      - alert: PowerFlexDriverHighCPU
+        expr: dell_csi_driver_cpu_usage_percent{driver="csi-vxflexos"} > 80
+        for: 5m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex CSI driver pod {{ $labels.pod }} has high CPU usage"
+          description: >
+            CPU usage for PowerFlex CSI driver pod {{ $labels.pod }} is {{ $value | printf "%.1f" }}%,
+            exceeding the 80% threshold for 5 minutes.
+            Sustained high CPU may indicate excessive concurrent operations or a processing bottleneck.
+          runbook_url: ""
+
+      - alert: PowerFlexDriverHighMemory
+        expr: dell_csi_driver_memory_usage_bytes{driver="csi-vxflexos"} > 2147483648
+        for: 5m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex CSI driver pod {{ $labels.pod }} has high memory usage"
+          description: >
+            Memory usage for PowerFlex CSI driver pod {{ $labels.pod }} is
+            {{ $value | printf "%.0f" }} bytes, exceeding the 2 GiB (2147483648 bytes) threshold
+            for 5 minutes. This may indicate a memory leak.
+            Review goroutine count and pending operation queues.
+          runbook_url: ""
+
+      # ── Category 3: Storage Capacity & Connectivity (PF-13–17) ───────────────
+      # Metrics prefix: dell_powerflex_storage_pool_* (NOT dell_powerflex_pool_*)
+      # Labels: {system_id, array_id, pool_id, pool_name}
+
+      - alert: PowerFlexPoolCapacityWarning
+        expr: dell_powerflex_storage_pool_utilization_ratio * 100 > 80
+        for: 5m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex storage pool {{ $labels.pool_name }} capacity warning"
+          description: >
+            Storage pool {{ $labels.pool_name }} (pool_id={{ $labels.pool_id }}) on array
+            {{ $labels.array_id }} is {{ $value | printf "%.1f" }}% full, exceeding the
+            80% warning threshold. Plan capacity expansion to avoid service disruption.
+          runbook_url: ""
+
+      - alert: PowerFlexPoolCapacityCritical
+        expr: dell_powerflex_storage_pool_utilization_ratio * 100 > 90
+        for: 5m
+        labels:
+          severity: critical
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex storage pool {{ $labels.pool_name }} capacity critical"
+          description: >
+            Storage pool {{ $labels.pool_name }} (pool_id={{ $labels.pool_id }}) on array
+            {{ $labels.array_id }} is {{ $value | printf "%.1f" }}% full, exceeding the
+            90% critical threshold. Volume creation will fail imminently.
+            Immediate capacity expansion required.
+          runbook_url: ""
+
+      - alert: PowerFlexThinProvisioningHighRatio
+        expr: dell_powerflex_storage_pool_thin_ratio > 0.8
+        for: 5m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex pool {{ $labels.pool_name }} thin provisioning ratio is high"
+          description: >
+            Thin provisioning ratio for pool {{ $labels.pool_name }} (pool_id={{ $labels.pool_id }})
+            on array {{ $labels.array_id }} is {{ $value | printf "%.2f" }}.
+            If all volumes are simultaneously fully written, pool capacity may be exhausted.
+            Review volume sizing and reclamation policies.
+          runbook_url: ""
+
+      - alert: PowerFlexDataReductionDegraded
+        expr: dell_powerflex_storage_pool_data_reduction_ratio < 1.5
+        for: 15m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex pool {{ $labels.pool_name }} data reduction ratio is degraded"
+          description: >
+            Data reduction ratio for pool {{ $labels.pool_name }} (pool_id={{ $labels.pool_id }})
+            on array {{ $labels.array_id }} is {{ $value | printf "%.2f" }}x, below the
+            1.5x threshold. Compression or deduplication efficiency may have degraded.
+            Review workload data characteristics and verify compression/deduplication features are enabled.
+          runbook_url: ""
+
+      - alert: PowerFlexArrayConnectivityLost
+        expr: dell_powerflex_array_healthy == 0
+        for: 5m
+        labels:
+          severity: critical
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex array {{ $labels.system_id }} is unreachable"
+          description: >
+            The PowerFlex array (system_id={{ $labels.system_id }}) has been unreachable for 5 minutes.
+            This alert fires when either: (1) the PowerFlex Gateway cannot be reached, or
+            (2) the MDM cluster state is not "online" or "configured".
+            All volume operations against this array will fail.
+          runbook_url: ""
+
+      # ── Category 4: RCG Replication Alerts (PF-18–26) ────────────────────────
+      # Metrics: dell_powerflex_rcg_* — labels: {system_id, rcg_id, rcg_name, ...}
+      # PF-18: info-style metric — use {state!="Consistent"} == 1
+      # PF-19: dell_powerflex_rcg_link_status does NOT exist — use rcg_activity_state
+      # PF-21: MUST include 'and' guard to prevent false-positives when RCG frozen/paused
+      # PF-26: dynamic RPO violation — lag > per-RCG rpo_seconds; rpo > 0 guard skips unconfigured RCGs
+
+      - alert: PowerFlexRCGStateNotConsistent
+        expr: dell_powerflex_rcg_state{state!="Consistent"} == 1
+        for: 5m
+        labels:
+          severity: critical
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex RCG {{ $labels.rcg_name }} is not in Consistent state"
+          description: >
+            Replication Consistency Group {{ $labels.rcg_name }} (rcg_id={{ $labels.rcg_id }})
+            on system {{ $labels.system_id }} has been in state "{{ $labels.state }}" for 5 minutes.
+            Expected state: "Consistent". This may indicate a replication link issue, lag overflow,
+            or active failover. Investigate immediately to avoid data protection gap.
+          runbook_url: ""
+
+      - alert: PowerFlexRCGInactive
+        expr: dell_powerflex_rcg_activity_state{direction="local"} == 0
+        for: 5m
+        labels:
+          severity: critical
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex RCG {{ $labels.rcg_name }} local activity is inactive"
+          description: >
+            Replication Consistency Group {{ $labels.rcg_name }} (rcg_id={{ $labels.rcg_id }})
+            on system {{ $labels.system_id }} local direction has been inactive for 5 minutes.
+            The replication link may be down. Check network connectivity to the remote site.
+          runbook_url: ""
+
+      - alert: PowerFlexRCGLagExceeded
+        expr: dell_powerflex_rcg_lag_persistent_seconds > 300
+        for: 5m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex RCG {{ $labels.rcg_name }} persistent lag exceeds threshold"
+          description: >
+            Replication Consistency Group {{ $labels.rcg_name }} (rcg_id={{ $labels.rcg_id }})
+            on system {{ $labels.system_id }} has persistent lag of {{ $value | printf "%.0f" }} seconds,
+            exceeding the 300-second threshold. Persistent lag represents data not yet durably
+            committed at the target, directly impacting RPO compliance.
+            Investigate replication bandwidth and target-side health.
+          runbook_url: ""
+
+      - alert: PowerFlexRCGBandwidthDegraded
+        expr: >-
+          dell_powerflex_rcg_transmit_bandwidth_kbps < 10240
+          and on(system_id, rcg_id, rcg_name)
+          dell_powerflex_rcg_activity_state{direction="local"} == 1
+          and on(system_id, rcg_id, rcg_name)
+          dell_powerflex_rcg_lag_persistent_seconds > 0
+          and on(system_id, rcg_id, rcg_name)
+          dell_powerflex_rcg_freeze_state == 0
+          and on(system_id, rcg_id, rcg_name)
+          dell_powerflex_rcg_pause_mode == 0
+        for: 5m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex RCG {{ $labels.rcg_name }} transmit bandwidth is degraded"
+          description: >
+            Replication Consistency Group {{ $labels.rcg_name }} (rcg_id={{ $labels.rcg_id }})
+            on system {{ $labels.system_id }} transmit bandwidth is {{ $value | printf "%.0f" }} KB/s,
+            below the 10240 KB/s threshold for 5 minutes while the RCG is actively replicating.
+            Low bandwidth may cause lag buildup. Check network capacity and QoS policies.
+          runbook_url: ""
+
+      - alert: PowerFlexRCGLatencyHigh
+        expr: dell_powerflex_rcg_transmit_latency_seconds > 5.0
+        for: 5m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex RCG {{ $labels.rcg_name }} transmit latency is high"
+          description: >
+            Replication Consistency Group {{ $labels.rcg_name }} (rcg_id={{ $labels.rcg_id }})
+            on system {{ $labels.system_id }} transmit latency is {{ $value | printf "%.2f" }} seconds,
+            exceeding the 5.0-second threshold for 5 minutes.
+            High transmit latency indicates WAN or network congestion on the replication path.
+          runbook_url: ""
+
+      - alert: PowerFlexRCGFrozen
+        expr: dell_powerflex_rcg_freeze_state == 1
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex RCG {{ $labels.rcg_name }} is frozen"
+          description: >
+            Replication Consistency Group {{ $labels.rcg_name }} (rcg_id={{ $labels.rcg_id }})
+            on system {{ $labels.system_id }} is in frozen state.
+            Replication is paused and data changes are not being replicated to the target.
+            Verify whether this is an intentional administrative action.
+          runbook_url: ""
+
+      - alert: PowerFlexRCGPaused
+        expr: dell_powerflex_rcg_pause_mode == 1
+        for: 0m
+        labels:
+          severity: warning
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex RCG {{ $labels.rcg_name }} is paused"
+          description: >
+            Replication Consistency Group {{ $labels.rcg_name }} (rcg_id={{ $labels.rcg_id }})
+            on system {{ $labels.system_id }} is in paused mode.
+            Replication data transfer is paused; lag will accumulate.
+            Verify whether this is an intentional administrative action.
+          runbook_url: ""
+
+      - alert: PowerFlexRCGFailoverActive
+        expr: dell_powerflex_rcg_failover_state == 1
+        for: 0m
+        labels:
+          severity: info
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex RCG {{ $labels.rcg_name }} failover is active"
+          description: >
+            Replication Consistency Group {{ $labels.rcg_name }} (rcg_id={{ $labels.rcg_id }})
+            on system {{ $labels.system_id }} has an active failover state.
+            This alert is informational. Verify that failover was intentional and monitor
+            recovery progress.
+          runbook_url: ""
+
+      - alert: PowerFlexRCGRPOViolation
+        expr: >-
+          dell_powerflex_rcg_lag_persistent_seconds
+          > on(system_id, rcg_id, rcg_name)
+          dell_powerflex_rcg_rpo_seconds
+          and on(system_id, rcg_id, rcg_name)
+          dell_powerflex_rcg_rpo_seconds > 0
+        for: 5m
+        labels:
+          severity: critical
+          platform: powerflex
+          component: csi-driver
+        annotations:
+          summary: "PowerFlex RCG {{ $labels.rcg_name }} RPO violation"
+          description: >
+            Replication Consistency Group {{ $labels.rcg_name }} (rcg_id={{ $labels.rcg_id }})
+            on system {{ $labels.system_id }} has persistent lag of {{ $value | printf "%.0f" }} seconds,
+            exceeding the per-RCG recovery point objective (RPO).
+            Data protection is at risk. Investigate replication health immediately
+            to prevent data loss exposure.
+          runbook_url: ""

--- a/charts/csi-vxflexos/values.yaml
+++ b/charts/csi-vxflexos/values.yaml
@@ -14,7 +14,7 @@ images:
     image: quay.io/dell/container-storage-modules/csi-vxflexos:v2.18.0
   # "powerflexSdc" defines the SDC image for init container.
   powerflexSdc:
-    image: quay.io/dell/storage/powerflex/sdc:5.1
+    image: quay.io/dell/storage/powerflex/sdc:5.1.0.2
   # CSI sidecars
   attacher:
     image: registry.k8s.io/sig-storage/csi-attacher:v4.12.0
@@ -169,6 +169,26 @@ spaceReclamation:
 # Default value: 8083
 podmonAPIPort: 8083
 
+# podmonAPIToken: Shared secret token for authenticating podmon API requests
+# When set, the driver will require Bearer token authentication on /array-status endpoints
+# Allowed values: Any string (recommend using a randomly generated token)
+# Security note: podmon API is HTTP; use this token only on trusted cluster-internal networks.
+# For production, use podmonAPITokenSecret to source this value from a Kubernetes Secret.
+# Default value: "" (empty - authentication disabled for backward compatibility)
+podmonAPIToken: ""
+
+# podmonAPITokenSecret: Kubernetes Secret containing the podmon API token
+# When set, the token will be sourced from the specified Secret instead of podmonAPIToken value
+# Allowed values:
+#   name: Secret name (required)
+#   key: Secret key containing the token (required, default: "podmon-api-token")
+# Example:
+#   podmonAPITokenSecret:
+#     name: my-podmon-secret
+#     key: api-token
+# Default value: null (use podmonAPIToken value instead)
+podmonAPITokenSecret: null
+
 # "controller" allows to configure controller specific parameters
 controller:
   # replication: allows to configure replication
@@ -190,6 +210,19 @@ controller:
     # Allowed values: string
     # Default value: replication.storage.dell.com
     replicationPrefix: "replication.storage.dell.com"
+
+    # Metrics configuration for replication sidecar
+    metrics:
+      enabled: false
+      port: 8445
+      tlsCertSecret: ""
+      collection:
+        interval: 30s
+      serviceMonitor:
+        enabled: false
+        interval: 30s
+        scrapeTimeout: ""
+        insecureSkipVerify: false
 
   healthMonitor:
     # enabled: Enable/Disable health monitor of CSI volumes
@@ -427,6 +460,45 @@ podmon:
       - "--driverPodLabelValue=dell-storage"
       - "--ignoreVolumelessPods=false"
 
+  # metrics: configuration for podmon resiliency metrics
+  metrics:
+    # enabled: Set to true to expose the metrics endpoint on the podmon containers.
+    # Default value: false
+    enabled: false
+    # port: Port on which the metrics endpoint is exposed. Default for podmon: 8444.
+    port: 8444
+    # tlsCertSecret: Name of a Kubernetes TLS Secret (tls.crt / tls.key) used to serve metrics over HTTPS.
+    # When set the chart mounts the secret and configures HTTPS automatically.
+    # Leave unset to serve metrics over plain HTTP.
+    tlsCertSecret: ""
+    # collection: Controls metrics collection cadence inside the resiliency module.
+    collection:
+      interval: 30s
+    # serviceMonitor: Creates a Prometheus Operator ServiceMonitor targeting the controller pods.
+    serviceMonitor:
+      enabled: false
+      interval: 30s
+      scrapeTimeout: ""
+      insecureSkipVerify: false
+    # podMonitor: Creates a Prometheus Operator PodMonitor targeting the node pods.
+    podMonitor:
+      enabled: false
+      interval: 30s
+      scrapeTimeout: ""
+      insecureSkipVerify: false
+    # prometheusRule: Controls optional Prometheus Operator PrometheusRule creation for resiliency alerts.
+    prometheusRule:
+      # enabled: When true, a PrometheusRule CR is created for resiliency alerting rules.
+      # Type: bool
+      # Default: true
+      # Effect: Requires the Prometheus Operator CRDs to be installed in the cluster.
+      enabled: true
+      # connectivitySuccessRatio: Minimum acceptable connectivity success ratio as percentage (0-100).
+      # Used by RES-02 (CSMResiliencyConnectivityLost) alert threshold.
+      # Type: integer
+      # Default: 90 (alert fires when connectivity drops below 90%)
+      connectivitySuccessRatio: 90
+
 # CSM module attributes
 # authorization: enable csm-authorization for RBAC
 # Deploy and configure authorization before installing driver
@@ -463,9 +535,9 @@ metrics:
   # port: Port on which the shared driver metrics endpoint is exposed.
   # This port serves gateway monitoring metrics and any other driver-supplied metrics.
   # Type: integer
-  # Default: 8443
+  # Default: 9090
   # Effect: Passed as X_CSI_METRICS_PORT to the driver container; used as targetPort in the Service.
-  port: 8443
+  port: 9090
 
   # tlsCertSecret: Name of a Kubernetes TLS Secret whose "tls.crt" and "tls.key" entries
   # are used to serve the metrics endpoint over HTTPS instead of plain HTTP.
@@ -502,6 +574,66 @@ metrics:
     # Effect: Passed as X_CSI_GATEWAY_MONITORING_POLL_INTERVAL to the driver container.
     pollInterval: "30s"
 
+  # leaderElection: configuration for metrics collector leader election.
+  # When enabled, array collectors (storage pool, volume, array health) run only on the leader controller pod.
+  leaderElection:
+    # enabled: Enable/Disable metrics collector leader election.
+    # Type: bool
+    # Default: false
+    # Effect: When true, the controller Deployment receives X_CSI_METRICS_LEADER_ELECTION_ENABLED=true,
+    #         and only one controller will run array collectors.
+    enabled: false
+
+    # leaseDuration: Duration of the leader election lease.
+    # Type: string (Go duration, e.g. "60s", "2m")
+    # Default: "60s"
+    # Effect: Passed as X_CSI_METRICS_LEADER_ELECTION_LEASE_DURATION to the driver container.
+    leaseDuration: "60s"
+
+    # renewDeadline: Duration before the leader must renew its lease.
+    # Type: string (Go duration, e.g. "40s", "1m")
+    # Default: "40s"
+    # Effect: Passed as X_CSI_METRICS_LEADER_ELECTION_RENEW_DEADLINE to the driver container.
+    renewDeadline: "40s"
+
+    # retryPeriod: Duration to wait before retrying to acquire the lease.
+    # Type: string (Go duration, e.g. "5s", "10s")
+    # Default: "5s"
+    # Effect: Passed as X_CSI_METRICS_LEADER_ELECTION_RETRY_PERIOD to the driver container.
+    retryPeriod: "5s"
+
+  # collection: Controls how frequently metrics are collected.
+  collection:
+    # interval: How often the driver collects metrics from the array.
+    # Type: string (duration, e.g. "30s", "1m")
+    # Default: "30s"
+    interval: "30s"
+    # cacheTTL: How long collected values are cached before re-querying the array.
+    # Type: string (duration, e.g. "25s")
+    # Default: "25s"
+    cacheTTL: "25s"
+
+  # array: Array-specific collector tuning.
+  array:
+    # rateLimit: Maximum array API requests per second.
+    # Type: integer
+    # Default: 100
+    rateLimit: 100
+    # timeout: Per-request timeout for array API calls.
+    # Type: string (duration)
+    # Default: "30s"
+    timeout: "30s"
+    # circuitBreaker: Circuit-breaker settings for array API calls.
+    circuitBreaker:
+      # threshold: Number of consecutive failures before the circuit opens.
+      # Type: integer
+      # Default: 3
+      threshold: 3
+      # resetTimeout: How long the circuit stays open before allowing a retry.
+      # Type: string (duration)
+      # Default: "30s"
+      resetTimeout: "30s"
+
   # serviceMonitor: Controls optional Prometheus Operator ServiceMonitor creation.
   serviceMonitor:
     # enabled: When true, a ServiceMonitor CR is created for automatic Prometheus Operator integration.
@@ -514,6 +646,11 @@ metrics:
     # Type: string (Prometheus duration, e.g. "30s", "1m")
     # Default: "30s"
     interval: "30s"
+
+    # scrapeTimeout: Prometheus scrape timeout for the metrics endpoint.
+    # Type: string (Prometheus duration, e.g. "10s")
+    # Default: "" (unset)
+    scrapeTimeout: ""
 
     # insecureSkipVerify: Controls TLS certificate verification when scraping metrics.
     # Only used when metrics.tlsCertSecret is set (HTTPS endpoint).
@@ -535,19 +672,88 @@ metrics:
     # Default: "30s"
     interval: "30s"
 
+    # scrapeTimeout: Prometheus scrape timeout for the node metrics endpoint.
+    # Type: string (Prometheus duration, e.g. "10s")
+    # Default: "" (unset)
+    scrapeTimeout: ""
+
     # insecureSkipVerify: Controls TLS certificate verification when scraping node metrics.
     # Only used when metrics.tlsCertSecret is set (HTTPS endpoint).
     # Type: bool
     # Default: false
     insecureSkipVerify: false
 
-  # prometheusRule: Controls optional Prometheus Operator PrometheusRule creation.
+  # prometheusRule: Controls optional Prometheus Operator PrometheusRule creation for driver-level alerts.
   prometheusRule:
-    # enabled: When true, a PrometheusRule CR is created for alerting/recording rules.
+    # enabled: When true, a PrometheusRule CR is created for driver alerting/recording rules.
     # Type: bool
     # Default: false
     # Effect: Requires the Prometheus Operator CRDs to be installed in the cluster.
     enabled: false
+
+    # Alerting threshold parameters for the 26 PowerFlex CSI driver alert rules.
+    # All values are numeric (int or float) — never quoted strings.
+    # Override with --set metrics.prometheusRule.<param>=<value> or in a custom values file.
+
+    # volumeOperationFailureThreshold: PF-01..08 threshold — minimum number of operation failures in 5 minutes
+    # above which a volume-operation alert fires.
+    # Type: integer (count)
+    # Default: 3
+    volumeOperationFailureThreshold: 3
+
+    # poolCapacityWarningPercent: PF-13 threshold — pool utilization % above which a warning fires.
+    # Type: integer (percent, 0–100)
+    # Default: 80
+    poolCapacityWarningPercent: 80
+
+    # poolCapacityCriticalPercent: PF-14 threshold — pool utilization % above which a critical alert fires.
+    # Type: integer (percent, 0–100)
+    # Default: 90
+    poolCapacityCriticalPercent: 90
+
+    # thinRatioWarningThreshold: PF-15 threshold — thin provisioning ratio above which a warning fires.
+    # Type: float (ratio: thin_allocated / physical_capacity)
+    # Default: 0.8
+    thinRatioWarningThreshold: 0.8
+
+    # dataReductionDegradedThreshold: PF-16 threshold — data reduction ratio below which a warning fires.
+    # Type: float (multiplier: e.g., 1.5 = 1.5x reduction)
+    # Default: 1.5
+    dataReductionDegradedThreshold: 1.5
+
+    # rcgLagWarningSeconds: PF-20 threshold — persistent replication lag in seconds above which a warning fires.
+    # Type: integer (seconds)
+    # Default: 300
+    rcgLagWarningSeconds: 300
+
+    # rcgBandwidthWarningKBps: PF-21 threshold — RCG transmit bandwidth in KB/s below which a warning fires.
+    # The guard (rcg_activity_state == 1) ensures this only fires when the RCG is actively replicating.
+    # Type: integer (KB/s)
+    # Default: 10240 (10 MB/s)
+    rcgBandwidthWarningKBps: 10240
+
+    # rcgLatencyWarningSeconds: PF-22 threshold — RCG transmit latency in seconds above which a warning fires.
+    # Type: float (seconds)
+    # Default: 5.0
+    rcgLatencyWarningSeconds: 5.0
+
+    # cpuWarningThreshold: PF-11 threshold — driver pod CPU usage % above which a warning fires.
+    # Type: integer (percent, 0–100)
+    # Default: 80
+    cpuWarningThreshold: 80
+
+    # memoryWarningThreshold: PF-12 threshold — driver pod memory usage in bytes above which a warning fires.
+    # Type: integer (bytes)
+    # Default: 2147483648 (2 GiB)
+    memoryWarningThreshold: 2147483648
+
+    # restartCountThreshold: PF-10 threshold — number of driver pod restart transitions in a 15-minute window
+    # above which a crash-loop warning fires. Uses changes() (counts value transitions) rather than delta()
+    # because changes() is resilient to staleness gaps caused by container restarts — delta() can return
+    # NaN when the series goes stale after a pod death and recovers after a gap.
+    # Type: integer (count)
+    # Default: 3
+    restartCountThreshold: 3
 
 interfaceNames:
   # worker1: interface1

--- a/charts/csm-authorization-v2.0/crds/csm-authorization.storage.dell.com_storages.yaml
+++ b/charts/csm-authorization-v2.0/crds/csm-authorization.storage.dell.com_storages.yaml
@@ -39,6 +39,13 @@ spec:
             spec:
               description: spec defines the desired state of Storage
               properties:
+                caCertPEM:
+                  description: |-
+                    CACertPEM is an optional PEM-encoded CA certificate (or certificate chain)
+                    used to verify the storage backend's TLS certificate. When provided, a
+                    custom trust store is built from this value instead of relying solely on
+                    the system's CA bundle.
+                  type: string
                 endpoint:
                   description: |-
                     EndPoint is the storage array endpoint.

--- a/charts/csm-authorization-v2.0/templates/prometheusrule.yaml
+++ b/charts/csm-authorization-v2.0/templates/prometheusrule.yaml
@@ -1,0 +1,120 @@
+{{- if eq (include "csm-authorization.isMetricsEnabled" .) "true" }}
+{{- if hasKey .Values.authorization.metrics "prometheusRule" }}
+{{- if eq .Values.authorization.metrics.prometheusRule.enabled true }}
+---
+# PrometheusRule for CSM Authorization module alerts.
+# Created when authorization.metrics.enabled AND authorization.metrics.prometheusRule.enabled are true.
+# Requires the Prometheus Operator CRDs to be installed in the cluster.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-csm-authorization-alerts
+  namespace: {{ include "custom.namespace" . }}
+  labels:
+    app: csm-authorization
+    release: {{ .Release.Name }}
+spec:
+  groups:
+    - name: csm-authorization-alerts
+      rules:
+        - alert: AuthorizationServiceDown
+          expr: dell_csm_auth_up == 0 or absent(dell_csm_auth_up)
+          for: 5m
+          labels:
+            severity: critical
+            platform: csm-authorization
+            component: authorization
+          annotations:
+            summary: "CSM Authorization proxy is down"
+            description: "The CSM Authorization proxy has been down or unscrapable for more than 5 minutes."
+            runbook_url: ""
+
+        - alert: HighAuthorizationFailureRate
+          expr: |
+            sum by (storage_type, tenant) (rate(dell_csm_auth_request_total{status="failure"}[5m])) /
+            sum by (storage_type, tenant) (rate(dell_csm_auth_request_total[5m])) > {{ .Values.authorization.metrics.prometheusRule.authFailureRateThreshold | default 0.10 }}
+          for: 5m
+          labels:
+            severity: warning
+            platform: csm-authorization
+            component: authorization
+          annotations:
+            summary: "High CSM Authorization failure rate"
+            description: "The CSM Authorization failure rate is above {{ .Values.authorization.metrics.prometheusRule.authFailureRateThreshold | default 0.10 }} for storage type {{ `{{ $labels.storage_type }}` }} and tenant {{ `{{ $labels.tenant }}` }}."
+            runbook_url: ""
+
+        - alert: TokenValidationFailure
+          expr: increase(dell_csm_auth_token_validation_total{result="failure"}[5m]) > 0
+          for: 1m
+          labels:
+            severity: warning
+            platform: csm-authorization
+            component: authorization
+          annotations:
+            summary: "CSM Authorization token validation failure"
+            description: "Token validation failures have been detected with reason {{ `{{ $labels.reason }}` }}."
+            runbook_url: ""
+
+        - alert: UnauthorizedAccessAttempts
+          expr: increase(dell_csm_auth_role_access_total{decision="deny",storage_type!="powerscale"}[5m]) > 0
+          for: 1m
+          labels:
+            severity: warning
+            platform: csm-authorization
+            component: authorization
+          annotations:
+            summary: "Unauthorized CSM Authorization access attempt"
+            description: "Role {{ `{{ $labels.role }}` }} denied access for storage type {{ `{{ $labels.storage_type }}` }}. PowerScale is excluded because its role-access path is handled separately."
+            runbook_url: ""
+
+        - alert: CredentialShieldingBreach
+          expr: increase(dell_csm_auth_credential_shield_total{status="failure"}[5m]) > 0
+          for: 1m
+          labels:
+            severity: critical
+            platform: csm-authorization
+            component: authorization
+          annotations:
+            summary: "CSM Authorization credential shielding breach"
+            description: "Credential shielding failed for storage type {{ `{{ $labels.storage_type }}` }}. Storage credentials may have been exposed."
+            runbook_url: ""
+
+        - alert: QuotaAuthorizationFailure
+          expr: increase(dell_csm_auth_quota_check_total{result="denied",storage_type!="powerscale"}[5m]) > 0
+          for: 1m
+          labels:
+            severity: warning
+            platform: csm-authorization
+            component: authorization
+          annotations:
+            summary: "CSM Authorization quota check denied"
+            description: "Quota check denied for tenant {{ `{{ $labels.tenant }}` }} on storage type {{ `{{ $labels.storage_type }}` }}. PowerScale is excluded because quota enforcement is handled differently there."
+            runbook_url: ""
+
+        - alert: HighAuthorizationLatency
+          expr: |
+            histogram_quantile({{ .Values.authorization.metrics.prometheusRule.authLatencyQuantile | default 0.95 }}, rate(dell_csm_auth_request_duration_seconds_bucket[5m])) > {{ .Values.authorization.metrics.prometheusRule.authLatencyThresholdSeconds | default 2.0 }}
+          for: 5m
+          labels:
+            severity: warning
+            platform: csm-authorization
+            component: authorization
+          annotations:
+            summary: "High CSM Authorization request latency"
+            description: "The {{ .Values.authorization.metrics.prometheusRule.authLatencyQuantile | default 0.95 }} quantile CSM Authorization request latency is above {{ .Values.authorization.metrics.prometheusRule.authLatencyThresholdSeconds | default 2.0 }} seconds for storage type {{ `{{ $labels.storage_type }}` }} and tenant {{ `{{ $labels.tenant }}` }}."
+            runbook_url: ""
+
+        - alert: AuthorizationServiceRecovery
+          expr: changes(dell_csm_auth_up[1m]) > 0 and dell_csm_auth_up == 1
+          for: 0m
+          labels:
+            severity: info
+            platform: csm-authorization
+            component: authorization
+          annotations:
+            summary: "CSM Authorization proxy has recovered"
+            description: "The CSM Authorization proxy transitioned to healthy within the last minute."
+            runbook_url: ""
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/csm-authorization-v2.0/templates/tenant-service-networkpolicy.yaml
+++ b/charts/csm-authorization-v2.0/templates/tenant-service-networkpolicy.yaml
@@ -1,0 +1,25 @@
+# NetworkPolicy that restricts ingress traffic to the tenant-service.
+# Only allows gRPC traffic (port 50051) from proxy-server and authorization-controller pods.
+# This provides defense-in-depth by limiting which services can call the tenant-service.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tenant-service-restrict
+  namespace: {{ include "custom.namespace" . }}
+spec:
+  podSelector:
+    matchLabels:
+      app: tenant-service
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: proxy-server
+        - podSelector:
+            matchLabels:
+              app: authorization-controller
+      ports:
+        - protocol: TCP
+          port: 50051

--- a/charts/csm-authorization-v2.0/tests/alert-rules-test.yaml
+++ b/charts/csm-authorization-v2.0/tests/alert-rules-test.yaml
@@ -1,0 +1,311 @@
+rule_files:
+  - alert-rules.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series: []
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: AuthorizationServiceDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              platform: csm-authorization
+              component: authorization
+            exp_annotations:
+              summary: "CSM Authorization proxy is down"
+              description: "The CSM Authorization proxy has been down or unscrapable for more than 5 minutes."
+              runbook_url: ""
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_auth_up{}'
+        values: '1+0x6'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: AuthorizationServiceDown
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_auth_request_total{storage_type="powerstore",tenant="t1",status="failure"}'
+        values: '0+15x7'
+      - series: 'dell_csm_auth_request_total{storage_type="powerstore",tenant="t1",status="success"}'
+        values: '0+85x7'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: HighAuthorizationFailureRate
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: csm-authorization
+              component: authorization
+              storage_type: powerstore
+              tenant: t1
+            exp_annotations:
+              summary: "High CSM Authorization failure rate"
+              description: "The CSM Authorization failure rate is above 0.10 for storage type powerstore and tenant t1."
+              runbook_url: ""
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_auth_request_total{storage_type="powerstore",tenant="t1",status="failure"}'
+        values: '0+5x7'
+      - series: 'dell_csm_auth_request_total{storage_type="powerstore",tenant="t1",status="success"}'
+        values: '0+95x7'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: HighAuthorizationFailureRate
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_auth_request_total{storage_type="powerstore",tenant="t1",status="failure"}'
+        values: '0+11x7'
+      - series: 'dell_csm_auth_request_total{storage_type="powerstore",tenant="t1",status="success"}'
+        values: '0+89x7'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: HighAuthorizationFailureRate
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: csm-authorization
+              component: authorization
+              storage_type: powerstore
+              tenant: t1
+            exp_annotations:
+              summary: "High CSM Authorization failure rate"
+              description: "The CSM Authorization failure rate is above 0.10 for storage type powerstore and tenant t1."
+              runbook_url: ""
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_auth_token_validation_total{result="failure",reason="expired"}'
+        values: '1+2x6'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: TokenValidationFailure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: csm-authorization
+              component: authorization
+              result: failure
+              reason: expired
+            exp_annotations:
+              summary: "CSM Authorization token validation failure"
+              description: "Token validation failures have been detected with reason expired."
+              runbook_url: ""
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_auth_token_validation_total{result="success"}'
+        values: '1+5x6'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: TokenValidationFailure
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_auth_role_access_total{role="admin",storage_type="powerstore",decision="deny"}'
+        values: '1+1x6'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: UnauthorizedAccessAttempts
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: csm-authorization
+              component: authorization
+              role: admin
+              storage_type: powerstore
+              decision: deny
+            exp_annotations:
+              summary: "Unauthorized CSM Authorization access attempt"
+              description: "Role admin denied access for storage type powerstore. PowerScale is excluded because its role-access path is handled separately."
+              runbook_url: ""
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_auth_role_access_total{role="admin",storage_type="powerstore",decision="allow"}'
+        values: '1+5x6'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: UnauthorizedAccessAttempts
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_auth_credential_shield_total{storage_type="powerstore",status="failure"}'
+        values: '0+1x6'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: CredentialShieldingBreach
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              platform: csm-authorization
+              component: authorization
+              storage_type: powerstore
+              status: failure
+            exp_annotations:
+              summary: "CSM Authorization credential shielding breach"
+              description: "Credential shielding failed for storage type powerstore. Storage credentials may have been exposed."
+              runbook_url: ""
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_auth_credential_shield_total{storage_type="powerstore",status="success"}'
+        values: '0+5x6'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: CredentialShieldingBreach
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_auth_quota_check_total{storage_type="powerstore",tenant="t1",result="denied"}'
+        values: '0+1x6'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: QuotaAuthorizationFailure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: csm-authorization
+              component: authorization
+              storage_type: powerstore
+              tenant: t1
+              result: denied
+            exp_annotations:
+              summary: "CSM Authorization quota check denied"
+              description: "Quota check denied for tenant t1 on storage type powerstore. PowerScale is excluded because quota enforcement is handled differently there."
+              runbook_url: ""
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_auth_quota_check_total{storage_type="powerstore",tenant="t1",result="allowed"}'
+        values: '0+10x6'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: QuotaAuthorizationFailure
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="0.1"}'
+        values: '0+5x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="0.5"}'
+        values: '0+5x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="1.0"}'
+        values: '0+5x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="2.0"}'
+        values: '0+5x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="5.0"}'
+        values: '0+5x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="+Inf"}'
+        values: '0+5x6'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: HighAuthorizationLatency
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="0.1"}'
+        values: '0+0x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="0.5"}'
+        values: '0+0x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="1.0"}'
+        values: '0+0x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="2.0"}'
+        values: '0+0x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="5.0"}'
+        values: '0+10x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="+Inf"}'
+        values: '0+10x6'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: HighAuthorizationLatency
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="0.1"}'
+        values: '0+5x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="0.5"}'
+        values: '0+5x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="1.0"}'
+        values: '0+5x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="2.0"}'
+        values: '0+5x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="5.0"}'
+        values: '0+100x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="+Inf"}'
+        values: '0+100x6'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: HighAuthorizationLatency
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="0.1"}'
+        values: '0+0x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="0.5"}'
+        values: '0+0x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="1.0"}'
+        values: '0+0x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="2.0"}'
+        values: '0+1x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="5.0"}'
+        values: '0+100x6'
+      - series: 'dell_csm_auth_request_duration_seconds_bucket{storage_type="powerstore",tenant="t1",le="+Inf"}'
+        values: '0+100x6'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: HighAuthorizationLatency
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              platform: csm-authorization
+              component: authorization
+              storage_type: powerstore
+              tenant: t1
+            exp_annotations:
+              summary: "High CSM Authorization request latency"
+              description: "The 0.95 quantile CSM Authorization request latency is above 2.0 seconds for storage type powerstore and tenant t1."
+              runbook_url: ""
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_auth_up{}'
+        values: '0 1 1'
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: AuthorizationServiceRecovery
+        exp_alerts:
+          - exp_labels:
+              severity: info
+              platform: csm-authorization
+              component: authorization
+            exp_annotations:
+              summary: "CSM Authorization proxy has recovered"
+              description: "The CSM Authorization proxy transitioned to healthy within the last minute."
+              runbook_url: ""
+      - eval_time: 2m
+        alertname: AuthorizationServiceRecovery
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_auth_up{}'
+        values: '0 0'
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: AuthorizationServiceRecovery
+        exp_alerts: []

--- a/charts/csm-authorization-v2.0/tests/alert-rules.yaml
+++ b/charts/csm-authorization-v2.0/tests/alert-rules.yaml
@@ -1,0 +1,101 @@
+groups:
+  - name: csm-authorization-alerts
+    rules:
+      - alert: AuthorizationServiceDown
+        expr: dell_csm_auth_up == 0 or absent(dell_csm_auth_up)
+        for: 5m
+        labels:
+          severity: critical
+          platform: csm-authorization
+          component: authorization
+        annotations:
+          summary: "CSM Authorization proxy is down"
+          description: "The CSM Authorization proxy has been down or unscrapable for more than 5 minutes."
+          runbook_url: ""
+
+      - alert: HighAuthorizationFailureRate
+        expr: |
+          sum by (storage_type, tenant) (rate(dell_csm_auth_request_total{status="failure"}[5m])) /
+          sum by (storage_type, tenant) (rate(dell_csm_auth_request_total[5m])) > 0.10
+        for: 5m
+        labels:
+          severity: warning
+          platform: csm-authorization
+          component: authorization
+        annotations:
+          summary: "High CSM Authorization failure rate"
+          description: "The CSM Authorization failure rate is above 0.10 for storage type {{ $labels.storage_type }} and tenant {{ $labels.tenant }}."
+          runbook_url: ""
+
+      - alert: TokenValidationFailure
+        expr: increase(dell_csm_auth_token_validation_total{result="failure"}[5m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+          platform: csm-authorization
+          component: authorization
+        annotations:
+          summary: "CSM Authorization token validation failure"
+          description: "Token validation failures have been detected with reason {{ $labels.reason }}."
+          runbook_url: ""
+
+      - alert: UnauthorizedAccessAttempts
+        expr: increase(dell_csm_auth_role_access_total{decision="deny",storage_type!="powerscale"}[5m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+          platform: csm-authorization
+          component: authorization
+        annotations:
+          summary: "Unauthorized CSM Authorization access attempt"
+          description: "Role {{ $labels.role }} denied access for storage type {{ $labels.storage_type }}. PowerScale is excluded because its role-access path is handled separately."
+          runbook_url: ""
+
+      - alert: CredentialShieldingBreach
+        expr: increase(dell_csm_auth_credential_shield_total{status="failure"}[5m]) > 0
+        for: 1m
+        labels:
+          severity: critical
+          platform: csm-authorization
+          component: authorization
+        annotations:
+          summary: "CSM Authorization credential shielding breach"
+          description: "Credential shielding failed for storage type {{ $labels.storage_type }}. Storage credentials may have been exposed."
+          runbook_url: ""
+
+      - alert: QuotaAuthorizationFailure
+        expr: increase(dell_csm_auth_quota_check_total{result="denied",storage_type!="powerscale"}[5m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+          platform: csm-authorization
+          component: authorization
+        annotations:
+          summary: "CSM Authorization quota check denied"
+          description: "Quota check denied for tenant {{ $labels.tenant }} on storage type {{ $labels.storage_type }}. PowerScale is excluded because quota enforcement is handled differently there."
+          runbook_url: ""
+
+      - alert: HighAuthorizationLatency
+        expr: |
+          histogram_quantile(0.95, rate(dell_csm_auth_request_duration_seconds_bucket[5m])) > 2.0
+        for: 5m
+        labels:
+          severity: warning
+          platform: csm-authorization
+          component: authorization
+        annotations:
+          summary: "High CSM Authorization request latency"
+          description: "The 0.95 quantile CSM Authorization request latency is above 2.0 seconds for storage type {{ $labels.storage_type }} and tenant {{ $labels.tenant }}."
+          runbook_url: ""
+
+      - alert: AuthorizationServiceRecovery
+        expr: changes(dell_csm_auth_up[1m]) > 0 and dell_csm_auth_up == 1
+        for: 0m
+        labels:
+          severity: info
+          platform: csm-authorization
+          component: authorization
+        annotations:
+          summary: "CSM Authorization proxy has recovered"
+          description: "The CSM Authorization proxy transitioned to healthy within the last minute."
+          runbook_url: ""

--- a/charts/csm-authorization-v2.0/values.yaml
+++ b/charts/csm-authorization-v2.0/values.yaml
@@ -82,7 +82,7 @@ authorization:
     # enabled: Enable/Disable the Prometheus metrics HTTP server on the proxy-server.
     # When true, the proxy-server receives X_CSI_METRICS_ENABLED=true,
     # X_CSI_METRICS_PORT, and a metrics Service is created.
-    # Default value: false
+    # Default value: true
     enabled: true
 
     # port: Port on which the proxy-server metrics endpoint is exposed.
@@ -110,12 +110,29 @@ authorization:
       # Default value: "30s"
       interval: "30s"
       # scrapeTimeout: Prometheus scrape timeout for the metrics endpoint.
-      # Default value: "" (unset)
+      # Default value: "" (inherits Prometheus global scrape_timeout, typically 10s)
       scrapeTimeout: ""
       # insecureSkipVerify: Controls TLS certificate verification when scraping.
       # Only used when metrics.tlsCertSecret is set (HTTPS endpoint).
       # Default value: false
       insecureSkipVerify: false
+
+    # prometheusRule: Controls optional Prometheus Operator PrometheusRule creation.
+    # When true, a PrometheusRule CR is created with alert definitions for the
+    # authorization proxy metrics endpoint.
+    # Requires the Prometheus Operator CRDs to be installed in the cluster.
+    # Default value: true
+    prometheusRule:
+      enabled: true
+      # authFailureRateThreshold: Ratio threshold for the high authorization
+      # failure-rate alert (P4.AUTH.2). Default value: 0.10
+      authFailureRateThreshold: 0.10
+      # authLatencyQuantile: Quantile used for the high latency alert (P4.AUTH.7).
+      # Default value: 0.95
+      authLatencyQuantile: 0.95
+      # authLatencyThresholdSeconds: Latency threshold in seconds for the high
+      # latency alert (P4.AUTH.7). Default value: 2.0
+      authLatencyThresholdSeconds: 2.0
 
 redis:
   name: redis-csm

--- a/charts/csm-replication/templates/_helpers.tpl
+++ b/charts/csm-replication/templates/_helpers.tpl
@@ -1,3 +1,5 @@
+{{/* Copyright © 2026 Dell Inc. or its subsidiaries. All Rights Reserved. */}}
+
 {{/*
 Expand the name of the chart.
 */}}
@@ -60,3 +62,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Check if metrics is enabled for the replication controller.
+*/}}
+{{- define "csm-replication.isMetricsEnabled" -}}
+{{- if and (hasKey .Values "metrics") .Values.metrics.enabled -}}
+    {{- "true" -}}
+{{- else -}}
+    {{- "false" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/csm-replication/templates/controller.yaml
+++ b/charts/csm-replication/templates/controller.yaml
@@ -282,6 +282,12 @@ spec:
     - name: https
       port: 8443
       targetPort: https
+{{- if eq (include "csm-replication.isMetricsEnabled" .) "true" }}
+    - name: repl-metrics
+      port: {{ .Values.metrics.port | default 8445 }}
+      targetPort: {{ .Values.metrics.port | default 8445 }}
+      protocol: TCP
+{{- end }}
   selector:
     control-plane: controller-manager
 ---
@@ -339,9 +345,29 @@ spec:
               value: /app/certs
             - name: X_CSI_REPLICATION_CONFIG_FILE_NAME
               value: config
+{{- if eq (include "csm-replication.isMetricsEnabled" .) "true" }}
+            - name: X_CSI_REPLICATION_METRICS_ENABLED
+              value: "true"
+            - name: X_CSI_REPLICATION_METRICS_PORT
+              value: "{{ .Values.metrics.port | default 8445 }}"
+            - name: X_CSI_REPLICATION_METRICS_COLLECTION_INTERVAL
+              value: "{{ .Values.metrics.collection.interval | default "30s" }}"
+{{- if .Values.metrics.tlsCertSecret }}
+            - name: X_CSI_REPLICATION_METRICS_TLS_CERT_FILE
+              value: /etc/replication-metrics-tls/tls.crt
+            - name: X_CSI_REPLICATION_METRICS_TLS_KEY_FILE
+              value: /etc/replication-metrics-tls/tls.key
+{{- end }}
+{{- end }}
           image: {{ .Values.image }}
           imagePullPolicy: Always
           name: manager
+{{- if eq (include "csm-replication.isMetricsEnabled" .) "true" }}
+          ports:
+            - name: repl-metrics
+              containerPort: {{ .Values.metrics.port | default 8445 }}
+              protocol: TCP
+{{- end }}
           resources:
             requests:
               cpu: 100m
@@ -351,6 +377,11 @@ spec:
               name: configmap-volume
             - mountPath: /app/certs
               name: cert-dir
+{{- if and (eq (include "csm-replication.isMetricsEnabled" .) "true") .Values.metrics.tlsCertSecret }}
+            - name: replication-metrics-tls
+              mountPath: /etc/replication-metrics-tls
+              readOnly: true
+{{- end }}
       terminationGracePeriodSeconds: 10
       volumes:
         - emptyDir: { }
@@ -359,3 +390,8 @@ spec:
             name: dell-replication-controller-config
             optional: true
           name: configmap-volume
+{{- if and (eq (include "csm-replication.isMetricsEnabled" .) "true") .Values.metrics.tlsCertSecret }}
+        - name: replication-metrics-tls
+          secret:
+            secretName: {{ .Values.metrics.tlsCertSecret }}
+{{- end }}

--- a/charts/csm-replication/templates/prometheusrule.yaml
+++ b/charts/csm-replication/templates/prometheusrule.yaml
@@ -1,0 +1,305 @@
+{{- if eq (include "csm-replication.isMetricsEnabled" .) "true" }}
+{{- if and .Values.metrics .Values.metrics.prometheusRule .Values.metrics.prometheusRule.enabled }}
+{{- $metricsNamespace := .Values.metrics.prometheusRule.metricsNamespace | default .Release.Namespace }}
+{{- $rpoThresholdSeconds := .Values.metrics.prometheusRule.rpoThresholdSeconds | int64 }}
+{{- $srdfMinBandwidth := .Values.metrics.prometheusRule.srdfMinBandwidth | int64 }}
+{{- $srdfLagSeconds := .Values.metrics.prometheusRule.srdfLagSeconds | int64 }}
+{{- if or (lt $rpoThresholdSeconds 30) (gt $rpoThresholdSeconds 86400) }}{{ fail "metrics.prometheusRule.rpoThresholdSeconds must be between 30 and 86400" }}{{- end }}
+{{- if or (lt $srdfMinBandwidth 1) (gt $srdfMinBandwidth 1073741824) }}{{ fail "metrics.prometheusRule.srdfMinBandwidth must be between 1 and 1073741824" }}{{- end }}
+{{- if or (lt $srdfLagSeconds 30) (gt $srdfLagSeconds 86400) }}{{ fail "metrics.prometheusRule.srdfLagSeconds must be between 30 and 86400" }}{{- end }}
+---
+# PrometheusRule for CSM Replication Module alerting rules.
+# Created when metrics.enabled AND metrics.prometheusRule.enabled are true.
+# Requires the Prometheus Operator CRDs and the CSI driver chart's replication
+# metrics ServiceMonitor, which scrapes the dell-csi-replicator producer.
+#
+# 12 alert rules + 2 record rules in a single group:
+#   Record Rules — State Tracking (SRDF state history)
+#   Category 1 — Replication Lag & RPO      (REP-01, REP-02)
+#   Category 2 — Replication Link & Failure (REP-03, REP-04)
+#   Category 3 — Controller Health & Metrics(REP-05, REP-06)
+#   Category 4 — Bandwidth Degradation      (REP-07)
+#   Category 5 — PowerMax SRDF State        (REP-09, REP-10, REP-11, REP-12)
+#   Category 6 — CSM-Initiated SRDF Actions (REP-08)
+#
+# namespace: {{ .Release.Namespace }} is set as a static label on every alert rule.
+# This is required so that AlertmanagerConfig namespace-scoped routing works correctly
+# for all alert types — including those whose expressions use aggregation (max by, min by)
+# that would otherwise drop the namespace label from the result set.
+# Pattern mirrors csi-powermax and csi-isilon Helm chart PrometheusRules.
+#
+# Thresholds configurable via .Values.metrics.prometheusRule.*
+#
+# PERFORMANCE TARGETS (BR JA-23013):
+# Critical alerts use 1m for: duration to meet 120s BR target.
+# Warning alerts use 2m for: duration to stay near target while reducing false positives.
+# See values.yaml for full rationale.
+#
+# SRDF State Codes (used in REP-09, REP-10, REP-11, REP-12 alerts):
+#   0 = UNKNOWN
+#   1 = SYNCHRONIZED
+#   2 = SYNC_IN_PROGRESS
+#   3 = SUSPENDED
+#   4 = FAILEDOVER
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-csm-replication-alerts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  groups:
+    - name: csm-replication-alerts
+      interval: 30s
+      rules:
+        # ── Record Rules — State Tracking ──
+        # Record rules create derived time series for state tracking and comparison.
+
+        # Record current SRDF state for comparison
+        - record: dell_powermax_srdf_group_state_current
+          expr: dell_powermax_srdf_group_state{namespace="{{ $metricsNamespace }}"}
+
+        # Record previous SRDF state (5 minutes ago) for transition detection
+        - record: dell_powermax_srdf_group_state_previous
+          expr: dell_powermax_srdf_group_state{namespace="{{ $metricsNamespace }}"} offset 5m
+
+        # ── Category 1: Replication Lag & RPO (REP-01, REP-02) ──
+        # Metric: dell_csm_repl_lag_seconds
+
+        # REP-01
+        # NOTE: 2m duration is an exception to the 120s BR target to reduce false positives on transient lag spikes.
+        - alert: CSMReplicationLagExceeded
+          expr: dell_csm_repl_lag_seconds{namespace="{{ $metricsNamespace }}"} > {{ $rpoThresholdSeconds }}
+          for: 2m
+          labels:
+            severity: warning
+            component: csm-replication
+            alert_id: REP-01
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Replication lag exceeded for policy {{`{{ $labels.policy_name }}`}}"
+            description: "Replication lag for policy {{`{{ $labels.policy_name }}`}} (driver: {{`{{ $labels.driver }}`}}) is {{`{{ $value }}`}}s (threshold: {{ $rpoThresholdSeconds }}s)."
+            runbook_url: "https://dell.github.io/csm-docs/docs/troubleshooting/replication/#replication-lag"
+
+        # REP-02 — longer for: 15m distinguishes sustained RPO violation from transient spikes
+        - alert: CSMReplicationRPOViolation
+          expr: dell_csm_repl_lag_seconds{namespace="{{ $metricsNamespace }}"} > {{ $rpoThresholdSeconds }}
+          for: 15m
+          labels:
+            severity: critical
+            component: csm-replication
+            alert_id: REP-02
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Replication sustained RPO violation for policy {{`{{ $labels.policy_name }}`}}"
+            description: "Replication lag for policy {{`{{ $labels.policy_name }}`}} (driver: {{`{{ $labels.driver }}`}}) has exceeded {{ $rpoThresholdSeconds }}s for over 15 minutes."
+            runbook_url: "https://dell.github.io/csm-docs/docs/troubleshooting/replication/#rpo-violation"
+
+        # ── Category 2: Replication Link & Failure (REP-03, REP-04) ──
+
+        # REP-03
+        # SetPairStatus removes the previous status-labeled series on transitions, so max-by
+        # collapses only duplicate reports across replicator replicas.
+        - alert: CSMReplicationLinkDown
+          expr: max by (namespace, driver, policy_name) (dell_csm_repl_pair_status{namespace="{{ $metricsNamespace }}"}) == 0
+          for: 1m
+          # NOTE: 1m duration meets 120s BR target (30s scrape + 30s eval + 60s for = ~120s total) for critical link failures.
+          labels:
+            severity: critical
+            component: csm-replication
+            alert_id: REP-03
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Replication link down for policy {{`{{ $labels.policy_name }}`}}"
+            description: "Replication link for policy {{`{{ $labels.policy_name }}`}} (driver: {{`{{ $labels.driver }}`}}) is reporting an inactive or unknown state."
+            runbook_url: "https://dell.github.io/csm-docs/docs/troubleshooting/replication/#link-down"
+
+        # REP-04
+        # The OR clause catches first-occurrence failures — it fires when the counter is > 0
+        # but had no data 6 minutes ago (meaning it just appeared for the first time).
+        # Together, the two clauses cover: repeated failures (increase > 0) AND first failures (new series).
+        - alert: CSMReplicationFailure
+          expr: |
+            (increase(dell_csm_repl_failure_total{namespace="{{ $metricsNamespace }}"}[5m]) > 0)
+            or
+            (dell_csm_repl_failure_total{namespace="{{ $metricsNamespace }}"} > 0 unless (dell_csm_repl_failure_total{namespace="{{ $metricsNamespace }}"} offset 6m))
+          for: 0m
+          labels:
+            severity: critical
+            component: csm-replication
+            alert_id: REP-04
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Replication operation failure for driver {{`{{ $labels.driver }}`}}"
+            description: "Replication action {{`{{ $labels.action }}`}} failed for driver {{`{{ $labels.driver }}`}}. Total failures: {{`{{ printf \"%.0f\" $value }}`}}. Investigate controller logs and array connectivity."
+            runbook_url: "https://dell.github.io/csm-docs/docs/troubleshooting/replication/#operation-failures"
+
+        # ── Category 3: Controller Health & Metrics (REP-05, REP-06) ──
+
+        # REP-05 — dell_csm_repl_controller_health exists in naming.go + replication_metrics.go
+        - alert: CSMReplicationControllerDown
+          expr: dell_csm_repl_controller_health{namespace="{{ $metricsNamespace }}"} == 0
+          for: 5m
+          labels:
+            severity: critical
+            component: csm-replication
+            alert_id: REP-05
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Replication controller unhealthy for driver {{`{{ $labels.driver }}`}}"
+            description: "CSM Replication controller for driver {{`{{ $labels.driver }}`}} is reporting unhealthy status."
+            runbook_url: "https://dell.github.io/csm-docs/docs/troubleshooting/replication/#controller-health"
+
+        # REP-06 — The dedicated stale metric detects incomplete monitoring cycles. The absent()
+        # expression detects a missing replicator endpoint, while the last complete collection
+        # timestamp detects a continuously scraped exporter whose collection loop is hung.
+        - alert: CSMReplicationMetricsStale
+          expr: |
+            dell_csm_repl_metrics_stale{namespace="{{ $metricsNamespace }}"} == 1
+            or
+            absent(dell_csm_repl_last_collection_timestamp_seconds{namespace="{{ $metricsNamespace }}"})
+            or
+            (time() - max by (namespace, driver) (dell_csm_repl_last_collection_timestamp_seconds{namespace="{{ $metricsNamespace }}"})) > 300
+          for: 5m
+          labels:
+            severity: warning
+            component: csm-replication
+            alert_id: REP-06
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Replication metrics stale in namespace {{`{{ $labels.namespace }}`}}"
+            description: "Replication metrics in namespace {{`{{ $labels.namespace }}`}} have not been updated in over 5 minutes. This may indicate monitoring loop failure, CSI gRPC connection loss, or pod scheduling issues."
+            runbook_url: "https://dell.github.io/csm-docs/docs/troubleshooting/replication/#metrics-stale"
+
+        # ── Category 4: Bandwidth Degradation (REP-07) ──
+        # PowerMax-specific metric; other platforms don't expose bandwidth metrics.
+        # NOTE: 10m duration is an intentional exception to the 120s BR target. Bandwidth fluctuates;
+        # longer duration avoids spurious alerts on transient degradation.
+
+        # REP-07
+        - alert: PowerMaxSRDFBandwidthDegraded
+          expr: dell_powermax_srdf_bandwidth_bytes_per_sec{namespace="{{ $metricsNamespace }}"} < {{ $srdfMinBandwidth }}
+          for: 10m
+          labels:
+            severity: warning
+            platform: powermax
+            component: srdf-replication
+            alert_id: REP-07
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax SRDF bandwidth degraded for RDF group {{`{{ $labels.rdf_group }}`}}"
+            description: "SRDF bandwidth for RDF group {{`{{ $labels.rdf_group }}`}} in replication group {{`{{ $labels.rg_name }}`}} (mode: {{`{{ $labels.mode }}`}}) is below {{ $srdfMinBandwidth }} bytes/s. Driver: {{`{{ $labels.driver }}`}}"
+            runbook_url: "https://dell.github.io/csm-docs/docs/troubleshooting/replication/#bandwidth-degradation"
+
+        # ── Category 5: PowerMax SRDF Replication State Monitoring (REP-09 to REP-12) ──
+        # PowerMax-specific SRDF state monitoring alerts.
+        # These alerts are owned by CSM Replication because the metrics (dell_powermax_srdf_*)
+        # are emitted by the csm-replication module, not the CSI driver.
+
+        # REP-09 [PowerMax] — Transition-based alert: fires during the 5-minute window after any state change
+        # away from SYNCHRONIZED. Catches active DR events as they happen.
+        # NOTE: State values are numeric (0=UNKNOWN, 1=SYNCHRONIZED, 2=SYNC_IN_PROGRESS, 3=SUSPENDED, 4=FAILEDOVER)
+        # DESIGN NOTE: This alert is EDGE-TRIGGERED (detects transitions). It fires within 5 minutes
+        # of a state change and resolves after ~5 minutes (when current==previous again).
+        # State 2 (SYNC_IN_PROGRESS) is explicitly filtered: it is a normal transient state during
+        # resyncs and requires no operator action. REP-10 handles the case where state 2 persists
+        # abnormally long (> 10m) via its level-triggered companion expression.
+        # For PERSISTENT degraded states, see REP-10 below.
+        - alert: PowerMaxSRDFStateNotSynchronized
+          expr: dell_powermax_srdf_group_state_current != dell_powermax_srdf_group_state_previous and dell_powermax_srdf_group_state_current != 1 and dell_powermax_srdf_group_state_current != 2
+          for: 1m
+          labels:
+            severity: critical
+            platform: powermax
+            component: srdf-replication
+            alert_id: REP-09
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax SRDF group {{`{{ $labels.rdf_group }}`}} state changed away from SYNCHRONIZED"
+            description: "SRDF group {{`{{ $labels.rdf_group }}`}} in replication group {{`{{ $labels.rg_name }}`}} (mode: {{`{{ $labels.mode }}`}}) transitioned to state {{`{{ printf \"%.0f\" $value }}`}} (0=UNKNOWN 3=SUSPENDED 4=FAILEDOVER). Driver: {{`{{ $labels.driver }}`}}. If this is a planned DR action (failover/suspend), acknowledge accordingly."
+            runbook_url: "https://dell.github.io/csm-docs/docs/troubleshooting/powermax/#srdf-replication"
+
+        # REP-10 [PowerMax] — Level-triggered companion: fires when SRDF stays degraded for >10 minutes.
+        # REP-10 is a persistent/level-triggered check that fires whenever the SRDF state is non-SYNCHRONIZED
+        # (excluding state=2/SYNC_IN_PROGRESS which is normal during bulk resync) for 10+ minutes.
+        # max by (namespace, driver, rg_name, rdf_group, mode) deduplicates pod-level series
+        # without combining identically named SRDF groups from different CSM namespaces.
+        - alert: PowerMaxSRDFStatePersistentlyDegraded
+          expr: |
+            max by (namespace, driver, rg_name, rdf_group, mode) (dell_powermax_srdf_group_state{namespace="{{ $metricsNamespace }}"}) > 2
+            or
+            max by (namespace, driver, rg_name, rdf_group, mode) (dell_powermax_srdf_group_state{namespace="{{ $metricsNamespace }}"}) == 0
+          for: 10m
+          labels:
+            severity: critical
+            platform: powermax
+            component: srdf-replication
+            alert_id: REP-10
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax SRDF group {{`{{ $labels.rdf_group }}`}} persistently in degraded state"
+            description: "SRDF group {{`{{ $labels.rdf_group }}`}} in replication group {{`{{ $labels.rg_name }}`}} (mode: {{`{{ $labels.mode }}`}}) has been in state {{`{{ printf \"%.0f\" $value }}`}} (3=SUSPENDED 4=FAILEDOVER 0=UNKNOWN) for over 10 minutes. Driver: {{`{{ $labels.driver }}`}}. Data protection is at risk — investigate immediately."
+            runbook_url: "https://dell.github.io/csm-docs/docs/troubleshooting/powermax/#srdf-replication"
+
+        # REP-11 [PowerMax]
+        # min by aggregates pod-level reports per namespace and SRDF group.
+        # min() fires if any pod reports link_status=0 persistently for 2m, deduplicating across replicas.
+        - alert: PowerMaxSRDFLinkDown
+          expr: |
+            min by (namespace, driver, rdf_group, mode) (dell_powermax_srdf_link_status{namespace="{{ $metricsNamespace }}"}) == 0
+          for: 2m
+          labels:
+            severity: critical
+            platform: powermax
+            component: srdf-replication
+            alert_id: REP-11
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax SRDF link down for RDF group {{`{{ $labels.rdf_group }}`}}"
+            description: "SRDF link for RDF group {{`{{ $labels.rdf_group }}`}} (mode: {{`{{ $labels.mode }}`}}) is inactive. Driver: {{`{{ $labels.driver }}`}}. The physical RDF link between arrays may be down — check network connectivity and RDF port status."
+            runbook_url: "https://dell.github.io/csm-docs/docs/troubleshooting/powermax/#srdf-replication"
+
+        # REP-12 [PowerMax].
+        # NOTE: 5m duration is an exception to the 120s BR target to reduce false positives on transient lag.
+        - alert: PowerMaxSRDFLagExceeded
+          expr: dell_powermax_srdf_lag_seconds{namespace="{{ $metricsNamespace }}"} > {{ $srdfLagSeconds }}
+          for: 5m
+          labels:
+            severity: warning
+            platform: powermax
+            component: srdf-replication
+            alert_id: REP-12
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "PowerMax SRDF replication lag exceeded for RDF group {{`{{ $labels.rdf_group }}`}}"
+            description: "SRDF replication lag for RDF group {{`{{ $labels.rdf_group }}`}} in replication group {{`{{ $labels.rg_name }}`}} (mode: {{`{{ $labels.mode }}`}}) exceeds {{ $srdfLagSeconds }}s threshold. Driver: {{`{{ $labels.driver }}`}}"
+            runbook_url: "https://dell.github.io/csm-docs/docs/troubleshooting/powermax/#srdf-replication"
+
+        # ── Category 6: CSM-Initiated SRDF Actions (BR Requirement 7) ──
+        # Alerts for CSM-initiated SRDF replication actions (failover, failback, reprotect, swap).
+        # Uses existing dell_csm_repl_success_total metric with action label.
+
+        # REP-08 — CSM-initiated SRDF failover triggered
+        # Regex filter matches all failover action types (FAILOVER_LOCAL, FAILOVER_REMOTE, etc.).
+        # The OR clause handles first-occurrence (failover appears from zero) using the same
+        # pattern as REP-04.
+        - alert: CSMReplicationSRDFFailoverTriggered
+          expr: |
+            (increase(dell_csm_repl_success_total{namespace="{{ $metricsNamespace }}",action=~"(FAILOVER|UNPLANNED_FAILOVER).*"}[5m]) > 0)
+            or
+            (dell_csm_repl_success_total{namespace="{{ $metricsNamespace }}",action=~"(FAILOVER|UNPLANNED_FAILOVER).*"} > 0
+             unless (dell_csm_repl_success_total{namespace="{{ $metricsNamespace }}",action=~"(FAILOVER|UNPLANNED_FAILOVER).*"} offset 6m))
+          for: 0m
+          labels:
+            severity: info
+            component: csm-replication
+            alert_id: REP-08
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: "CSM Replication SRDF failover triggered: action={{`{{ $labels.action }}`}} for driver {{`{{ $labels.driver }}`}}"
+            description: "CSM Replication initiated SRDF failover action '{{`{{ $labels.action }}`}}' for driver {{`{{ $labels.driver }}`}}. This indicates CSM-managed disaster recovery has been activated. Verify the failover was intentional and confirm RPO/RTO objectives are met."
+            runbook_url: "https://dell.github.io/csm-docs/docs/troubleshooting/replication/#srdf-failover"
+{{- end }}
+{{- end }}

--- a/charts/csm-replication/templates/servicemonitor.yaml
+++ b/charts/csm-replication/templates/servicemonitor.yaml
@@ -1,6 +1,8 @@
 {{- if eq (include "csm-replication.isMetricsEnabled" .) "true" }}
 {{- if and (hasKey .Values.metrics "serviceMonitor") .Values.metrics.serviceMonitor.enabled }}
 ---
+# Scrapes the standalone replication controller. Replication alert series are scraped
+# from dell-csi-replicator by the CSI driver chart's replication ServiceMonitor.
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/csm-replication/templates/servicemonitor.yaml
+++ b/charts/csm-replication/templates/servicemonitor.yaml
@@ -1,0 +1,28 @@
+{{- if eq (include "csm-replication.isMetricsEnabled" .) "true" }}
+{{- if and (hasKey .Values.metrics "serviceMonitor") .Values.metrics.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "csm-replication.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "csm-replication.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  endpoints:
+    - port: repl-metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval | default "30s" }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      path: /metrics
+      {{- if .Values.metrics.tlsCertSecret }}
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: {{ .Values.metrics.serviceMonitor.insecureSkipVerify | default false }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/csm-replication/tests/alert-rules-test.yaml
+++ b/charts/csm-replication/tests/alert-rules-test.yaml
@@ -1,0 +1,71 @@
+rule_files:
+  - alert-rules.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_repl_metrics_stale{namespace="csm",driver="csi-powermax"}'
+        values: '0+0x11'
+      - series: 'dell_csm_repl_last_collection_timestamp_seconds{namespace="csm",driver="csi-powermax"}'
+        values: '0+0x11'
+    alert_rule_test:
+      - eval_time: 11m
+        alertname: CSMReplicationMetricsStale
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: csm-replication
+              alert_id: REP-06
+              namespace: csm
+              driver: csi-powermax
+            exp_annotations:
+              summary: "CSM Replication metrics stale in namespace csm"
+              description: "Replication metrics in namespace csm have not been updated in over 5 minutes. This may indicate monitoring loop failure, CSI gRPC connection loss, or pod scheduling issues."
+              runbook_url: "https://dell.github.io/csm-docs/docs/troubleshooting/replication/#metrics-stale"
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_csm_repl_metrics_stale{namespace="csm",driver="csi-powermax"}'
+        values: '0+0x11'
+      - series: 'dell_csm_repl_last_collection_timestamp_seconds{namespace="csm",driver="csi-powermax"}'
+        values: '0+60x11'
+    alert_rule_test:
+      - eval_time: 11m
+        alertname: CSMReplicationMetricsStale
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_powermax_srdf_group_state{namespace="csm",driver="csi-powermax",rg_name="rg-1",rdf_group="10",mode="ASYNC"}'
+        values: '1+0x10'
+      - series: 'dell_powermax_srdf_group_state{namespace="other",driver="csi-powermax",rg_name="rg-1",rdf_group="10",mode="ASYNC"}'
+        values: '4+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PowerMaxSRDFStatePersistentlyDegraded
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'dell_powermax_srdf_group_state{namespace="csm",driver="csi-powermax",rg_name="rg-1",rdf_group="10",mode="ASYNC"}'
+        values: '4+0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PowerMaxSRDFStatePersistentlyDegraded
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              platform: powermax
+              component: srdf-replication
+              alert_id: REP-10
+              namespace: csm
+              driver: csi-powermax
+              rg_name: rg-1
+              rdf_group: 10
+              mode: ASYNC
+            exp_annotations:
+              summary: "PowerMax SRDF group 10 persistently in degraded state"
+              description: "SRDF group 10 in replication group rg-1 (mode: ASYNC) has been in state 4 (3=SUSPENDED 4=FAILEDOVER 0=UNKNOWN) for over 10 minutes. Driver: csi-powermax. Data protection is at risk."
+              runbook_url: "https://dell.github.io/csm-docs/docs/troubleshooting/powermax/#srdf-replication"

--- a/charts/csm-replication/tests/alert-rules.yaml
+++ b/charts/csm-replication/tests/alert-rules.yaml
@@ -1,0 +1,37 @@
+groups:
+  - name: csm-replication-alerts
+    rules:
+      - alert: CSMReplicationMetricsStale
+        expr: |
+          dell_csm_repl_metrics_stale{namespace="csm"} == 1
+          or
+          absent(dell_csm_repl_last_collection_timestamp_seconds{namespace="csm"})
+          or
+          (time() - max by (namespace, driver) (dell_csm_repl_last_collection_timestamp_seconds{namespace="csm"})) > 300
+        for: 5m
+        labels:
+          severity: warning
+          component: csm-replication
+          alert_id: REP-06
+          namespace: csm
+        annotations:
+          summary: "CSM Replication metrics stale in namespace {{ $labels.namespace }}"
+          description: "Replication metrics in namespace {{ $labels.namespace }} have not been updated in over 5 minutes. This may indicate monitoring loop failure, CSI gRPC connection loss, or pod scheduling issues."
+          runbook_url: "https://dell.github.io/csm-docs/docs/troubleshooting/replication/#metrics-stale"
+
+      - alert: PowerMaxSRDFStatePersistentlyDegraded
+        expr: |
+          max by (namespace, driver, rg_name, rdf_group, mode) (dell_powermax_srdf_group_state{namespace="csm"}) > 2
+          or
+          max by (namespace, driver, rg_name, rdf_group, mode) (dell_powermax_srdf_group_state{namespace="csm"}) == 0
+        for: 10m
+        labels:
+          severity: critical
+          platform: powermax
+          component: srdf-replication
+          alert_id: REP-10
+          namespace: csm
+        annotations:
+          summary: "PowerMax SRDF group {{ $labels.rdf_group }} persistently in degraded state"
+          description: "SRDF group {{ $labels.rdf_group }} in replication group {{ $labels.rg_name }} (mode: {{ $labels.mode }}) has been in state {{ printf \"%.0f\" $value }} (3=SUSPENDED 4=FAILEDOVER 0=UNKNOWN) for over 10 minutes. Driver: {{ $labels.driver }}. Data protection is at risk."
+          runbook_url: "https://dell.github.io/csm-docs/docs/troubleshooting/powermax/#srdf-replication"

--- a/charts/csm-replication/values.yaml
+++ b/charts/csm-replication/values.yaml
@@ -46,6 +46,19 @@ enableKubevirtPVCRemap: "false"
 # Default value: false
 allowPvcCreationOnTarget: "false"
 
+# Metrics configuration for replication controller
+metrics:
+  enabled: false
+  port: 8445
+  tlsCertSecret: ""
+  collection:
+    interval: "30s"
+  serviceMonitor:
+    enabled: false
+    interval: "30s"
+    scrapeTimeout: ""
+    insecureSkipVerify: false
+
 # HostAliases: Optional features that allows <hostname:IP> entries injection into pod's /etc/hosts file
 # hostAliases:
 #  - ip: "10.10.10.10"

--- a/charts/csm-replication/values.yaml
+++ b/charts/csm-replication/values.yaml
@@ -58,6 +58,28 @@ metrics:
     interval: "30s"
     scrapeTimeout: ""
     insecureSkipVerify: false
+  # prometheusRule: configures PrometheusRule creation for alert rules
+  # The alert metrics are produced by dell-csi-replicator in the CSI driver controller pod.
+  # Enable replication metrics and its ServiceMonitor in the installed CSI driver chart,
+  # and set metricsNamespace below when that driver is in a different namespace.
+  prometheusRule:
+    # enabled: Enable/Disable PrometheusRule creation
+    # Requires metrics.enabled to also be true
+    # Allowed values: true, false
+    # Default value: false
+    enabled: false
+    # metricsNamespace: Namespace where the CSI driver chart exposes dell-csi-replicator metrics.
+    # Defaults to this chart's release namespace; set it when the CSI driver runs elsewhere.
+    metricsNamespace: ""
+    # rpoThresholdSeconds: lag threshold for REP-01/REP-02 alerts (30-86400 seconds)
+    # Default value: 300 (5 minutes)
+    rpoThresholdSeconds: 300
+    # srdfMinBandwidth: minimum SRDF bandwidth threshold in bytes/s for REP-07 (PowerMax only, 1-1073741824)
+    # Default value: 10485760 (10 MB/s)
+    srdfMinBandwidth: 10485760
+    # srdfLagSeconds: SRDF lag threshold for REP-12 in seconds (PowerMax only, 30-86400)
+    # Default value: 300 (5 minutes)
+    srdfLagSeconds: 300
 
 # HostAliases: Optional features that allows <hostname:IP> entries injection into pod's /etc/hosts file
 # hostAliases:

--- a/charts/karavi-observability/templates/_helpers.tpl
+++ b/charts/karavi-observability/templates/_helpers.tpl
@@ -1,3 +1,4 @@
+{{/* Copyright © 2026 Dell Inc. or its subsidiaries. All Rights Reserved. */}}
 {{/*
 Namespace for all resources to be installed into
 If not defined in values file then the helm release namespace is used
@@ -6,4 +7,92 @@ By default this is not set so the helm release namespace will be used
 
 {{- define "custom.namespace" -}}
 	{{ .Values.namespace | default .Release.Namespace }}
+{{- end -}}
+
+{{/*
+Generate PrometheusRule for a specific driver
+Args:
+  .driverName: The driver name (e.g., "powerflex", "powerstore", "powerscale", "powermax")
+  .jobPattern: The Prometheus job pattern (e.g., "karavi-metrics-powerflex.*")
+  .root: The root context (pass $ from the template)
+*/}}
+{{- define "karavi.prometheusRule" -}}
+{{- $driverName := .driverName -}}
+{{- $moduleLabel := .moduleLabel -}}
+{{- $platformLabel := .platformLabel -}}
+{{- $platformLabelRef := printf "{{ $labels.%s }}" $platformLabel -}}
+{{- $jobPattern := .jobPattern -}}
+{{- $root := .root -}}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ $root.Release.Name }}-{{ $driverName }}-alerts
+  namespace: {{ include "custom.namespace" $root }}
+  labels:
+    app.kubernetes.io/name: karavi-observability
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
+    app.kubernetes.io/component: observability-alerts
+    app.kubernetes.io/driver: {{ $driverName }}
+    release: prometheus
+spec:
+  groups:
+    - name: csm-observability-alerts-{{ $driverName }}
+      interval: 30s
+      rules:
+        - alert: CSMObservabilityMetricsCollectionFailure
+          expr: absent(dell_csm_obs_collection_rate{module="{{ $moduleLabel }}"}) or dell_csm_obs_collection_rate{module="{{ $moduleLabel }}"} == 0
+          for: 3m
+          labels:
+            severity: warning
+            platform: observability
+            component: csm-module
+            driver: {{ $driverName }}
+            alert_id: OBS-01
+          annotations:
+            summary: "CSM observability metrics collection failed for {{ $driverName }} on {{ $platformLabelRef }}"
+            description: "No observability collection data has been produced for driver {{ $driverName }} and module {{ $moduleLabel }} on platform {{ $platformLabelRef }} for 3 minutes. Check the observability collector and upstream driver connectivity."
+            runbook_url: "https://dell.github.io/csm-docs/docs/observability/alerts/csm-observability/"
+
+        - alert: CSMObservabilityMetricsExportFailure
+          expr: increase(dell_csm_obs_export_success_total{module="{{ $moduleLabel }}",status=~"failure|error"}[5m]) > 0
+          for: 3m
+          labels:
+            severity: warning
+            platform: observability
+            component: csm-module
+            driver: {{ $driverName }}
+            alert_id: OBS-02
+          annotations:
+            summary: "CSM observability metrics export failure for {{ $driverName }} on {{ $platformLabelRef }}"
+            description: "Observability export failures were detected for driver {{ $driverName }} and module {{ $moduleLabel }} on platform {{ $platformLabelRef }}. Investigate the export backend and the observability pipeline."
+            runbook_url: "https://dell.github.io/csm-docs/docs/observability/alerts/csm-observability/"
+
+        - alert: CSMObservabilityArrayConnectivityLost
+          expr: dell_csm_obs_array_connectivity{module="{{ $moduleLabel }}"} == 0
+          for: 2m
+          labels:
+            severity: critical
+            platform: observability
+            component: csm-module
+            driver: {{ $driverName }}
+            alert_id: OBS-03
+          annotations:
+            summary: "CSM observability lost array connectivity for {{ $driverName }} on {{ $platformLabelRef }}"
+            description: "The observability module has reported lost array connectivity for driver {{ $driverName }} and module {{ $moduleLabel }} on platform {{ $platformLabelRef }}. Check storage array reachability, credentials, and network connectivity."
+            runbook_url: "https://dell.github.io/csm-docs/docs/observability/alerts/csm-observability/"
+
+        - alert: CSMObservabilityScrapeEndpointUnavailable
+          expr: absent(up{job=~"{{ $jobPattern }}"}) or up{job=~"{{ $jobPattern }}"} == 0
+          for: 2m
+          labels:
+            severity: critical
+            platform: observability
+            component: csm-module
+            driver: {{ $driverName }}
+            alert_id: OBS-04
+          annotations:
+            summary: "CSM observability scrape endpoint unavailable for {{ $driverName }}"
+            description: "The Prometheus scrape endpoint for the {{ $driverName }} observability metrics exporter is unavailable. Check the observability metrics service, ServiceMonitor, and pod health."
+            runbook_url: "https://dell.github.io/csm-docs/docs/observability/alerts/csm-observability/"
 {{- end -}}

--- a/charts/karavi-observability/templates/karavi-metrics-powerflex-service-monitor.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerflex-service-monitor.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.karaviMetricsPowerflex.enabled .Values.karaviMetricsPowerflex.metrics.enabled .Values.karaviMetricsPowerflex.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: karavi-metrics-powerflex-observability
+  namespace: {{ include "custom.namespace" . }}
+  labels:
+    app.kubernetes.io/name: karavi-metrics-powerflex
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ include "custom.namespace" . }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: karavi-metrics-powerflex
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  endpoints:
+    - port: obs-metrics
+      path: /metrics
+      interval: {{ .Values.karaviMetricsPowerflex.metrics.serviceMonitor.interval }}
+      {{- if .Values.karaviMetricsPowerflex.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.karaviMetricsPowerflex.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      scheme: {{ if .Values.karaviMetricsPowerflex.metrics.tlsCertSecret }}https{{ else }}http{{ end }}
+      {{- if .Values.karaviMetricsPowerflex.metrics.tlsCertSecret }}
+      tlsConfig:
+        insecureSkipVerify: {{ .Values.karaviMetricsPowerflex.metrics.serviceMonitor.insecureSkipVerify }}
+      {{- end }}
+{{- end }}

--- a/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerflex.yaml
@@ -15,6 +15,11 @@ spec:
   - name: karavi-metrics-powerflex
     port: 2222
     targetPort: 2222
+  {{- if .Values.karaviMetricsPowerflex.metrics.enabled }}
+  - name: obs-metrics
+    port: {{ .Values.karaviMetricsPowerflex.metrics.port }}
+    targetPort: {{ .Values.karaviMetricsPowerflex.metrics.port }}
+  {{- end }}
   selector:
     app.kubernetes.io/name: karavi-metrics-powerflex
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -53,6 +58,12 @@ spec:
       - name: karavi-metrics-powerflex
         image: {{ .Values.karaviMetricsPowerflex.image }}
         resources: {}
+        {{- if .Values.karaviMetricsPowerflex.metrics.enabled }}
+        ports:
+        - name: obs-metrics
+          containerPort: {{ .Values.karaviMetricsPowerflex.metrics.port }}
+          protocol: TCP
+        {{- end }}
         env:
         - name: POWERFLEX_METRICS_ENDPOINT
           value: "{{ .Values.karaviMetricsPowerflex.endpoint }}"
@@ -62,6 +73,18 @@ spec:
               fieldPath: metadata.namespace
         - name: TLS_ENABLED
           value: "true"
+        {{- if .Values.karaviMetricsPowerflex.metrics.enabled }}
+        - name: X_CSI_METRICS_ENABLED
+          value: "{{ .Values.karaviMetricsPowerflex.metrics.enabled }}"
+        - name: X_CSI_METRICS_PORT
+          value: "{{ .Values.karaviMetricsPowerflex.metrics.port }}"
+        {{- if .Values.karaviMetricsPowerflex.metrics.tlsCertSecret }}
+        - name: X_CSI_METRICS_TLS_CERT_FILE
+          value: /etc/metrics-tls/tls.crt
+        - name: X_CSI_METRICS_TLS_KEY_FILE
+          value: /etc/metrics-tls/tls.key
+        {{- end }}
+        {{- end }}
         volumeMounts:
         - name: vxflexos-config
           mountPath: /vxflexos-config
@@ -70,6 +93,11 @@ spec:
           readOnly: true
         - name: karavi-metrics-powerflex-configmap
           mountPath: /etc/config
+        {{- if and .Values.karaviMetricsPowerflex.metrics.enabled .Values.karaviMetricsPowerflex.metrics.tlsCertSecret }}
+        - name: metrics-tls
+          mountPath: /etc/metrics-tls
+          readOnly: true
+        {{- end }}
       {{- if hasKey .Values.karaviMetricsPowerflex "authorization" }}
       {{- if eq .Values.karaviMetricsPowerflex.authorization.enabled true }}
       - name: karavi-authorization-proxy
@@ -119,6 +147,11 @@ spec:
       - name: karavi-metrics-powerflex-configmap
         configMap:
           name: karavi-metrics-powerflex-configmap
+      {{- if and .Values.karaviMetricsPowerflex.metrics.enabled .Values.karaviMetricsPowerflex.metrics.tlsCertSecret }}
+      - name: metrics-tls
+        secret:
+          secretName: {{ .Values.karaviMetricsPowerflex.metrics.tlsCertSecret }}
+      {{- end }}
      {{- if hasKey .Values.karaviMetricsPowerflex "authorization" }}
      {{- if eq .Values.karaviMetricsPowerflex.authorization.enabled true }}
       {{- if $authorizationConfigSecret }}

--- a/charts/karavi-observability/templates/karavi-metrics-powermax.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powermax.yaml
@@ -58,12 +58,6 @@ spec:
       - name: karavi-metrics-powermax
         image: {{ .Values.karaviMetricsPowermax.image }}
         resources: {}
-        {{- if .Values.karaviMetricsPowermax.metrics.enabled }}
-        ports:
-        - name: obs-metrics
-          containerPort: {{ .Values.karaviMetricsPowermax.metrics.port }}
-          protocol: TCP
-        {{- end }}
         env:
         {{- $useRevProxySecret := and (hasKey .Values.karaviMetricsPowermax "useSecret") (.Values.karaviMetricsPowermax.useSecret | default false) }}
         - name: X_CSI_REVPROXY_USE_SECRET
@@ -163,11 +157,11 @@ spec:
       - name: karavi-metrics-powermax-configmap
         configMap:
           name: karavi-metrics-powermax-configmap
-      {{- if and .Values.karaviMetricsPowermax.metrics.enabled .Values.karaviMetricsPowermax.metrics.tlsCertSecret }}
+        {{- if and .Values.karaviMetricsPowermax.metrics.enabled .Values.karaviMetricsPowermax.metrics.tlsCertSecret }}
       - name: metrics-tls
         secret:
           secretName: {{ .Values.karaviMetricsPowermax.metrics.tlsCertSecret }}
-      {{- end }}
+        {{- end }}
      {{- if hasKey .Values.karaviMetricsPowermax "authorization" }}
      {{- if eq .Values.karaviMetricsPowermax.authorization.enabled true }}
       {{- if $authorizationConfigSecret }}
@@ -220,12 +214,5 @@ spec:
     {{- if .Values.karaviMetricsPowermax.metrics.tlsCertSecret }}
     tlsConfig:
       insecureSkipVerify: {{ .Values.karaviMetricsPowermax.metrics.serviceMonitor.insecureSkipVerify }}
-      cert:
-        secret:
-          name: {{ .Values.karaviMetricsPowermax.metrics.tlsCertSecret }}
-          key: obs-tls.crt
-      keySecret:
-        name: {{ .Values.karaviMetricsPowermax.metrics.tlsCertSecret }}
-        key: obs-tls.key
     {{- end }}
 {{- end }}

--- a/charts/karavi-observability/templates/karavi-metrics-powerstore.yaml
+++ b/charts/karavi-observability/templates/karavi-metrics-powerstore.yaml
@@ -207,7 +207,7 @@ spec:
           key: obs-tls.crt
       keySecret:
         name: {{ .Values.karaviMetricsPowerstore.metrics.tlsCertSecret }}
-          key: obs-tls.key
+        key: obs-tls.key
     {{- end }}
 {{- end }}
 

--- a/charts/karavi-observability/templates/karavi-observability-configmap.yaml
+++ b/charts/karavi-observability/templates/karavi-observability-configmap.yaml
@@ -17,9 +17,19 @@ data:
     POWERFLEX_STORAGE_POOL_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerflex.storageClassPoolPollFrequencySeconds }}"
     POWERFLEX_MAX_CONCURRENT_QUERIES: "{{ .Values.karaviMetricsPowerflex.concurrentPowerflexQueries }}"
     POWERFLEX_TOPOLOGY_METRICS_ENABLED: "{{ .Values.karaviMetricsPowerflex.topologyMetricsEnabled }}"
-    POWERFLEX_TOPOLOGY_METRICS_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerflex.topologyMetricsPollFrequencySeconds }}"    
+    POWERFLEX_TOPOLOGY_METRICS_POLL_FREQUENCY: "{{ .Values.karaviMetricsPowerflex.topologyMetricsPollFrequencySeconds }}"
     LOG_LEVEL: "{{ .Values.karaviMetricsPowerflex.logLevel }}"
     LOG_FORMAT: "{{ .Values.karaviMetricsPowerflex.logFormat }}"
+    {{- if .Values.karaviMetricsPowerflex.metrics.enabled }}
+    X_CSI_METRICS_ENABLED: "true"
+    X_CSI_METRICS_PORT: "{{ .Values.karaviMetricsPowerflex.metrics.port }}"
+    {{- if .Values.karaviMetricsPowerflex.metrics.tlsCertSecret }}
+    X_CSI_METRICS_TLS_CERT_FILE: "/etc/metrics-tls/tls.crt"
+    X_CSI_METRICS_TLS_KEY_FILE: "/etc/metrics-tls/tls.key"
+    {{- end }}
+    {{- else }}
+    X_CSI_METRICS_ENABLED: "false"
+    {{- end }}
 
 {{ end }}
 

--- a/charts/karavi-observability/templates/prometheusrule.yaml
+++ b/charts/karavi-observability/templates/prometheusrule.yaml
@@ -1,0 +1,55 @@
+{{- with .Values.karaviMetricsPowerflex }}
+{{- if .enabled }}
+{{- with .metrics }}
+{{- if .enabled }}
+{{- with .prometheusRule }}
+{{- if .enabled }}
+{{ include "karavi.prometheusRule" (dict "driverName" "powerflex" "moduleLabel" "metrics-powerflex" "platformLabel" "system_id" "jobPattern" "karavi-metrics-powerflex.*" "root" $) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- with .Values.karaviMetricsPowerstore }}
+{{- if .enabled }}
+{{- with .metrics }}
+{{- if .enabled }}
+{{- with .prometheusRule }}
+{{- if .enabled }}
+{{ include "karavi.prometheusRule" (dict "driverName" "powerstore" "moduleLabel" "metrics-powerstore" "platformLabel" "global_id" "jobPattern" "karavi-metrics-powerstore.*" "root" $) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- with .Values.karaviMetricsPowerscale }}
+{{- if .enabled }}
+{{- with .metrics }}
+{{- if .enabled }}
+{{- with .prometheusRule }}
+{{- if .enabled }}
+{{ include "karavi.prometheusRule" (dict "driverName" "powerscale" "moduleLabel" "metrics-powerscale" "platformLabel" "cluster_name" "jobPattern" "karavi-metrics-powerscale.*" "root" $) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- with .Values.karaviMetricsPowermax }}
+{{- if .enabled }}
+{{- with .metrics }}
+{{- if .enabled }}
+{{- with .prometheusRule }}
+{{- if .enabled }}
+{{ include "karavi.prometheusRule" (dict "driverName" "powermax" "moduleLabel" "metrics-powermax" "platformLabel" "array_id" "jobPattern" "karavi-metrics-powermax.*" "root" $) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/karavi-observability/values.yaml
+++ b/charts/karavi-observability/values.yaml
@@ -1,3 +1,7 @@
+# PrometheusRule alerting is configured per driver under each karaviMetrics<Driver>.metrics.prometheusRule block.
+# This chart renders one PrometheusRule resource per enabled driver when that driver's
+# metrics.enabled and metrics.prometheusRule.enabled flags are both true.
+
 karaviMetricsPowerflex:
   image: quay.io/dell/container-storage-modules/csm-metrics-powerflex:v1.16.0
   enabled: true
@@ -42,6 +46,44 @@ karaviMetricsPowerflex:
     #   "false" - TLS certificate will be verified
     # Default value: "true"
     skipCertificateValidation: true
+  # metrics: configuration for observability self-metrics (dell_csm_obs_* on port /metrics)
+  metrics:
+    # enabled: Enable/Disable observability self-metrics endpoint
+    # Allowed values: true, false
+    # Default value: false
+    enabled: false
+    # port: Port used by observability self-metrics endpoint
+    # Allowed values: 1-65535
+    # Default value: 8443
+    port: 8443
+    # tlsCertSecret: Name of secret containing TLS certificate and key for observability self-metrics
+    # Allowed values: Kubernetes secret name, empty string
+    # Default value: ""
+    tlsCertSecret: ""
+    # serviceMonitor: Configure ServiceMonitor for observability self-metrics
+    serviceMonitor:
+      # enabled: Enable/Disable ServiceMonitor creation for observability self-metrics
+      # Allowed values: true, false
+      # Default value: false
+      enabled: false
+      # interval: Prometheus scrape interval for observability self-metrics
+      # Allowed values: duration string (for example: 15s, 30s, 1m)
+      # Default value: "30s"
+      interval: "30s"
+      # scrapeTimeout: Prometheus scrape timeout for observability self-metrics
+      # Allowed values: duration string, empty string
+      # Default value: ""
+      scrapeTimeout: ""
+      # insecureSkipVerify: Skip TLS certificate verification while scraping observability self-metrics
+      # Allowed values: true, false
+      # Default value: false
+      insecureSkipVerify: false
+    # prometheusRule: Configure Prometheus Operator PrometheusRule creation for observability alerts
+    prometheusRule:
+      # enabled: Enable/Disable PrometheusRule creation for this driver's observability alerts
+      # Allowed values: true, false
+      # Default value: true
+      enabled: true
 
 karaviMetricsPowerstore:
   image: quay.io/dell/container-storage-modules/csm-metrics-powerstore:v1.16.0
@@ -105,6 +147,12 @@ karaviMetricsPowerstore:
       # Allowed values: true, false
       # Default value: false
       insecureSkipVerify: false
+    # prometheusRule: Configure Prometheus Operator PrometheusRule creation for observability alerts
+    prometheusRule:
+      # enabled: Enable/Disable PrometheusRule creation for this driver's observability alerts
+      # Allowed values: true, false
+      # Default value: true
+      enabled: true
   zipkin:
     uri: ""
     serviceName: metrics-powerstore
@@ -185,6 +233,12 @@ karaviMetricsPowerscale:
       # Allowed values: true, false
       # Default value: false
       insecureSkipVerify: false
+    # prometheusRule: Configure Prometheus Operator PrometheusRule creation for observability alerts
+    prometheusRule:
+      # enabled: Enable/Disable PrometheusRule creation for this driver's observability alerts
+      # Allowed values: true, false
+      # Default value: true
+      enabled: true
   # isiClientOptions to access Powerscale OneFS API server
   isiClientOptions:
     # set isiSkipCertificateValidation to true/false to skip/verify OneFS API server's certificates
@@ -284,6 +338,12 @@ karaviMetricsPowermax:
       # Allowed values: true, false
       # Default value: false
       insecureSkipVerify: false
+    # prometheusRule: Configure Prometheus Operator PrometheusRule creation for observability alerts
+    prometheusRule:
+      # enabled: Enable/Disable PrometheusRule creation for this driver's observability alerts
+      # Allowed values: true, false
+      # Default value: true
+      enabled: true
   authorization:
     enabled: false
     # sidecarProxy.image: the container image used for the csm-authorization-sidecar.

--- a/container-storage-modules/container-storage-modules/values.yaml
+++ b/container-storage-modules/container-storage-modules/values.yaml
@@ -332,7 +332,7 @@ csi-vxflexos:
       image: quay.io/dell/container-storage-modules/csi-vxflexos:v2.18.0
     # "powerflexSdc" defines the SDC image for init container.
     powerflexSdc:
-      image: quay.io/dell/storage/powerflex/sdc:5.0
+      image: quay.io/dell/storage/powerflex/sdc:5.1.0.2
     # CSI sidecars
     attacher:
       image: registry.k8s.io/sig-storage/csi-attacher:v4.12.0

--- a/samples/csm-authorization/config.yaml
+++ b/samples/csm-authorization/config.yaml
@@ -1,2 +1,2 @@
 web:
-  jwtsigningsecret: secret
+  jwtsigningsecret: test-strong-secret-abcdefghijklm


### PR DESCRIPTION
## Summary
- Sync Helm chart updates from  into 
- Add and update metrics/alerting support across driver charts
- Include PrometheusRule and ServiceMonitor resources where applicable
- Update values for observability and alerting configuration

## Test plan
- [x] Reviewed chart diffs for the updated driver modules
- [x] Verified the branch pushes successfully
- [x] Confirmed alerting and metrics templates are present in the expected charts